### PR TITLE
fix: .check_lst_failures() uses .stop_incompatible() instead of .stop_cant_coerce() (#273)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # stbl (development version)
 
+## Bug fixes
+
+* `to_chr()`, `to_dbl()`, `to_fct()`, `to_int()`, and `to_lgl()` now throw an "incompatible type" error (with failing element locations) instead of a generic "can't coerce" error when a list contains elements that can't be converted (#273).
+
 ## New functions
 
 * New `stabilize_one_of()` (and `stabilise_one_of()`) validates `x` by trying each unnamed stabilizer function in `...` in order, returning the first successful result. If all functions fail, an informative error combining the individual failure messages is thrown. New `to_one_of()` works analogously, accepting type prototypes (e.g. `integer()`, `character()`) in `...` and dispatching to [to()] (#215).

--- a/R/aaa-conditions.R
+++ b/R/aaa-conditions.R
@@ -189,11 +189,6 @@ rlang::caller_env
 
 #' Abort with an "incompatible type" message
 #'
-#' @param to The target object for the coercion.
-#' @param failures `(logical)` A logical vector indicating which elements
-#'   failed.
-#' @param due_to `(length-1 character)` A string describing the reason for the
-#'   failure.
 #' @inheritParams .stbl_abort
 #' @inheritParams .shared-params
 #' @inherit .shared-return-conditions return

--- a/R/aaa-shared_params.R
+++ b/R/aaa-shared_params.R
@@ -25,6 +25,10 @@
 #' @param coerce_function `(length-1 logical)` Should functions be coerced?
 #' @param depth `(length-1 integer)` Current recursion depth. Do not manually
 #'   set this parameter.
+#' @param due_to `(length-1 character)` A string describing the reason for the
+#'   failure.
+#' @param failures `(logical)` A logical vector indicating which elements
+#'   failed.
 #' @param is_rlang_cls_scalar `(function)` An `is_scalar_*()` function from
 #'   rlang, used for a fast path if `x` is already the right type.
 #' @param levels `(character)` The desired factor levels.
@@ -54,6 +58,7 @@
 #'   message that should be displayed. To check that a pattern is *not* matched,
 #'   attach a `negate` attribute set to `TRUE`. If a complex regex pattern
 #'   throws an error, try installing the stringi package.
+#' @param to The target object for the coercion.
 #' @param to_class `(length-1 character)` The name of the class to coerce to.
 #' @param to_cls_args `(list)` A list of additional arguments to pass to
 #'   `to_cls_fn()`.

--- a/R/cls_unexported.R
+++ b/R/cls_unexported.R
@@ -228,17 +228,16 @@
 #'
 #' @param valid `(logical)` The `valid` vector returned by a `stbl_lst_to_*`
 #'   C routine.
-#' @inheritParams .shared-params
+#' @inheritParams .stop_incompatible
 #' @inherit .shared-return-conditions return
 #' @keywords internal
-.check_lst_failures <- function(valid, to_class, x_class, x_arg, call) {
-  if (all(valid)) {
-    return(invisible(NULL))
-  }
-  .stop_cant_coerce(
-    from_class = x_class,
-    to_class = to_class,
-    x_arg = x_arg,
-    call = call
+.check_lst_failures <- function(valid, to, x_class, x_arg, call) {
+  .check_cast_failures(
+    !valid,
+    x_class,
+    to,
+    "incompatible element types",
+    x_arg,
+    call
   )
 }

--- a/R/to_chr.R
+++ b/R/to_chr.R
@@ -79,7 +79,7 @@ to_character <- to_chr
   x_class = object_type(x)
 ) {
   res <- .Call(stbl_lst_to_chr, x)
-  .check_lst_failures(res[["valid"]], "character", x_class, x_arg, call)
+  .check_lst_failures(res[["valid"]], character(), x_class, x_arg, call)
   res[["result"]]
 }
 

--- a/R/to_dbl.R
+++ b/R/to_dbl.R
@@ -40,7 +40,7 @@ to_dbl.list <- function(
   x_class = object_type(x)
 ) {
   res <- .Call(stbl_lst_to_dbl, x)
-  .check_lst_failures(res[["valid"]], "double", x_class, x_arg, call)
+  .check_lst_failures(res[["valid"]], double(), x_class, x_arg, call)
   res[["result"]]
 }
 

--- a/R/to_fct.R
+++ b/R/to_fct.R
@@ -89,7 +89,7 @@ to_fct.list <- function(
   x_class = object_type(x)
 ) {
   res <- .Call(stbl_lst_to_fct, x)
-  .check_lst_failures(res[["valid"]], "factor", x_class, x_arg, call)
+  .check_lst_failures(res[["valid"]], factor(), x_class, x_arg, call)
   .coerce_fct_levels(res[["result"]], levels, to_na, x_arg, call)
 }
 

--- a/R/to_int.R
+++ b/R/to_int.R
@@ -40,7 +40,7 @@ to_int.list <- function(
   x_class = object_type(x)
 ) {
   res <- .Call(stbl_lst_to_int, x)
-  .check_lst_failures(res[["valid"]], "integer", x_class, x_arg, call)
+  .check_lst_failures(res[["valid"]], integer(), x_class, x_arg, call)
   res[["result"]]
 }
 

--- a/R/to_lgl.R
+++ b/R/to_lgl.R
@@ -88,7 +88,7 @@ to_lgl.list <- function(
   x_class = object_type(x)
 ) {
   res <- .Call(stbl_lst_to_lgl, x)
-  .check_lst_failures(res[["valid"]], "logical", x_class, x_arg, call)
+  .check_lst_failures(res[["valid"]], logical(), x_class, x_arg, call)
   res[["result"]]
 }
 

--- a/man/c_x_to_y.Rd
+++ b/man/c_x_to_y.Rd
@@ -124,6 +124,8 @@
 \item{levels}{\code{(character)} The desired factor levels.}
 
 \item{to_na}{\code{(character)} Values to convert to \code{NA}.}
+
+\item{to}{The target object for the coercion.}
 }
 \value{
 \code{.x_to_y()}: A list with two elements: \code{result}, the converted

--- a/man/dot-check_lst_failures.Rd
+++ b/man/dot-check_lst_failures.Rd
@@ -4,13 +4,13 @@
 \alias{.check_lst_failures}
 \title{Check list coercion failures and error if any element could not be converted}
 \usage{
-.check_lst_failures(valid, to_class, x_class, x_arg, call)
+.check_lst_failures(valid, to, x_class, x_arg, call)
 }
 \arguments{
 \item{valid}{\code{(logical)} The \code{valid} vector returned by a \verb{stbl_lst_to_*}
 C routine.}
 
-\item{to_class}{\verb{(length-1 character)} The name of the class to coerce to.}
+\item{to}{The target object for the coercion.}
 
 \item{x_class}{\verb{(length-1 character)} The class name of the argument being
 stabilized to use in error messages. Use this if you remove a special class

--- a/man/dot-shared-params.Rd
+++ b/man/dot-shared-params.Rd
@@ -39,6 +39,12 @@ the integer index of the factor.}
 \item{depth}{\verb{(length-1 integer)} Current recursion depth. Do not manually
 set this parameter.}
 
+\item{due_to}{\verb{(length-1 character)} A string describing the reason for the
+failure.}
+
+\item{failures}{\code{(logical)} A logical vector indicating which elements
+failed.}
+
 \item{is_rlang_cls_scalar}{\verb{(function)} An \verb{is_scalar_*()} function from
 rlang, used for a fast path if \code{x} is already the right type.}
 
@@ -78,6 +84,8 @@ character vector where the value is the regex pattern and the name is the
 message that should be displayed. To check that a pattern is \emph{not} matched,
 attach a \code{negate} attribute set to \code{TRUE}. If a complex regex pattern
 throws an error, try installing the stringi package.}
+
+\item{to}{The target object for the coercion.}
 
 \item{to_class}{\verb{(length-1 character)} The name of the class to coerce to.}
 

--- a/tests/testthat/_snaps/check.md
+++ b/tests/testthat/_snaps/check.md
@@ -1,8 +1,10 @@
 # .check_na() works (#95)
 
     Code
-      .check_na(c(1, NA), allow_na = FALSE)
-    Condition
+      (expect_pkg_error_classes(.check_na(c(1, NA), allow_na = FALSE), "stbl",
+      "bad_na"))
+    Output
+      <error/stbl-error-bad_na>
       Error:
       ! `c(1, NA)` must not contain NA values.
       * NA locations: 2
@@ -10,8 +12,9 @@
 # .check_size() works (#95)
 
     Code
-      .check_size(1:5, 6, 10)
-    Condition
+      (expect_pkg_error_classes(.check_size(1:5, 6, 10), "stbl", "size_too_small"))
+    Output
+      <error/stbl-error-size_too_small>
       Error:
       ! `1:5` must have size >= 6.
       x 5 is too small.
@@ -19,8 +22,9 @@
 ---
 
     Code
-      .check_size(1:5, 1, 4)
-    Condition
+      (expect_pkg_error_classes(.check_size(1:5, 1, 4), "stbl", "size_too_large"))
+    Output
+      <error/stbl-error-size_too_large>
       Error:
       ! `1:5` must have size <= 4.
       x 5 is too big.
@@ -28,8 +32,9 @@
 # .check_scalar() works (#95)
 
     Code
-      .check_scalar(1:2)
-    Condition
+      (expect_pkg_error_classes(.check_scalar(1:2), "stbl", "non_scalar"))
+    Output
+      <error/stbl-error-non_scalar>
       Error:
       ! `1:2` must be a single <integer>.
       x `1:2` has 2 values.
@@ -37,8 +42,10 @@
 ---
 
     Code
-      .check_scalar(NULL, allow_null = FALSE)
-    Condition
+      (expect_pkg_error_classes(.check_scalar(NULL, allow_null = FALSE), "stbl",
+      "non_scalar"))
+    Output
+      <error/stbl-error-non_scalar>
       Error:
       ! `NULL` must be a single <non-NULL>.
       x `NULL` has no values.
@@ -46,8 +53,10 @@
 ---
 
     Code
-      .check_scalar(character(), allow_zero_length = FALSE)
-    Condition
+      (expect_pkg_error_classes(.check_scalar(character(), allow_zero_length = FALSE),
+      "stbl", "bad_empty"))
+    Output
+      <error/stbl-error-bad_empty>
       Error:
       ! `character()` must be a single <character (non-empty)>.
       x `character()` has no values.
@@ -55,8 +64,9 @@
 # .check_x_no_more_than_y() works (#95)
 
     Code
-      .check_x_no_more_than_y(2, 1)
-    Condition
+      (expect_pkg_error_classes(.check_x_no_more_than_y(2, 1), "stbl", "size_x_vs_y"))
+    Output
+      <error/stbl-error-size_x_vs_y>
       Error:
       ! `2` can't be larger than `1`.
       * `2` = 2
@@ -65,9 +75,11 @@
 # .check_cast_failures() works
 
     Code
-      .check_cast_failures(failures = failures, x_class = "character", to = logical(),
-      due_to = "incompatible values", x_arg = "test_arg", call = rlang::current_env())
-    Condition
+      (expect_pkg_error_classes(.check_cast_failures(failures = failures, x_class = "character",
+        to = logical(), due_to = "incompatible values", x_arg = "test_arg", call = rlang::current_env()),
+      "stbl", "incompatible_type"))
+    Output
+      <error/stbl-error-incompatible_type>
       Error:
       ! `test_arg` <character> must be coercible to <logical>
       x Can't convert some values due to incompatible values.
@@ -76,16 +88,19 @@
 # .check_all_named() works (#203)
 
     Code
-      .check_all_named(list(1, 2))
-    Condition
+      (expect_pkg_error_classes(.check_all_named(list(1, 2)), "stbl", "bad_named"))
+    Output
+      <error/stbl-error-bad_named>
       Error:
       ! `list(1, 2)` must have all elements named.
 
 # .check_not_jagged() works (#203)
 
     Code
-      .check_not_jagged(list(a = 1:3, b = 1:2))
-    Condition
+      (expect_pkg_error_classes(.check_not_jagged(list(a = 1:3, b = 1:2)), "stbl",
+      "jagged"))
+    Output
+      <error/stbl-error-jagged>
       Error:
       ! Can't coerce `list(a = 1:3, b = 1:2)` <list> to <data.frame>.
       i All list elements must have length 3 or 1.

--- a/tests/testthat/_snaps/to_chr.md
+++ b/tests/testthat/_snaps/to_chr.md
@@ -28,41 +28,49 @@
       ! Can't coerce `function(x) x` <function> to <character>.
       i Anonymous functions can't be converted to a string name.
 
-# to_chr() fails gracefully for weird cases (#22)
+# to_chr() fails gracefully for weird cases (#22, #273)
 
     Code
-      (expect_pkg_error_classes(to_chr(given), "stbl", "coerce", "character"))
+      (expect_pkg_error_classes(to_chr(given), "stbl", "incompatible_type"))
     Output
-      <error/stbl-error-coerce-character>
+      <error/stbl-error-incompatible_type>
       Error:
-      ! Can't coerce `given` <list> to <character>.
+      ! `given` <list> must be coercible to <character>
+      x Can't convert some values due to incompatible element types.
+      * Locations: 1
 
 ---
 
     Code
-      (expect_pkg_error_classes(wrapped_to_chr(given), "stbl", "coerce", "character"))
+      (expect_pkg_error_classes(wrapped_to_chr(given), "stbl", "incompatible_type"))
     Output
-      <error/stbl-error-coerce-character>
+      <error/stbl-error-incompatible_type>
       Error in `wrapped_to_chr()`:
-      ! Can't coerce `val` <list> to <character>.
+      ! `val` <list> must be coercible to <character>
+      x Can't convert some values due to incompatible element types.
+      * Locations: 1
 
 ---
 
     Code
-      (expect_pkg_error_classes(to_chr(given), "stbl", "coerce", "character"))
+      (expect_pkg_error_classes(to_chr(given), "stbl", "incompatible_type"))
     Output
-      <error/stbl-error-coerce-character>
+      <error/stbl-error-incompatible_type>
       Error:
-      ! Can't coerce `given` <list> to <character>.
+      ! `given` <list> must be coercible to <character>
+      x Can't convert some values due to incompatible element types.
+      * Locations: 2
 
 ---
 
     Code
-      (expect_pkg_error_classes(wrapped_to_chr(given), "stbl", "coerce", "character"))
+      (expect_pkg_error_classes(wrapped_to_chr(given), "stbl", "incompatible_type"))
     Output
-      <error/stbl-error-coerce-character>
+      <error/stbl-error-incompatible_type>
       Error in `wrapped_to_chr()`:
-      ! Can't coerce `val` <list> to <character>.
+      ! `val` <list> must be coercible to <character>
+      x Can't convert some values due to incompatible element types.
+      * Locations: 2
 
 ---
 
@@ -85,20 +93,24 @@
 ---
 
     Code
-      (expect_pkg_error_classes(to_chr(given), "stbl", "coerce", "character"))
+      (expect_pkg_error_classes(to_chr(given), "stbl", "incompatible_type"))
     Output
-      <error/stbl-error-coerce-character>
+      <error/stbl-error-incompatible_type>
       Error:
-      ! Can't coerce `given` <list> to <character>.
+      ! `given` <list> must be coercible to <character>
+      x Can't convert some values due to incompatible element types.
+      * Locations: 2
 
 ---
 
     Code
-      (expect_pkg_error_classes(wrapped_to_chr(given), "stbl", "coerce", "character"))
+      (expect_pkg_error_classes(wrapped_to_chr(given), "stbl", "incompatible_type"))
     Output
-      <error/stbl-error-coerce-character>
+      <error/stbl-error-incompatible_type>
       Error in `wrapped_to_chr()`:
-      ! Can't coerce `val` <list> to <character>.
+      ! `val` <list> must be coercible to <character>
+      x Can't convert some values due to incompatible element types.
+      * Locations: 2
 
 # to_chr_scalar() errors for non-scalars (#22)
 
@@ -120,24 +132,28 @@
       ! `val` must be a single <character>.
       x `val` has 26 values.
 
-# to_chr_scalar() errors for uncoerceable types (#22)
+# to_chr_scalar() errors for uncoerceable types (#22, #273)
 
     Code
-      (expect_pkg_error_classes(to_chr_scalar(given), "stbl", "coerce", "character"))
+      (expect_pkg_error_classes(to_chr_scalar(given), "stbl", "incompatible_type"))
     Output
-      <error/stbl-error-coerce-character>
+      <error/stbl-error-incompatible_type>
       Error:
-      ! Can't coerce `given` <list> to <character>.
+      ! `given` <list> must be coercible to <character>
+      x Can't convert some values due to incompatible element types.
+      * Locations: 1
 
 ---
 
     Code
-      (expect_pkg_error_classes(wrapped_to_chr_scalar(given), "stbl", "coerce",
-      "character"))
+      (expect_pkg_error_classes(wrapped_to_chr_scalar(given), "stbl",
+      "incompatible_type"))
     Output
-      <error/stbl-error-coerce-character>
+      <error/stbl-error-incompatible_type>
       Error in `wrapped_to_chr_scalar()`:
-      ! Can't coerce `val` <list> to <character>.
+      ! `val` <list> must be coercible to <character>
+      x Can't convert some values due to incompatible element types.
+      * Locations: 1
 
 # to_chr_scalar() respects allow_null (#22, #189)
 

--- a/tests/testthat/_snaps/to_dbl.md
+++ b/tests/testthat/_snaps/to_dbl.md
@@ -106,6 +106,17 @@
       x Can't convert some values due to incompatible values.
       * Locations: 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, ..., 25, and 26
 
+# to_dbl() works for lists (#128, #273)
+
+    Code
+      (expect_pkg_error_classes(to_dbl(list(1.1, 1:5)), "stbl", "incompatible_type"))
+    Output
+      <error/stbl-error-incompatible_type>
+      Error:
+      ! `list(1.1, 1:5)` <list> must be coercible to <double>
+      x Can't convert some values due to incompatible element types.
+      * Locations: 2
+
 # to_dbl_scalar() provides informative error messages (#23)
 
     Code

--- a/tests/testthat/_snaps/to_fct.md
+++ b/tests/testthat/_snaps/to_fct.md
@@ -36,7 +36,18 @@
       Error in `wrapped_to_fct()`:
       ! `val` must not be <NULL>.
 
-# to_fct() errors for things that can't be coerced (#62)
+# to_fct() works for lists (#64, #273)
+
+    Code
+      (expect_pkg_error_classes(to_fct(list("a", 1:5)), "stbl", "incompatible_type"))
+    Output
+      <error/stbl-error-incompatible_type>
+      Error:
+      ! `list("a", 1:5)` <list> must be coercible to <factor>
+      x Can't convert some values due to incompatible element types.
+      * Locations: 2
+
+# to_fct() errors for things that can't be coerced (#62, #273)
 
     Code
       to_fct(given)
@@ -71,18 +82,24 @@
 ---
 
     Code
-      to_fct(given)
-    Condition
+      (expect_pkg_error_classes(to_fct(given), "stbl", "incompatible_type"))
+    Output
+      <error/stbl-error-incompatible_type>
       Error:
-      ! Can't coerce `given` <list> to <factor>.
+      ! `given` <list> must be coercible to <factor>
+      x Can't convert some values due to incompatible element types.
+      * Locations: 1 and 2
 
 ---
 
     Code
-      wrapped_to_fct(given)
-    Condition
+      (expect_pkg_error_classes(wrapped_to_fct(given), "stbl", "incompatible_type"))
+    Output
+      <error/stbl-error-incompatible_type>
       Error in `wrapped_to_fct()`:
-      ! Can't coerce `val` <list> to <factor>.
+      ! `val` <list> must be coercible to <factor>
+      x Can't convert some values due to incompatible element types.
+      * Locations: 1 and 2
 
 # to_fct_scalar() provides informative error messages (#62)
 

--- a/tests/testthat/_snaps/to_int.md
+++ b/tests/testthat/_snaps/to_int.md
@@ -206,6 +206,17 @@
       x Can't convert some values due to incompatible values.
       * Locations: 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, ..., 25, and 26
 
+# to_int() works for lists (#2, #273)
+
+    Code
+      (expect_pkg_error_classes(to_int(list(1L, 1:5)), "stbl", "incompatible_type"))
+    Output
+      <error/stbl-error-incompatible_type>
+      Error:
+      ! `list(1L, 1:5)` <list> must be coercible to <integer>
+      x Can't convert some values due to incompatible element types.
+      * Locations: 2
+
 # to_int_scalar() provides informative error messages (#12)
 
     Code

--- a/tests/testthat/_snaps/to_lgl.md
+++ b/tests/testthat/_snaps/to_lgl.md
@@ -54,21 +54,38 @@
       x Can't convert some values due to incompatible values.
       * Locations: 1, 2, 3, 4, 5, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, ..., 25, and 26
 
-# to_lgl() errors for other types (#21)
+# to_lgl() works for lists (#21, #273)
 
     Code
-      to_lgl(given)
-    Condition
+      (expect_pkg_error_classes(to_lgl(list(TRUE, 1:5)), "stbl", "incompatible_type"))
+    Output
+      <error/stbl-error-incompatible_type>
       Error:
-      ! Can't coerce `given` <list> to <logical>.
+      ! `list(TRUE, 1:5)` <list> must be coercible to <logical>
+      x Can't convert some values due to incompatible element types.
+      * Locations: 2
+
+# to_lgl() errors for other types (#21, #273)
+
+    Code
+      (expect_pkg_error_classes(to_lgl(given), "stbl", "incompatible_type"))
+    Output
+      <error/stbl-error-incompatible_type>
+      Error:
+      ! `given` <list> must be coercible to <logical>
+      x Can't convert some values due to incompatible element types.
+      * Locations: 2
 
 ---
 
     Code
-      wrapped_to_lgl(given)
-    Condition
+      (expect_pkg_error_classes(wrapped_to_lgl(given), "stbl", "incompatible_type"))
+    Output
+      <error/stbl-error-incompatible_type>
       Error in `wrapped_to_lgl()`:
-      ! Can't coerce `val` <list> to <logical>.
+      ! `val` <list> must be coercible to <logical>
+      x Can't convert some values due to incompatible element types.
+      * Locations: 2
 
 ---
 

--- a/tests/testthat/test-check.R
+++ b/tests/testthat/test-check.R
@@ -2,46 +2,34 @@ test_that(".check_na() works (#95)", {
   expect_null(.check_na(1))
   expect_null(.check_na(NA))
   expect_null(.check_na(c(1, 2), allow_na = FALSE))
-  expect_pkg_error_classes(
+  expect_pkg_error_snapshot(
     .check_na(c(1, NA), allow_na = FALSE),
     "stbl",
     "bad_na"
-  )
-  expect_snapshot(
-    .check_na(c(1, NA), allow_na = FALSE),
-    error = TRUE
   )
 })
 
 test_that(".check_size() works (#95)", {
   expect_null(.check_size(1:5, NULL, NULL))
   expect_null(.check_size(1:5, 1, 10))
-  expect_pkg_error_classes(.check_size(1:5, 6, 10), "stbl", "size_too_small")
-  expect_snapshot(.check_size(1:5, 6, 10), error = TRUE)
-  expect_pkg_error_classes(.check_size(1:5, 1, 4), "stbl", "size_too_large")
-  expect_snapshot(.check_size(1:5, 1, 4), error = TRUE)
+  expect_pkg_error_snapshot(.check_size(1:5, 6, 10), "stbl", "size_too_small")
+  expect_pkg_error_snapshot(.check_size(1:5, 1, 4), "stbl", "size_too_large")
 })
 
 test_that(".check_scalar() works (#95)", {
   expect_null(.check_scalar(1))
   expect_null(.check_scalar(NULL))
   expect_null(.check_scalar(character()))
-  expect_pkg_error_classes(.check_scalar(1:2), "stbl", "non_scalar")
-  expect_snapshot(.check_scalar(1:2), error = TRUE)
-  expect_pkg_error_classes(
+  expect_pkg_error_snapshot(.check_scalar(1:2), "stbl", "non_scalar")
+  expect_pkg_error_snapshot(
     .check_scalar(NULL, allow_null = FALSE),
     "stbl",
     "non_scalar"
   )
-  expect_snapshot(.check_scalar(NULL, allow_null = FALSE), error = TRUE)
-  expect_pkg_error_classes(
+  expect_pkg_error_snapshot(
     .check_scalar(character(), allow_zero_length = FALSE),
     "stbl",
     "bad_empty"
-  )
-  expect_snapshot(
-    .check_scalar(character(), allow_zero_length = FALSE),
-    error = TRUE
   )
 })
 
@@ -62,8 +50,11 @@ test_that(".check_x_no_more_than_y() works (#95)", {
   expect_null(.check_x_no_more_than_y(2, 2))
   expect_null(.check_x_no_more_than_y(NULL, 2))
   expect_null(.check_x_no_more_than_y(1, NULL))
-  expect_pkg_error_classes(.check_x_no_more_than_y(2, 1), "stbl", "size_x_vs_y")
-  expect_snapshot(.check_x_no_more_than_y(2, 1), error = TRUE)
+  expect_pkg_error_snapshot(
+    .check_x_no_more_than_y(2, 1),
+    "stbl",
+    "size_x_vs_y"
+  )
 })
 
 test_that(".check_cast_failures() works", {
@@ -81,7 +72,7 @@ test_that(".check_cast_failures() works", {
 
   # Failure path
   failures <- c(FALSE, TRUE, FALSE, TRUE)
-  expect_pkg_error_classes(
+  expect_pkg_error_snapshot(
     .check_cast_failures(
       failures = failures,
       x_class = "character",
@@ -93,40 +84,20 @@ test_that(".check_cast_failures() works", {
     "stbl",
     "incompatible_type"
   )
-
-  expect_snapshot(
-    .check_cast_failures(
-      failures = failures,
-      x_class = "character",
-      to = logical(),
-      due_to = "incompatible values",
-      x_arg = "test_arg",
-      call = rlang::current_env()
-    ),
-    error = TRUE
-  )
 })
 
 test_that(".check_all_named() works (#203)", {
   expect_null(.check_all_named(list(a = 1, b = 2)))
-  expect_pkg_error_classes(.check_all_named(list(1, 2)), "stbl", "bad_named")
-  expect_snapshot(
-    .check_all_named(list(1, 2)),
-    error = TRUE
-  )
+  expect_pkg_error_snapshot(.check_all_named(list(1, 2)), "stbl", "bad_named")
 })
 
 test_that(".check_not_jagged() works (#203)", {
   expect_null(.check_not_jagged(list()))
   expect_null(.check_not_jagged(list(a = 1, b = 2)))
   expect_null(.check_not_jagged(list(a = 1:3, b = 1:3)))
-  expect_pkg_error_classes(
+  expect_pkg_error_snapshot(
     .check_not_jagged(list(a = 1:3, b = 1:2)),
     "stbl",
     "jagged"
-  )
-  expect_snapshot(
-    .check_not_jagged(list(a = 1:3, b = 1:2)),
-    error = TRUE
   )
 })

--- a/tests/testthat/test-check.R
+++ b/tests/testthat/test-check.R
@@ -2,9 +2,10 @@ test_that(".check_na() works (#95)", {
   expect_null(.check_na(1))
   expect_null(.check_na(NA))
   expect_null(.check_na(c(1, 2), allow_na = FALSE))
-  expect_error(
+  expect_pkg_error_classes(
     .check_na(c(1, NA), allow_na = FALSE),
-    class = .compile_dash("stbl", "error", "bad_na")
+    "stbl",
+    "bad_na"
   )
   expect_snapshot(
     .check_na(c(1, NA), allow_na = FALSE),
@@ -15,15 +16,9 @@ test_that(".check_na() works (#95)", {
 test_that(".check_size() works (#95)", {
   expect_null(.check_size(1:5, NULL, NULL))
   expect_null(.check_size(1:5, 1, 10))
-  expect_error(
-    .check_size(1:5, 6, 10),
-    class = .compile_dash("stbl", "error", "size_too_small")
-  )
+  expect_pkg_error_classes(.check_size(1:5, 6, 10), "stbl", "size_too_small")
   expect_snapshot(.check_size(1:5, 6, 10), error = TRUE)
-  expect_error(
-    .check_size(1:5, 1, 4),
-    class = .compile_dash("stbl", "error", "size_too_large")
-  )
+  expect_pkg_error_classes(.check_size(1:5, 1, 4), "stbl", "size_too_large")
   expect_snapshot(.check_size(1:5, 1, 4), error = TRUE)
 })
 
@@ -31,19 +26,18 @@ test_that(".check_scalar() works (#95)", {
   expect_null(.check_scalar(1))
   expect_null(.check_scalar(NULL))
   expect_null(.check_scalar(character()))
-  expect_error(
-    .check_scalar(1:2),
-    class = .compile_dash("stbl", "error", "non_scalar")
-  )
+  expect_pkg_error_classes(.check_scalar(1:2), "stbl", "non_scalar")
   expect_snapshot(.check_scalar(1:2), error = TRUE)
-  expect_error(
+  expect_pkg_error_classes(
     .check_scalar(NULL, allow_null = FALSE),
-    class = .compile_dash("stbl", "error", "non_scalar")
+    "stbl",
+    "non_scalar"
   )
   expect_snapshot(.check_scalar(NULL, allow_null = FALSE), error = TRUE)
-  expect_error(
+  expect_pkg_error_classes(
     .check_scalar(character(), allow_zero_length = FALSE),
-    class = .compile_dash("stbl", "error", "bad_empty")
+    "stbl",
+    "bad_empty"
   )
   expect_snapshot(
     .check_scalar(character(), allow_zero_length = FALSE),
@@ -68,10 +62,7 @@ test_that(".check_x_no_more_than_y() works (#95)", {
   expect_null(.check_x_no_more_than_y(2, 2))
   expect_null(.check_x_no_more_than_y(NULL, 2))
   expect_null(.check_x_no_more_than_y(1, NULL))
-  expect_error(
-    .check_x_no_more_than_y(2, 1),
-    class = .compile_dash("stbl", "error", "size_x_vs_y")
-  )
+  expect_pkg_error_classes(.check_x_no_more_than_y(2, 1), "stbl", "size_x_vs_y")
   expect_snapshot(.check_x_no_more_than_y(2, 1), error = TRUE)
 })
 
@@ -90,7 +81,7 @@ test_that(".check_cast_failures() works", {
 
   # Failure path
   failures <- c(FALSE, TRUE, FALSE, TRUE)
-  expect_error(
+  expect_pkg_error_classes(
     .check_cast_failures(
       failures = failures,
       x_class = "character",
@@ -99,7 +90,8 @@ test_that(".check_cast_failures() works", {
       x_arg = "test_arg",
       call = rlang::current_env()
     ),
-    class = .compile_dash("stbl", "error", "incompatible_type")
+    "stbl",
+    "incompatible_type"
   )
 
   expect_snapshot(
@@ -117,10 +109,7 @@ test_that(".check_cast_failures() works", {
 
 test_that(".check_all_named() works (#203)", {
   expect_null(.check_all_named(list(a = 1, b = 2)))
-  expect_error(
-    .check_all_named(list(1, 2)),
-    class = .compile_dash("stbl", "error", "bad_named")
-  )
+  expect_pkg_error_classes(.check_all_named(list(1, 2)), "stbl", "bad_named")
   expect_snapshot(
     .check_all_named(list(1, 2)),
     error = TRUE
@@ -131,9 +120,10 @@ test_that(".check_not_jagged() works (#203)", {
   expect_null(.check_not_jagged(list()))
   expect_null(.check_not_jagged(list(a = 1, b = 2)))
   expect_null(.check_not_jagged(list(a = 1:3, b = 1:3)))
-  expect_error(
+  expect_pkg_error_classes(
     .check_not_jagged(list(a = 1:3, b = 1:2)),
-    class = .compile_dash("stbl", "error", "jagged")
+    "stbl",
+    "jagged"
   )
   expect_snapshot(
     .check_not_jagged(list(a = 1:3, b = 1:2)),

--- a/tests/testthat/test-cls_unexported.R
+++ b/tests/testthat/test-cls_unexported.R
@@ -17,13 +17,14 @@ test_that(".to_cls_scalar() works", {
     1L
   )
 
-  expect_error(
+  expect_pkg_error_classes(
     .to_cls_scalar(
       c("1", "2"),
       is_rlang_cls_scalar = rlang::is_scalar_integer,
       to_cls_fn = as.integer
     ),
-    class = .compile_dash("stbl", "error", "non_scalar")
+    "stbl",
+    "non_scalar"
   )
 })
 
@@ -44,9 +45,10 @@ test_that(".stabilize_cls() calls to_cls_fn with to_cls_args", {
     1:5
   )
 
-  expect_error(
+  expect_pkg_error_classes(
     .stabilize_cls(1:5, to_cls_fn = to_fn),
-    class = .compile_dash("stbl", "error", "fail")
+    "stbl",
+    "fail"
   )
 })
 
@@ -66,23 +68,25 @@ test_that(".stabilize_cls() calls check_cls_value_fn", {
     1:3
   )
 
-  expect_error(
+  expect_pkg_error_classes(
     .stabilize_cls(
       1:5,
       to_cls_fn = as.integer,
       check_cls_value_fn = check_fn,
       check_cls_value_fn_args = list(my_arg = "success")
     ),
-    class = .compile_dash("stbl", "error", "custom")
+    "stbl",
+    "custom"
   )
 
-  expect_error(
+  expect_pkg_error_classes(
     .stabilize_cls(
       1:3,
       to_cls_fn = as.integer,
       check_cls_value_fn = check_fn
     ),
-    class = .compile_dash("stbl", "error", "fail")
+    "stbl",
+    "fail"
   )
 })
 
@@ -92,14 +96,16 @@ test_that(".stabilize_cls() calls stabilize_arg", {
     1:5
   )
 
-  expect_error(
+  expect_pkg_error_classes(
     .stabilize_cls(1:5, to_cls_fn = as.integer, min_size = 6),
-    class = .compile_dash("stbl", "error", "size_too_small")
+    "stbl",
+    "size_too_small"
   )
 
-  expect_error(
+  expect_pkg_error_classes(
     .stabilize_cls(1:5, to_cls_fn = as.integer, max_size = 4),
-    class = .compile_dash("stbl", "error", "size_too_large")
+    "stbl",
+    "size_too_large"
   )
 })
 
@@ -123,9 +129,10 @@ test_that(".stabilize_cls_scalar() calls to_cls_scalar_fn with args", {
     1L
   )
 
-  expect_error(
+  expect_pkg_error_classes(
     .stabilize_cls_scalar("1", to_cls_scalar_fn = to_fn_scalar),
-    class = .compile_dash("stbl", "error", "fail")
+    "stbl",
+    "fail"
   )
 })
 
@@ -151,35 +158,38 @@ test_that(".stabilize_cls_scalar() calls check_cls_value_fn", {
     1L
   )
 
-  expect_error(
+  expect_pkg_error_classes(
     .stabilize_cls_scalar(
       "5",
       to_cls_scalar_fn = to_fn_scalar,
       check_cls_value_fn = check_fn,
       check_cls_value_fn_args = list(my_arg = "success")
     ),
-    class = .compile_dash("stbl", "error", "custom")
+    "stbl",
+    "custom"
   )
 
-  expect_error(
+  expect_pkg_error_classes(
     .stabilize_cls_scalar(
       "1",
       to_cls_scalar_fn = to_fn_scalar,
       check_cls_value_fn = check_fn
     ),
-    class = .compile_dash("stbl", "error", "fail")
+    "stbl",
+    "fail"
   )
 })
 
 test_that(".stabilize_cls_scalar() checks for NA and empty dots", {
   to_fn_scalar <- function(x, ...) as.integer(x)
-  expect_error(
+  expect_pkg_error_classes(
     .stabilize_cls_scalar(
       NA_integer_,
       to_cls_scalar_fn = to_fn_scalar,
       allow_na = FALSE
     ),
-    class = .compile_dash("stbl", "error", "bad_na")
+    "stbl",
+    "bad_na"
   )
 
   expect_error(
@@ -225,7 +235,7 @@ test_that(".to_cls_from_fct() works (#23)", {
   )
 
   # coerce_factor = FALSE
-  expect_error(
+  expect_pkg_error_classes(
     .to_cls_from_fct(
       x = factor(1:3),
       to_cls_fn = to_fn,
@@ -233,7 +243,9 @@ test_that(".to_cls_from_fct() works (#23)", {
       to_class = "integer",
       coerce_factor = FALSE
     ),
-    class = .compile_dash("stbl", "error", "coerce", "integer")
+    "stbl",
+    "coerce",
+    "integer"
   )
 })
 
@@ -249,7 +261,7 @@ test_that(".check_lst_failures() returns NULL when all elements are valid (#273)
 })
 
 test_that(".check_lst_failures() errors when any element is invalid (#273)", {
-  expect_error(
+  expect_pkg_error_classes(
     .check_lst_failures(
       c(TRUE, FALSE),
       to = character(),
@@ -257,7 +269,8 @@ test_that(".check_lst_failures() errors when any element is invalid (#273)", {
       x_arg = "x",
       call = rlang::current_env()
     ),
-    class = .compile_dash("stbl", "error", "incompatible_type")
+    "stbl",
+    "incompatible_type"
   )
 })
 
@@ -273,12 +286,13 @@ test_that(".to_num_from_complex() works (#23)", {
   )
 
   # Failure path
-  expect_error(
+  expect_pkg_error_classes(
     .to_num_from_complex(
       x = c(1 + 1i, 2),
       cast_fn = as.integer,
       to_type_obj = integer()
     ),
-    class = .compile_dash("stbl", "error", "incompatible_type")
+    "stbl",
+    "incompatible_type"
   )
 })

--- a/tests/testthat/test-cls_unexported.R
+++ b/tests/testthat/test-cls_unexported.R
@@ -237,10 +237,10 @@ test_that(".to_cls_from_fct() works (#23)", {
   )
 })
 
-test_that(".check_lst_failures() returns NULL when all elements are valid (#noissue)", {
+test_that(".check_lst_failures() returns NULL when all elements are valid (#273)", {
   result <- .check_lst_failures(
     c(TRUE, TRUE, TRUE),
-    to_class = "character",
+    to = character(),
     x_class = "list",
     x_arg = "x",
     call = rlang::current_env()
@@ -248,16 +248,16 @@ test_that(".check_lst_failures() returns NULL when all elements are valid (#nois
   expect_null(result)
 })
 
-test_that(".check_lst_failures() errors when any element is invalid (#noissue)", {
+test_that(".check_lst_failures() errors when any element is invalid (#273)", {
   expect_error(
     .check_lst_failures(
       c(TRUE, FALSE),
-      to_class = "character",
+      to = character(),
       x_class = "list",
       x_arg = "x",
       call = rlang::current_env()
     ),
-    class = .compile_dash("stbl", "error", "coerce", "character")
+    class = .compile_dash("stbl", "error", "incompatible_type")
   )
 })
 

--- a/tests/testthat/test-pkg_abort.R
+++ b/tests/testthat/test-pkg_abort.R
@@ -64,9 +64,10 @@ test_that("pkg_abort() passes dots to cli_abort() (#136)", {
   wrapped_abort <- function(message, subclass, ...) {
     pkg_abort("wrapped", message, subclass, ...)
   }
-  expect_error(
+  expect_pkg_error_classes(
     wrapped_abort("A message.", "a_subclass", .internal = TRUE),
-    class = "wrapped-error-a_subclass"
+    "wrapped",
+    "a_subclass"
   )
   expect_snapshot(
     wrapped_abort("A message.", "a_subclass", .internal = TRUE),

--- a/tests/testthat/test-specify_lst.R
+++ b/tests/testthat/test-specify_lst.R
@@ -9,9 +9,10 @@ test_that("specify_lst() creates a working specifier (#110)", {
 
 test_that("specify_lst() respects pre-configured element specs (#110)", {
   spec <- specify_lst(count = specify_int_scalar())
-  expect_error(
+  expect_pkg_error_classes(
     spec(list(count = "not-int")),
-    class = .compile_dash("stbl", "error", "incompatible_type")
+    "stbl",
+    "incompatible_type"
   )
 })
 
@@ -32,18 +33,12 @@ test_that("specify_lst() passes through additional element specs from ... (#110)
 
 test_that("specify_lst() respects .min_size (#110)", {
   spec <- specify_lst(.min_size = 2)
-  expect_error(
-    spec(list(a = 1L)),
-    class = .compile_dash("stbl", "error", "size_too_small")
-  )
+  expect_pkg_error_classes(spec(list(a = 1L)), "stbl", "size_too_small")
 })
 
 test_that("specify_lst() respects .allow_null (#110)", {
   spec <- specify_lst(.allow_null = FALSE)
-  expect_error(
-    spec(NULL),
-    class = .compile_dash("stbl", "error", "bad_null")
-  )
+  expect_pkg_error_classes(spec(NULL), "stbl", "bad_null")
 })
 
 test_that("specify_list() exists (#110)", {
@@ -63,8 +58,9 @@ test_that("specify_lst() accepts elements named 'x_arg', 'call', 'x_class' (#204
 test_that("stabilize_lst() with nested specify_lst() propagates errors correctly (#204)", {
   inner_spec <- specify_lst(a = specify_int_scalar())
   given_bad <- list(outer = list(a = "not-int"))
-  expect_error(
+  expect_pkg_error_classes(
     stabilize_lst(given_bad, outer = inner_spec),
-    class = .compile_dash("stbl", "error", "incompatible_type")
+    "stbl",
+    "incompatible_type"
   )
 })

--- a/tests/testthat/test-stabilize_arg.R
+++ b/tests/testthat/test-stabilize_arg.R
@@ -22,9 +22,10 @@ test_that("stabilize_arg() complains about weird args (#11, #58, #99)", {
 
 test_that("stabilize_arg() rejects NULLs when asked (#11, #58, #99)", {
   given <- NULL
-  expect_error(
+  expect_pkg_error_classes(
     stabilize_arg(given, allow_null = FALSE),
-    class = .compile_dash("stbl", "error", "bad_null")
+    "stbl",
+    "bad_null"
   )
   expect_snapshot(
     stabilize_arg(given, allow_null = FALSE),
@@ -41,9 +42,10 @@ test_that("stabilize_arg() checks NAs (#11, #58, #99)", {
   expect_identical(stabilize_arg(given, allow_na = FALSE), given)
 
   given[c(4, 7)] <- NA
-  expect_error(
+  expect_pkg_error_classes(
     stabilize_arg(given, allow_na = FALSE),
-    class = .compile_dash("stbl", "error", "bad_na")
+    "stbl",
+    "bad_na"
   )
   expect_snapshot(
     stabilize_arg(given, allow_na = FALSE),
@@ -59,9 +61,10 @@ test_that("stabilize_arg() checks size args (#11, #58, #99)", {
   given <- TRUE
   expect_true(stabilize_arg(given, min_size = 1, max_size = 1))
 
-  expect_error(
+  expect_pkg_error_classes(
     stabilize_arg(given, min_size = 2, max_size = 1),
-    class = .compile_dash("stbl", "error", "size_x_vs_y")
+    "stbl",
+    "size_x_vs_y"
   )
   expect_snapshot(
     stabilize_arg(given, min_size = 2, max_size = 1),
@@ -80,9 +83,10 @@ test_that("stabilize_arg() checks min_size (#11, #58, #99)", {
     given
   )
 
-  expect_error(
+  expect_pkg_error_classes(
     stabilize_arg(given, min_size = 11),
-    class = .compile_dash("stbl", "error", "size_too_small")
+    "stbl",
+    "size_too_small"
   )
   expect_snapshot(
     stabilize_arg(given, min_size = 11),
@@ -96,9 +100,10 @@ test_that("stabilize_arg() checks min_size (#11, #58, #99)", {
 
 test_that("stabilize_arg() checks max_size (#11, #58)", {
   given <- 1:3
-  expect_error(
+  expect_pkg_error_classes(
     stabilize_arg(given, max_size = 2),
-    class = .compile_dash("stbl", "error", "size_too_large")
+    "stbl",
+    "size_too_large"
   )
   expect_snapshot(
     stabilize_arg(given, max_size = 2),
@@ -118,10 +123,7 @@ test_that("stabilize_arg_scalar() allows length-1 args through (#12)", {
 
 test_that("stabilize_arg_scalar() errors for non-scalars (#12, #58)", {
   given <- 1:10
-  expect_error(
-    stabilize_arg_scalar(given),
-    class = .compile_dash("stbl", "error", "non_scalar")
-  )
+  expect_pkg_error_classes(stabilize_arg_scalar(given), "stbl", "non_scalar")
   expect_snapshot(
     stabilize_arg_scalar(given),
     error = TRUE
@@ -134,9 +136,10 @@ test_that("stabilize_arg_scalar() errors for non-scalars (#12, #58)", {
 
 test_that("stabilize_arg_scalar() respects allow_null (#12, #58)", {
   given <- NULL
-  expect_error(
+  expect_pkg_error_classes(
     stabilize_arg_scalar(given, allow_null = FALSE),
-    class = .compile_dash("stbl", "error", "non_scalar")
+    "stbl",
+    "non_scalar"
   )
   expect_snapshot(
     stabilize_arg_scalar(given, allow_null = FALSE),
@@ -150,9 +153,10 @@ test_that("stabilize_arg_scalar() respects allow_null (#12, #58)", {
 
 test_that("stabilize_arg_scalar() errors on weird internal arg values (#12, #58)", {
   given <- NULL
-  expect_error(
+  expect_pkg_error_classes(
     stabilize_arg_scalar(given, allow_null = c(TRUE, FALSE)),
-    class = .compile_dash("stbl", "error", "non_scalar")
+    "stbl",
+    "non_scalar"
   )
   expect_snapshot(
     stabilize_arg_scalar(given, allow_null = c(TRUE, FALSE)),

--- a/tests/testthat/test-stabilize_chr.R
+++ b/tests/testthat/test-stabilize_chr.R
@@ -15,9 +15,10 @@ test_that("stabilize_chr() works on happy path (#22, #27, #52)", {
 test_that("stabilize_chr() errors for bad regex matches (#27, #52)", {
   given <- c("123456789", "12345-6789")
   pattern <- r"(^\d{5}(?:[-\s]\d{4})?$)"
-  expect_error(
+  expect_pkg_error_classes(
     stabilize_chr(given, regex = pattern),
-    class = .compile_dash("stbl", "error", "must")
+    "stbl",
+    "must"
   )
   expect_snapshot(
     stabilize_chr(given, regex = pattern),
@@ -38,12 +39,13 @@ test_that("stabilize_chr() works with complex url regex (#52)", {
       regex = url_regex
     )
   )
-  expect_error(
+  expect_pkg_error_classes(
     stabilize_chr(
       c("example.com", "not a url"),
       regex = url_regex
     ),
-    class = .compile_dash("stbl", "error", "must")
+    "stbl",
+    "must"
   )
   expect_snapshot(
     stabilize_chr(
@@ -57,12 +59,13 @@ test_that("stabilize_chr() works with complex url regex (#52)", {
 test_that("stabilize_chr() allows for customized error messages (#52)", {
   skip_if_not_installed("stringi")
   url_regex <- r"(^(?:(?:(?:https?|ftp):)?\/\/)?(?:\S+(?::\S*)?@)?(?:(?!(?:10|127)(?:\.\d{1,3}){3})(?!(?:169\.254|192\.168)(?:\.\d{1,3}){2})(?!172\.(?:1[6-9]|2\d|3[0-1])(?:\.\d{1,3}){2})(?:[1-9]\d?|1\d\d|2[01]\d|22[0-3])(?:\.(?:1?\d{1,2}|2[0-4]\d|25[0-5])){2}(?:\.(?:[1-9]\d?|1\d\d|2[0-4]\d|25[0-4]))|(?:(?:[a-z0-9\u00a1-\uffff][a-z0-9\u00a1-\uffff_-]{0,62})?[a-z0-9\u00a1-\uffff]\.)+(?:[a-z\u00a1-\uffff]{2,}\.?))(?::\d{2,5})?(?:[/?#]\S*)?$)"
-  expect_error(
+  expect_pkg_error_classes(
     stabilize_chr(
       c("not a url", "example.com"),
       regex = c("must be a url." = url_regex)
     ),
-    class = .compile_dash("stbl", "error", "must")
+    "stbl",
+    "must"
   )
   expect_snapshot(
     stabilize_chr(
@@ -74,9 +77,10 @@ test_that("stabilize_chr() allows for customized error messages (#52)", {
 })
 
 test_that("stabilize_chr() works with regex that contains braces (#52)", {
-  expect_error(
+  expect_pkg_error_classes(
     stabilize_chr(c("b", "aa"), regex = "a{1,3}"),
-    class = .compile_dash("stbl", "error", "must")
+    "stbl",
+    "must"
   )
   expect_snapshot(
     stabilize_chr(c("b", "aa"), regex = "a{1,3}"),
@@ -94,10 +98,7 @@ test_that("stabilize_chr() accepts negated regex args (#85)", {
   )
 
   given <- c("a", "b", "c")
-  expect_error(
-    stabilize_chr(given, regex = regex),
-    class = .compile_dash("stbl", "error", "must")
-  )
+  expect_pkg_error_classes(stabilize_chr(given, regex = regex), "stbl", "must")
   expect_snapshot(
     stabilize_chr(given, regex = regex),
     error = TRUE
@@ -115,10 +116,7 @@ test_that("stabilize_chr() accepts multiple regex rules (#86, #85)", {
     given
   )
   given <- c("apple", "banana", "boat", "plum")
-  expect_error(
-    stabilize_chr(given, regex = rules),
-    class = .compile_dash("stbl", "error", "must")
-  )
+  expect_pkg_error_classes(stabilize_chr(given, regex = rules), "stbl", "must")
   expect_snapshot(
     stabilize_chr(given, regex = rules),
     error = TRUE
@@ -131,9 +129,10 @@ test_that("stabilize_chr() works with stringr::fixed() (#87)", {
     stabilize_chr("a.b", regex = stringr::fixed("a.b")),
     "a.b"
   )
-  expect_error(
+  expect_pkg_error_classes(
     stabilize_chr(c("a.b", "acb"), regex = stringr::fixed("a.b")),
-    class = .compile_dash("stbl", "error", "must")
+    "stbl",
+    "must"
   )
   expect_snapshot(
     stabilize_chr(c("a.b", "acb"), regex = stringr::fixed("a.b")),
@@ -147,9 +146,10 @@ test_that("stabilize_chr() works with stringr::coll() (#87)", {
     stabilize_chr("A", regex = stringr::coll("a", ignore_case = TRUE)),
     "A"
   )
-  expect_error(
+  expect_pkg_error_classes(
     stabilize_chr(c("a", "A"), regex = stringr::coll("a")),
-    class = .compile_dash("stbl", "error", "must")
+    "stbl",
+    "must"
   )
   expect_snapshot(
     stabilize_chr(c("a", "A"), regex = stringr::coll("a")),
@@ -163,9 +163,10 @@ test_that("stabilize_chr() works with stringr::regex() (#87)", {
     stabilize_chr("A", regex = stringr::regex("a", ignore_case = TRUE)),
     "A"
   )
-  expect_error(
+  expect_pkg_error_classes(
     stabilize_chr(c("A", "B"), regex = stringr::regex("a", ignore_case = TRUE)),
-    class = .compile_dash("stbl", "error", "must")
+    "stbl",
+    "must"
   )
   expect_snapshot(
     stabilize_chr(c("A", "B"), regex = stringr::regex("a", ignore_case = TRUE)),
@@ -181,7 +182,7 @@ test_that("stabilize_chr works with NA and regex pattern (#27, #52)", {
       regex = "^[A-Za-z]+$"
     )
   })
-  expect_error(
+  expect_pkg_error_classes(
     {
       stabilize_chr(
         c("abc", NA),
@@ -189,7 +190,8 @@ test_that("stabilize_chr works with NA and regex pattern (#27, #52)", {
         regex = "^[A-Za-z]+$"
       )
     },
-    class = .compile_dash("stbl", "error", "bad_na")
+    "stbl",
+    "bad_na"
   )
 })
 
@@ -200,10 +202,7 @@ test_that("stabilize_chr_scalar() allows length-1 chrs through (#22, #189)", {
 
 test_that("stabilize_chr_scalar() respects allow_null (#22, #189)", {
   given <- NULL
-  expect_error(
-    stabilize_chr_scalar(given),
-    class = .compile_dash("stbl", "error", "bad_null")
-  )
+  expect_pkg_error_classes(stabilize_chr_scalar(given), "stbl", "bad_null")
   expect_snapshot(
     stabilize_chr_scalar(given),
     error = TRUE
@@ -216,10 +215,7 @@ test_that("stabilize_chr_scalar() respects allow_null (#22, #189)", {
 
 test_that("stabilize_chr_scalar() errors for non-scalars (#22)", {
   given <- letters
-  expect_error(
-    stabilize_chr_scalar(given),
-    class = .compile_dash("stbl", "error", "non_scalar")
-  )
+  expect_pkg_error_classes(stabilize_chr_scalar(given), "stbl", "non_scalar")
   expect_snapshot(
     stabilize_chr_scalar(given),
     error = TRUE
@@ -231,9 +227,10 @@ test_that("stabilize_chr_scalar() errors for non-scalars (#22)", {
 })
 
 test_that("stabilize_chr_scalar() works with regex that contains braces (#52)", {
-  expect_error(
+  expect_pkg_error_classes(
     stabilize_chr_scalar("b", regex = "a{1,3}"),
-    class = .compile_dash("stbl", "error", "must")
+    "stbl",
+    "must"
   )
   expect_snapshot(
     stabilize_chr_scalar("b", regex = "a{1,3}"),

--- a/tests/testthat/test-stabilize_dbl.R
+++ b/tests/testthat/test-stabilize_dbl.R
@@ -4,9 +4,10 @@ test_that("stabilize_dbl() checks min_value (#23, #176)", {
     stabilize_dbl(given, min_value = 1.1, max_value = 10.1),
     given
   )
-  expect_error(
+  expect_pkg_error_classes(
     stabilize_dbl(given, min_value = 11.1),
-    class = .compile_dash("stbl", "error", "outside_range")
+    "stbl",
+    "outside_range"
   )
   expect_snapshot(
     stabilize_dbl(given, min_value = 11.1),
@@ -24,9 +25,10 @@ test_that("stabilize_dbl() checks min_value (#23, #176)", {
 
 test_that("stabilize_dbl() checks max_value (#23, #176)", {
   given <- 1.1:10.1
-  expect_error(
+  expect_pkg_error_classes(
     stabilize_dbl(given, max_value = 4.1),
-    class = .compile_dash("stbl", "error", "outside_range")
+    "stbl",
+    "outside_range"
   )
   expect_snapshot(
     stabilize_dbl(given, max_value = 4.1),
@@ -46,10 +48,7 @@ test_that("stabilize_dbl_scalar() allows length-1 dbls through (#23, #189)", {
 
 test_that("stabilize_dbl_scalar() respects allow_null (#23, #189)", {
   given <- NULL
-  expect_error(
-    stabilize_dbl_scalar(given),
-    class = .compile_dash("stbl", "error", "bad_null")
-  )
+  expect_pkg_error_classes(stabilize_dbl_scalar(given), "stbl", "bad_null")
   expect_snapshot(
     stabilize_dbl_scalar(given),
     error = TRUE
@@ -62,10 +61,7 @@ test_that("stabilize_dbl_scalar() respects allow_null (#23, #189)", {
 
 test_that("stabilize_dbl_scalar() errors on non-scalars (#23)", {
   given <- 1.1:10.1
-  expect_error(
-    stabilize_dbl_scalar(given),
-    class = .compile_dash("stbl", "error", "non_scalar")
-  )
+  expect_pkg_error_classes(stabilize_dbl_scalar(given), "stbl", "non_scalar")
   expect_snapshot(
     stabilize_dbl_scalar(given),
     error = TRUE

--- a/tests/testthat/test-stabilize_df.R
+++ b/tests/testthat/test-stabilize_df.R
@@ -110,13 +110,14 @@ test_that("stabilize_df() validates extra columns with .extra_cols (#142)", {
 })
 
 test_that("stabilize_df() enforces .min_rows (#142)", {
-  expect_error(
+  expect_pkg_error_classes(
     stabilize_df(
       mtcars[0, ],
       .min_rows = 1,
       .extra_cols = stabilize_present
     ),
-    class = "stbl-error-too_few_rows"
+    "stbl",
+    "too_few_rows"
   )
 })
 
@@ -133,13 +134,14 @@ test_that("stabilize_df() enforces .min_rows (snapshot) (#142)", {
 })
 
 test_that("stabilize_df() enforces .max_rows (#142)", {
-  expect_error(
+  expect_pkg_error_classes(
     stabilize_df(
       mtcars,
       .max_rows = 5,
       .extra_cols = stabilize_present
     ),
-    class = "stbl-error-too_many_rows"
+    "stbl",
+    "too_many_rows"
   )
 })
 
@@ -174,13 +176,14 @@ test_that("stabilize_df() enforces .col_names (#142)", {
       .extra_cols = stabilize_present
     )
   )
-  expect_error(
+  expect_pkg_error_classes(
     stabilize_df(
       data.frame(a = 1L),
       .col_names = c("a", "b"),
       .extra_cols = stabilize_present
     ),
-    class = "stbl-error-missing_cols"
+    "stbl",
+    "missing_cols"
   )
 })
 

--- a/tests/testthat/test-stabilize_fct.R
+++ b/tests/testthat/test-stabilize_fct.R
@@ -3,9 +3,10 @@ test_that("stabilize_fct() works (#62)", {
 })
 
 test_that("stabilize_fct() throws errors for bad levels (#62, #67)", {
-  expect_error(
+  expect_pkg_error_classes(
     stabilize_fct(letters[1:5], levels = c("a", "c"), to_na = "b"),
-    class = .compile_dash("stbl", "error", "fct_levels")
+    "stbl",
+    "fct_levels"
   )
   expect_snapshot(
     stabilize_fct(letters[1:5], levels = c("a", "c"), to_na = "b"),
@@ -24,10 +25,7 @@ test_that("stabilize_fct_scalar() works (#62, #189)", {
 
 test_that("stabilize_fct_scalar() respects allow_null (#62, #189)", {
   given <- NULL
-  expect_error(
-    stabilize_fct_scalar(given),
-    class = .compile_dash("stbl", "error", "bad_null")
-  )
+  expect_pkg_error_classes(stabilize_fct_scalar(given), "stbl", "bad_null")
   expect_snapshot(
     stabilize_fct_scalar(given),
     error = TRUE
@@ -40,10 +38,7 @@ test_that("stabilize_fct_scalar() respects allow_null (#62, #189)", {
 
 test_that("stabilize_fct_scalar() errors for non-scalars (#62)", {
   given <- letters
-  expect_error(
-    stabilize_fct_scalar(given),
-    class = .compile_dash("stbl", "error", "non_scalar")
-  )
+  expect_pkg_error_classes(stabilize_fct_scalar(given), "stbl", "non_scalar")
   expect_snapshot(
     stabilize_fct_scalar(given),
     error = TRUE

--- a/tests/testthat/test-stabilize_int.R
+++ b/tests/testthat/test-stabilize_int.R
@@ -4,9 +4,10 @@ test_that("stabilize_int() checks min_value (#2, #6, #176)", {
     stabilize_int(given, min_value = 1, max_value = 10),
     given
   )
-  expect_error(
+  expect_pkg_error_classes(
     stabilize_int(given, min_value = 11),
-    class = .compile_dash("stbl", "error", "outside_range")
+    "stbl",
+    "outside_range"
   )
   expect_snapshot(
     stabilize_int(given, min_value = 11),
@@ -20,9 +21,10 @@ test_that("stabilize_int() checks min_value (#2, #6, #176)", {
 
 test_that("stabilize_int() checks max_value (#5, #176)", {
   given <- 1:10
-  expect_error(
+  expect_pkg_error_classes(
     stabilize_int(given, max_value = 4),
-    class = .compile_dash("stbl", "error", "outside_range")
+    "stbl",
+    "outside_range"
   )
   expect_snapshot(
     stabilize_int(given, max_value = 4),
@@ -42,10 +44,7 @@ test_that("stabilize_int_scalar() allows length-1 ints through (#12, #189)", {
 
 test_that("stabilize_int_scalar() respects allow_null (#12, #189)", {
   given <- NULL
-  expect_error(
-    stabilize_int_scalar(given),
-    class = .compile_dash("stbl", "error", "bad_null")
-  )
+  expect_pkg_error_classes(stabilize_int_scalar(given), "stbl", "bad_null")
   expect_snapshot(
     stabilize_int_scalar(given),
     error = TRUE
@@ -58,10 +57,7 @@ test_that("stabilize_int_scalar() respects allow_null (#12, #189)", {
 
 test_that("stabilize_int_scalar() errors on non-scalars (#12)", {
   given <- 1:10
-  expect_error(
-    stabilize_int_scalar(given),
-    class = .compile_dash("stbl", "error", "non_scalar")
-  )
+  expect_pkg_error_classes(stabilize_int_scalar(given), "stbl", "non_scalar")
   expect_snapshot(
     stabilize_int_scalar(given),
     error = TRUE

--- a/tests/testthat/test-stabilize_lgl.R
+++ b/tests/testthat/test-stabilize_lgl.R
@@ -17,9 +17,10 @@ test_that("stabilize_lgl() checks NAs (#28)", {
     stabilize_lgl(given),
     c(TRUE, NA, TRUE, FALSE)
   )
-  expect_error(
+  expect_pkg_error_classes(
     stabilize_lgl(given, allow_na = FALSE),
-    class = .compile_dash("stbl", "error", "bad_na")
+    "stbl",
+    "bad_na"
   )
   expect_snapshot(
     stabilize_lgl(given, allow_na = FALSE),
@@ -33,9 +34,10 @@ test_that("stabilize_lgl() checks NAs (#28)", {
 
 test_that("stabilize_lgl() checks min_size (#28)", {
   given <- c("TRUE", NA, "true", "fALSE")
-  expect_error(
+  expect_pkg_error_classes(
     stabilize_lgl(given, min_size = 5),
-    class = .compile_dash("stbl", "error", "size_too_small")
+    "stbl",
+    "size_too_small"
   )
   expect_snapshot(
     stabilize_lgl(given, min_size = 5),
@@ -49,9 +51,10 @@ test_that("stabilize_lgl() checks min_size (#28)", {
 
 test_that("stabilize_lgl() checks max_size (#28)", {
   given <- c("TRUE", NA, "true", "fALSE")
-  expect_error(
+  expect_pkg_error_classes(
     stabilize_lgl(given, max_size = 3),
-    class = .compile_dash("stbl", "error", "size_too_large")
+    "stbl",
+    "size_too_large"
   )
   expect_snapshot(
     stabilize_lgl(given, max_size = 3),
@@ -70,10 +73,7 @@ test_that("stabilize_lgl_scalar() allows length-1 lgls through (#28, #189)", {
 
 test_that("stabilize_lgl_scalar() respects allow_null (#28, #189)", {
   given <- NULL
-  expect_error(
-    stabilize_lgl_scalar(given),
-    class = .compile_dash("stbl", "error", "bad_null")
-  )
+  expect_pkg_error_classes(stabilize_lgl_scalar(given), "stbl", "bad_null")
   expect_snapshot(
     stabilize_lgl_scalar(given),
     error = TRUE
@@ -86,10 +86,7 @@ test_that("stabilize_lgl_scalar() respects allow_null (#28, #189)", {
 
 test_that("stabilize_lgl_scalar() errors on non-scalars (#28)", {
   given <- c(TRUE, FALSE, TRUE)
-  expect_error(
-    stabilize_lgl_scalar(given),
-    class = .compile_dash("stbl", "error", "non_scalar")
-  )
+  expect_pkg_error_classes(stabilize_lgl_scalar(given), "stbl", "non_scalar")
   expect_snapshot(
     stabilize_lgl_scalar(given),
     error = TRUE

--- a/tests/testthat/test-stabilize_lst.R
+++ b/tests/testthat/test-stabilize_lst.R
@@ -3,9 +3,10 @@ test_that("stabilize_lst() returns NULL for NULL input by default (#110)", {
 })
 
 test_that("stabilize_lst() respects .allow_null (#110)", {
-  expect_error(
+  expect_pkg_error_classes(
     stabilize_lst(NULL, .allow_null = FALSE),
-    class = .compile_dash("stbl", "error", "bad_null")
+    "stbl",
+    "bad_null"
   )
   expect_snapshot(
     stabilize_lst(NULL, .allow_null = FALSE),
@@ -38,9 +39,10 @@ test_that("stabilize_lst() validates required named elements (#110)", {
 })
 
 test_that("stabilize_lst() errors when required named element is missing (#110)", {
-  expect_error(
+  expect_pkg_error_classes(
     stabilize_lst(list(foo = "a"), name = specify_chr_scalar()),
-    class = .compile_dash("stbl", "error", "missing_element")
+    "stbl",
+    "missing_element"
   )
   expect_snapshot(
     stabilize_lst(list(foo = "a"), name = specify_chr_scalar()),
@@ -53,12 +55,13 @@ test_that("stabilize_lst() errors when required named element is missing (#110)"
 })
 
 test_that("stabilize_lst() errors informatively when element fails validation (#110)", {
-  expect_error(
+  expect_pkg_error_classes(
     stabilize_lst(
       list(count = "not-an-int"),
       count = specify_int_scalar()
     ),
-    class = .compile_dash("stbl", "error", "incompatible_type")
+    "stbl",
+    "incompatible_type"
   )
   expect_snapshot(
     stabilize_lst(list(count = "not-an-int"), count = specify_int_scalar()),
@@ -67,9 +70,10 @@ test_that("stabilize_lst() errors informatively when element fails validation (#
 })
 
 test_that("stabilize_lst() errors on extra named elements by default (#110)", {
-  expect_error(
+  expect_pkg_error_classes(
     stabilize_lst(list(a = 1L, b = 2L)),
-    class = .compile_dash("stbl", "error", "bad_named")
+    "stbl",
+    "bad_named"
   )
   expect_snapshot(
     stabilize_lst(list(a = 1L, b = 2L)),
@@ -87,17 +91,15 @@ test_that("stabilize_lst() validates extra named elements with .named (#110)", {
     stabilize_lst(given, .named = specify_int_scalar()),
     given
   )
-  expect_error(
+  expect_pkg_error_classes(
     stabilize_lst(list(a = 1L, b = "not-int"), .named = specify_int_scalar()),
-    class = .compile_dash("stbl", "error", "incompatible_type")
+    "stbl",
+    "incompatible_type"
   )
 })
 
 test_that("stabilize_lst() errors on unnamed elements by default (#110)", {
-  expect_error(
-    stabilize_lst(list(1L, 2L)),
-    class = .compile_dash("stbl", "error", "bad_unnamed")
-  )
+  expect_pkg_error_classes(stabilize_lst(list(1L, 2L)), "stbl", "bad_unnamed")
   expect_snapshot(
     stabilize_lst(list(1L, 2L)),
     error = TRUE
@@ -114,9 +116,10 @@ test_that("stabilize_lst() validates unnamed elements with .unnamed (#110)", {
     stabilize_lst(given, .unnamed = specify_int_scalar()),
     given
   )
-  expect_error(
+  expect_pkg_error_classes(
     stabilize_lst(list(1L, "not-int"), .unnamed = specify_int_scalar()),
-    class = .compile_dash("stbl", "error", "incompatible_type")
+    "stbl",
+    "incompatible_type"
   )
 })
 
@@ -134,9 +137,10 @@ test_that("stabilize_lst() handles mixed named/unnamed lists (#110)", {
 })
 
 test_that("stabilize_lst() enforces .min_size (#110)", {
-  expect_error(
+  expect_pkg_error_classes(
     stabilize_lst(list(a = 1L), .named = specify_int_scalar(), .min_size = 2),
-    class = .compile_dash("stbl", "error", "size_too_small")
+    "stbl",
+    "size_too_small"
   )
   expect_snapshot(
     stabilize_lst(list(a = 1L), .named = specify_int_scalar(), .min_size = 2),
@@ -145,13 +149,14 @@ test_that("stabilize_lst() enforces .min_size (#110)", {
 })
 
 test_that("stabilize_lst() enforces .max_size (#110)", {
-  expect_error(
+  expect_pkg_error_classes(
     stabilize_lst(
       list(a = 1L, b = 2L, c = 3L),
       .named = specify_int_scalar(),
       .max_size = 2
     ),
-    class = .compile_dash("stbl", "error", "size_too_large")
+    "stbl",
+    "size_too_large"
   )
 })
 
@@ -163,12 +168,14 @@ test_that("stabilize_lst() validates nested lists (#110)", {
     given
   )
   # data.frame can't be coerced to chr_scalar
-  expect_error(
+  expect_pkg_error_classes(
     stabilize_lst(
       list(aes = list(x = mtcars, y = "hp")),
       aes = spec_aes
     ),
-    class = .compile_dash("stbl", "error", "coerce", "character")
+    "stbl",
+    "coerce",
+    "character"
   )
   expect_snapshot(
     stabilize_lst(list(aes = list(x = mtcars, y = "hp")), aes = spec_aes),
@@ -177,16 +184,18 @@ test_that("stabilize_lst() validates nested lists (#110)", {
 })
 
 test_that("stabilize_lst() with unnamed specs errors informatively (#110)", {
-  expect_error(
+  expect_pkg_error_classes(
     stabilize_lst(list(1L), specify_int_scalar()),
-    class = .compile_dash("stbl", "error", "unnamed_spec")
+    "stbl",
+    "unnamed_spec"
   )
 })
 
 test_that(".check_duplicate_names(): errors on duplicate names by default (#110)", {
-  expect_error(
+  expect_pkg_error_classes(
     stabilize_lst(list(a = 1L, a = 2L), .named = specify_int_scalar()),
-    class = .compile_dash("stbl", "error", "duplicate_names")
+    "stbl",
+    "duplicate_names"
   )
   expect_snapshot(
     stabilize_lst(list(a = 1L, a = 2L), .named = specify_int_scalar()),
@@ -221,13 +230,14 @@ test_that(".check_duplicate_names(): reports all duplicate name groups (#110)", 
 })
 
 test_that(".check_duplicate_names(): unnamed elements do not count as duplicates (#110)", {
-  expect_error(
+  expect_pkg_error_classes(
     stabilize_lst(
       list(a = 1L, 2L, a = 3L),
       .named = specify_int_scalar(),
       .unnamed = specify_int_scalar()
     ),
-    class = .compile_dash("stbl", "error", "duplicate_names")
+    "stbl",
+    "duplicate_names"
   )
 })
 

--- a/tests/testthat/test-stabilize_present.R
+++ b/tests/testthat/test-stabilize_present.R
@@ -6,10 +6,7 @@ test_that("stabilize_present() returns any non-NULL value unchanged (#110)", {
 })
 
 test_that("stabilize_present() errors for NULL (#110)", {
-  expect_error(
-    stabilize_present(NULL),
-    class = .compile_dash("stbl", "error", "bad_null")
-  )
+  expect_pkg_error_classes(stabilize_present(NULL), "stbl", "bad_null")
   expect_snapshot(
     stabilize_present(NULL),
     error = TRUE
@@ -22,8 +19,9 @@ test_that("stabilize_present() works as an element spec in stabilize_lst() (#110
     stabilize_lst(given, data = stabilize_present),
     given
   )
-  expect_error(
+  expect_pkg_error_classes(
     stabilize_lst(list(data = NULL), data = stabilize_present),
-    class = .compile_dash("stbl", "error", "bad_null")
+    "stbl",
+    "bad_null"
   )
 })

--- a/tests/testthat/test-to_chr.R
+++ b/tests/testthat/test-to_chr.R
@@ -122,33 +122,29 @@ test_that("to_chr() errors for anonymous functions (#251)", {
   expect_identical(wrapped_to_chr(function(x) x), "val")
 })
 
-test_that("to_chr() fails gracefully for weird cases (#22)", {
+test_that("to_chr() fails gracefully for weird cases (#22, #273)", {
   given <- list(mean)
   expect_pkg_error_snapshot(
     to_chr(given),
     "stbl",
-    "coerce",
-    "character"
+    "incompatible_type"
   )
   expect_pkg_error_snapshot(
     wrapped_to_chr(given),
     "stbl",
-    "coerce",
-    "character"
+    "incompatible_type"
   )
 
   given <- list("x", mean)
   expect_pkg_error_snapshot(
     to_chr(given),
     "stbl",
-    "coerce",
-    "character"
+    "incompatible_type"
   )
   expect_pkg_error_snapshot(
     wrapped_to_chr(given),
     "stbl",
-    "coerce",
-    "character"
+    "incompatible_type"
   )
 
   given <- mtcars
@@ -169,14 +165,12 @@ test_that("to_chr() fails gracefully for weird cases (#22)", {
   expect_pkg_error_snapshot(
     to_chr(given),
     "stbl",
-    "coerce",
-    "character"
+    "incompatible_type"
   )
   expect_pkg_error_snapshot(
     wrapped_to_chr(given),
     "stbl",
-    "coerce",
-    "character"
+    "incompatible_type"
   )
 })
 
@@ -202,19 +196,17 @@ test_that("to_chr_scalar() errors for non-scalars (#22)", {
   )
 })
 
-test_that("to_chr_scalar() errors for uncoerceable types (#22)", {
+test_that("to_chr_scalar() errors for uncoerceable types (#22, #273)", {
   given <- list(a = 1:10)
   expect_pkg_error_snapshot(
     to_chr_scalar(given),
     "stbl",
-    "coerce",
-    "character"
+    "incompatible_type"
   )
   expect_pkg_error_snapshot(
     wrapped_to_chr_scalar(given),
     "stbl",
-    "coerce",
-    "character"
+    "incompatible_type"
   )
 })
 

--- a/tests/testthat/test-to_dbl.R
+++ b/tests/testthat/test-to_dbl.R
@@ -15,9 +15,10 @@ test_that("to_dbl() works for NULL (#23)", {
 
 test_that("to_dbl() respects allow_null (#23)", {
   given <- NULL
-  expect_error(
+  expect_pkg_error_classes(
     to_dbl(given, allow_null = FALSE),
-    class = .compile_dash("stbl", "error", "bad_null")
+    "stbl",
+    "bad_null"
   )
   expect_snapshot(
     to_dbl(given, allow_null = FALSE),
@@ -44,9 +45,11 @@ test_that("to_dbl() works for chrs (#23)", {
 test_that("to_dbl() respects coerce_character (#23)", {
   expected <- c(1.1, 2.2)
   given <- as.character(expected)
-  expect_error(
+  expect_pkg_error_classes(
     to_dbl(given, coerce_character = FALSE),
-    class = .compile_dash("stbl", "error", "coerce", "double")
+    "stbl",
+    "coerce",
+    "double"
   )
   expect_snapshot(
     to_dbl(given, coerce_character = FALSE),
@@ -60,10 +63,7 @@ test_that("to_dbl() respects coerce_character (#23)", {
 
 test_that("to_dbl() errors informatively for bad chrs (#23)", {
   given <- c("1.1", "a")
-  expect_error(
-    to_dbl(given),
-    class = .compile_dash("stbl", "error", "incompatible_type")
-  )
+  expect_pkg_error_classes(to_dbl(given), "stbl", "incompatible_type")
   expect_snapshot(
     to_dbl(given),
     error = TRUE
@@ -83,10 +83,7 @@ test_that("to_dbl() works for complexes (#23)", {
 test_that("to_dbl() errors informatively for bad complexes (#23)", {
   given <- as.complex(c(1.1, 2.2))
   given[[1]] <- 1.1 + 1i
-  expect_error(
-    to_dbl(given),
-    class = .compile_dash("stbl", "error", "incompatible_type")
-  )
+  expect_pkg_error_classes(to_dbl(given), "stbl", "incompatible_type")
   expect_snapshot(
     to_dbl(given),
     error = TRUE
@@ -106,9 +103,11 @@ test_that("to_dbl() works for factors (#23)", {
 test_that("to_dbl() respects coerce_factor (#23)", {
   expected <- c(1.1, 3.3)
   given <- factor(expected)
-  expect_error(
+  expect_pkg_error_classes(
     to_dbl(given, coerce_factor = FALSE),
-    class = .compile_dash("stbl", "error", "coerce", "double")
+    "stbl",
+    "coerce",
+    "double"
   )
   expect_snapshot(
     to_dbl(given, coerce_factor = FALSE),
@@ -122,10 +121,7 @@ test_that("to_dbl() respects coerce_factor (#23)", {
 
 test_that("to_dbl() errors informatively for bad factors (#23)", {
   given <- factor(letters)
-  expect_error(
-    to_dbl(given),
-    class = .compile_dash("stbl", "error", "incompatible_type")
-  )
+  expect_pkg_error_classes(to_dbl(given), "stbl", "incompatible_type")
   expect_snapshot(
     to_dbl(given),
     error = TRUE
@@ -159,10 +155,7 @@ test_that("to_dbl_scalar() allows length-1 dbls through (#23)", {
 
 test_that("to_dbl_scalar() provides informative error messages (#23)", {
   given <- c(1.1, 2.2)
-  expect_error(
-    to_dbl_scalar(given),
-    class = .compile_dash("stbl", "error", "non_scalar")
-  )
+  expect_pkg_error_classes(to_dbl_scalar(given), "stbl", "non_scalar")
   expect_snapshot(
     to_dbl_scalar(given),
     error = TRUE
@@ -175,10 +168,7 @@ test_that("to_dbl_scalar() provides informative error messages (#23)", {
 
 test_that("to_dbl_scalar() respects allow_null (#23, #189)", {
   given <- NULL
-  expect_error(
-    to_dbl_scalar(given),
-    class = .compile_dash("stbl", "error", "bad_null")
-  )
+  expect_pkg_error_classes(to_dbl_scalar(given), "stbl", "bad_null")
   expect_snapshot(
     to_dbl_scalar(given),
     error = TRUE
@@ -191,10 +181,7 @@ test_that("to_dbl_scalar() respects allow_null (#23, #189)", {
 
 test_that("to_dbl_scalar respects allow_zero_length (#23, #43, #45, #189)", {
   given <- double()
-  expect_error(
-    to_dbl_scalar(given),
-    class = .compile_dash("stbl", "error", "bad_empty")
-  )
+  expect_pkg_error_classes(to_dbl_scalar(given), "stbl", "bad_empty")
   expect_snapshot(
     to_dbl_scalar(given),
     error = TRUE

--- a/tests/testthat/test-to_dbl.R
+++ b/tests/testthat/test-to_dbl.R
@@ -136,12 +136,13 @@ test_that("to_dbl() errors informatively for bad factors (#23)", {
   )
 })
 
-test_that("to_dbl() works for lists (#128)", {
+test_that("to_dbl() works for lists (#128, #273)", {
   expect_identical(to_dbl(list(1.1, 2L, "3.3")), c(1.1, 2.0, 3.3))
   expect_identical(to_dbl(list(list(1.1), 2L)), c(1.1, 2.0))
-  expect_error(
+  expect_pkg_error_snapshot(
     to_dbl(list(1.1, 1:5)),
-    class = .compile_dash("stbl", "error", "coerce", "double")
+    "stbl",
+    "incompatible_type"
   )
 })
 

--- a/tests/testthat/test-to_df.R
+++ b/tests/testthat/test-to_df.R
@@ -7,10 +7,7 @@ test_that("to_df() returns NULL for NULL input by default (#201)", {
 })
 
 test_that("to_df() respects allow_null (#201)", {
-  expect_error(
-    to_df(NULL, allow_null = FALSE),
-    class = .compile_dash("stbl", "error", "bad_null")
-  )
+  expect_pkg_error_classes(to_df(NULL, allow_null = FALSE), "stbl", "bad_null")
   expect_snapshot(
     to_df(NULL, allow_null = FALSE),
     error = TRUE
@@ -58,10 +55,7 @@ test_that("to_df() coerces a list of equal-length vectors to a data frame (#201)
 })
 
 test_that("to_df() errors for a list with incompatible column lengths (#201)", {
-  expect_error(
-    to_df(list(a = 1:3, b = 1:2)),
-    class = .compile_dash("stbl", "error", "jagged")
-  )
+  expect_pkg_error_classes(to_df(list(a = 1:3, b = 1:2)), "stbl", "jagged")
   expect_snapshot(
     to_df(list(a = 1:3, b = 1:2)),
     error = TRUE
@@ -73,10 +67,7 @@ test_that("to_df() errors for a list with incompatible column lengths (#201)", {
 })
 
 test_that("to_df() errors for an unnamed list (#203)", {
-  expect_error(
-    to_df(list(1, 2)),
-    class = .compile_dash("stbl", "error", "bad_named")
-  )
+  expect_pkg_error_classes(to_df(list(1, 2)), "stbl", "bad_named")
   expect_snapshot(
     to_df(list(1, 2)),
     error = TRUE
@@ -84,9 +75,11 @@ test_that("to_df() errors for an unnamed list (#203)", {
 })
 
 test_that("to_df() errors for non-coercible types (#201)", {
-  expect_error(
+  expect_pkg_error_classes(
     to_df("not a data frame"),
-    class = .compile_dash("stbl", "error", "coerce", "data.frame")
+    "stbl",
+    "coerce",
+    "data.frame"
   )
   expect_snapshot(
     to_df("not a data frame"),
@@ -117,20 +110,21 @@ test_that("to_df() coerces named vector types to a data frame (#203)", {
 })
 
 test_that("to_df() errors for inline vector expressions (#203)", {
-  expect_error(
+  expect_pkg_error_classes(
     to_df(c("a", "b", "c")),
-    class = .compile_dash("stbl", "error", "coerce", "data.frame")
+    "stbl",
+    "coerce",
+    "data.frame"
   )
-  expect_error(
-    to_df(c(1.5, 2.5)),
-    class = .compile_dash("stbl", "error", "coerce", "data.frame")
-  )
+  expect_pkg_error_classes(to_df(c(1.5, 2.5)), "stbl", "coerce", "data.frame")
 })
 
 test_that("to_df.default() errors for non-coercible types (#201)", {
-  expect_error(
+  expect_pkg_error_classes(
     to_df(as.Date("2024-01-01")),
-    class = .compile_dash("stbl", "error", "coerce", "data.frame")
+    "stbl",
+    "coerce",
+    "data.frame"
   )
   expect_snapshot(
     to_df(as.Date("2024-01-01")),

--- a/tests/testthat/test-to_fct.R
+++ b/tests/testthat/test-to_fct.R
@@ -13,9 +13,10 @@ test_that("to_fct() deals with levels of fcts (#62)", {
 })
 
 test_that("to_fct() throws errors for bad levels (#62, #67, #177)", {
-  expect_error(
+  expect_pkg_error_classes(
     to_fct(letters[1:5], levels = c("a", "c"), to_na = "b"),
-    class = .compile_dash("stbl", "error", "fct_levels")
+    "stbl",
+    "fct_levels"
   )
   expect_snapshot(
     to_fct(letters[1:5], levels = c("a", "c"), to_na = "b"),
@@ -44,9 +45,10 @@ test_that("to_fct() works for NULL (#62)", {
 
 test_that("to_fct() respects allow_null (#62)", {
   given <- NULL
-  expect_error(
+  expect_pkg_error_classes(
     to_fct(given, allow_null = FALSE),
-    class = .compile_dash("stbl", "error", "bad_null")
+    "stbl",
+    "bad_null"
   )
   expect_snapshot(
     to_fct(given, allow_null = FALSE),
@@ -76,18 +78,12 @@ test_that("to_fct() works for lists (#64, #273)", {
 
 test_that("to_fct() errors for things that can't be coerced (#62, #273)", {
   given <- mean
-  expect_error(
-    to_fct(given),
-    class = .compile_dash("stbl", "error", "coerce", "factor")
-  )
+  expect_pkg_error_classes(to_fct(given), "stbl", "coerce", "factor")
   expect_snapshot(to_fct(given), error = TRUE)
   expect_snapshot(wrapped_to_fct(given), error = TRUE)
 
   given <- mtcars
-  expect_error(
-    to_fct(given),
-    class = .compile_dash("stbl", "error", "coerce", "factor")
-  )
+  expect_pkg_error_classes(to_fct(given), "stbl", "coerce", "factor")
   expect_snapshot(to_fct(given), error = TRUE)
   expect_snapshot(wrapped_to_fct(given), error = TRUE)
 
@@ -116,20 +112,14 @@ test_that("to_fct_scalar() allows length-1 fcts through (#62)", {
 
 test_that("to_fct_scalar() provides informative error messages (#62)", {
   given <- letters
-  expect_error(
-    to_fct_scalar(given),
-    class = .compile_dash("stbl", "error", "non_scalar")
-  )
+  expect_pkg_error_classes(to_fct_scalar(given), "stbl", "non_scalar")
   expect_snapshot(to_fct_scalar(given), error = TRUE)
   expect_snapshot(wrapped_to_fct_scalar(given), error = TRUE)
 })
 
 test_that("to_fct_scalar respects allow_zero_length (#62, #43, #45, #189)", {
   given <- factor()
-  expect_error(
-    to_fct_scalar(given),
-    class = .compile_dash("stbl", "error", "bad_empty")
-  )
+  expect_pkg_error_classes(to_fct_scalar(given), "stbl", "bad_empty")
   expect_snapshot(
     to_fct_scalar(given),
     error = TRUE
@@ -156,9 +146,10 @@ test_that("to_fct() works for ints via C (#241)", {
 
 test_that("to_fct() errors for ints with unexpected levels (#241)", {
   given <- c(1L, 2L, 3L)
-  expect_error(
+  expect_pkg_error_classes(
     to_fct(given, levels = c("1", "2")),
-    class = .compile_dash("stbl", "error", "fct_levels")
+    "stbl",
+    "fct_levels"
   )
   expect_snapshot(
     to_fct(given, levels = c("1", "2")),

--- a/tests/testthat/test-to_fct.R
+++ b/tests/testthat/test-to_fct.R
@@ -58,7 +58,7 @@ test_that("to_fct() respects allow_null (#62)", {
   )
 })
 
-test_that("to_fct() works for lists (#64)", {
+test_that("to_fct() works for lists (#64, #273)", {
   expect_identical(
     to_fct(list("a", "b")),
     factor(c("a", "b"))
@@ -67,13 +67,14 @@ test_that("to_fct() works for lists (#64)", {
     to_fct(list(list("a"), "b")),
     factor(c("a", "b"))
   )
-  expect_error(
+  expect_pkg_error_snapshot(
     to_fct(list("a", 1:5)),
-    class = .compile_dash("stbl", "error", "coerce", "factor")
+    "stbl",
+    "incompatible_type"
   )
 })
 
-test_that("to_fct() errors for things that can't be coerced (#62)", {
+test_that("to_fct() errors for things that can't be coerced (#62, #273)", {
   given <- mean
   expect_error(
     to_fct(given),
@@ -91,12 +92,16 @@ test_that("to_fct() errors for things that can't be coerced (#62)", {
   expect_snapshot(wrapped_to_fct(given), error = TRUE)
 
   given <- list(a = 1, b = 1:5)
-  expect_error(
+  expect_pkg_error_snapshot(
     to_fct(given),
-    class = .compile_dash("stbl", "error", "coerce", "factor")
+    "stbl",
+    "incompatible_type"
   )
-  expect_snapshot(to_fct(given), error = TRUE)
-  expect_snapshot(wrapped_to_fct(given), error = TRUE)
+  expect_pkg_error_snapshot(
+    wrapped_to_fct(given),
+    "stbl",
+    "incompatible_type"
+  )
 })
 
 test_that("to_fct() treats numbers as text (#62)", {

--- a/tests/testthat/test-to_int.R
+++ b/tests/testthat/test-to_int.R
@@ -214,12 +214,13 @@ test_that("to_int() errors informatively for bad factors (#4)", {
   )
 })
 
-test_that("to_int() works for lists (#2)", {
+test_that("to_int() works for lists (#2, #273)", {
   expect_identical(to_int(list(1L, 2.0, "3")), c(1L, 2L, 3L))
   expect_identical(to_int(list(list(1L), 2L)), c(1L, 2L))
-  expect_error(
+  expect_pkg_error_snapshot(
     to_int(list(1L, 1:5)),
-    class = .compile_dash("stbl", "error", "coerce", "integer")
+    "stbl",
+    "incompatible_type"
   )
 })
 

--- a/tests/testthat/test-to_int.R
+++ b/tests/testthat/test-to_int.R
@@ -10,9 +10,10 @@ test_that("to_int() works for NULL (#2)", {
 
 test_that("to_int() respects allow_null (#2)", {
   given <- NULL
-  expect_error(
+  expect_pkg_error_classes(
     to_int(given, allow_null = FALSE),
-    class = .compile_dash("stbl", "error", "bad_null")
+    "stbl",
+    "bad_null"
   )
   expect_snapshot(
     to_int(given, allow_null = FALSE),
@@ -39,10 +40,7 @@ test_that("to_int() works for dbls (#2)", {
 test_that("to_int() errors for dbls that would lose precision (#2, #217)", {
   given <- as.double(1:10)
   given[[4]] <- 1.1
-  expect_error(
-    to_int(given),
-    class = .compile_dash("stbl", "error", "incompatible_type")
-  )
+  expect_pkg_error_classes(to_int(given), "stbl", "incompatible_type")
   expect_snapshot(
     to_int(given),
     error = TRUE
@@ -53,10 +51,7 @@ test_that("to_int() errors for dbls that would lose precision (#2, #217)", {
   )
 
   given[[4]] <- Inf
-  expect_error(
-    to_int(given),
-    class = .compile_dash("stbl", "error", "incompatible_type")
-  )
+  expect_pkg_error_classes(to_int(given), "stbl", "incompatible_type")
   expect_snapshot(
     to_int(given),
     error = TRUE
@@ -76,9 +71,11 @@ test_that("to_int() works for chrs (#2)", {
 test_that("to_int() respects coerce_character (#14)", {
   expected <- 1:10
   given <- as.character(expected)
-  expect_error(
+  expect_pkg_error_classes(
     to_int(given, coerce_character = FALSE),
-    class = .compile_dash("stbl", "error", "coerce", "integer")
+    "stbl",
+    "coerce",
+    "integer"
   )
   expect_snapshot(
     to_int(given, coerce_character = FALSE),
@@ -93,10 +90,7 @@ test_that("to_int() respects coerce_character (#14)", {
 test_that("to_int() errors informatively for bad chrs (#2)", {
   given <- as.character(1:10)
   given[[4]] <- "1.1"
-  expect_error(
-    to_int(given),
-    class = .compile_dash("stbl", "error", "incompatible_type")
-  )
+  expect_pkg_error_classes(to_int(given), "stbl", "incompatible_type")
   expect_snapshot(
     to_int(given),
     error = TRUE
@@ -107,10 +101,7 @@ test_that("to_int() errors informatively for bad chrs (#2)", {
   )
 
   given[[4]] <- "a"
-  expect_error(
-    to_int(given),
-    class = .compile_dash("stbl", "error", "incompatible_type")
-  )
+  expect_pkg_error_classes(to_int(given), "stbl", "incompatible_type")
   expect_snapshot(
     to_int(given),
     error = TRUE
@@ -130,10 +121,7 @@ test_that("to_int() works for complexes (#2)", {
 test_that("to_int() errors informatively for bad complexes (#2)", {
   given <- as.complex(1:10)
   given[[4]] <- 1 + 1i
-  expect_error(
-    to_int(given),
-    class = .compile_dash("stbl", "error", "incompatible_type")
-  )
+  expect_pkg_error_classes(to_int(given), "stbl", "incompatible_type")
   expect_snapshot(
     to_int(given),
     error = TRUE
@@ -147,10 +135,7 @@ test_that("to_int() errors informatively for bad complexes (#2)", {
 test_that("to_int() errors for complexes that would lose precision (#noissue)", {
   given <- as.complex(1:10)
   given[[4]] <- 1.5 + 0i
-  expect_error(
-    to_int(given),
-    class = .compile_dash("stbl", "error", "incompatible_type")
-  )
+  expect_pkg_error_classes(to_int(given), "stbl", "incompatible_type")
   expect_snapshot(
     to_int(given),
     error = TRUE
@@ -161,10 +146,7 @@ test_that("to_int() errors for complexes that would lose precision (#noissue)", 
   )
 
   given[[4]] <- Inf + 0i
-  expect_error(
-    to_int(given),
-    class = .compile_dash("stbl", "error", "incompatible_type")
-  )
+  expect_pkg_error_classes(to_int(given), "stbl", "incompatible_type")
   expect_snapshot(
     to_int(given),
     error = TRUE
@@ -184,9 +166,11 @@ test_that("to_int() works for factors (#4)", {
 test_that("to_int() respects coerce_factor (#14)", {
   expected <- c(1L, 3L, 5L, 7L)
   given <- factor(expected)
-  expect_error(
+  expect_pkg_error_classes(
     to_int(given, coerce_factor = FALSE),
-    class = .compile_dash("stbl", "error", "coerce", "integer")
+    "stbl",
+    "coerce",
+    "integer"
   )
   expect_snapshot(
     to_int(given, coerce_factor = FALSE),
@@ -200,10 +184,7 @@ test_that("to_int() respects coerce_factor (#14)", {
 
 test_that("to_int() errors informatively for bad factors (#4)", {
   given <- factor(letters)
-  expect_error(
-    to_int(given),
-    class = .compile_dash("stbl", "error", "incompatible_type")
-  )
+  expect_pkg_error_classes(to_int(given), "stbl", "incompatible_type")
   expect_snapshot(
     to_int(given),
     error = TRUE
@@ -238,10 +219,7 @@ test_that("to_int_scalar() allows length-1 ints through (#12)", {
 
 test_that("to_int_scalar() provides informative error messages (#12)", {
   given <- 1:10
-  expect_error(
-    to_int_scalar(given),
-    class = .compile_dash("stbl", "error", "non_scalar")
-  )
+  expect_pkg_error_classes(to_int_scalar(given), "stbl", "non_scalar")
   expect_snapshot(
     to_int_scalar(given),
     error = TRUE
@@ -254,10 +232,7 @@ test_that("to_int_scalar() provides informative error messages (#12)", {
 
 test_that("to_int_scalar() respects allow_null (#12, #189)", {
   given <- NULL
-  expect_error(
-    to_int_scalar(given),
-    class = .compile_dash("stbl", "error", "bad_null")
-  )
+  expect_pkg_error_classes(to_int_scalar(given), "stbl", "bad_null")
   expect_snapshot(
     to_int_scalar(given),
     error = TRUE
@@ -270,10 +245,7 @@ test_that("to_int_scalar() respects allow_null (#12, #189)", {
 
 test_that("to_int_scalar respects allow_zero_length (#12, #43, #45, #189)", {
   given <- integer()
-  expect_error(
-    to_int_scalar(given),
-    class = .compile_dash("stbl", "error", "bad_empty")
-  )
+  expect_pkg_error_classes(to_int_scalar(given), "stbl", "bad_empty")
   expect_snapshot(
     to_int_scalar(given),
     error = TRUE

--- a/tests/testthat/test-to_lgl.R
+++ b/tests/testthat/test-to_lgl.R
@@ -25,9 +25,10 @@ test_that("to_lgl() works for NULL (#21)", {
 
 test_that("to_lgl() respects allow_null (#21)", {
   given <- NULL
-  expect_error(
+  expect_pkg_error_classes(
     to_lgl(given, allow_null = FALSE),
-    class = .compile_dash("stbl", "error", "bad_null")
+    "stbl",
+    "bad_null"
   )
   expect_snapshot(
     to_lgl(given, allow_null = FALSE),
@@ -110,10 +111,7 @@ test_that("to_lgl works for characters (#21)", {
 })
 
 test_that("to_lgl() errors for bad characters (#21)", {
-  expect_error(
-    to_lgl(letters),
-    class = .compile_dash("stbl", "error", "incompatible_type")
-  )
+  expect_pkg_error_classes(to_lgl(letters), "stbl", "incompatible_type")
   expect_snapshot(
     to_lgl(letters),
     error = TRUE
@@ -162,10 +160,7 @@ test_that("to_lgl works for factors (#21)", {
 
 test_that("to_lgl errors for bad factors (#21)", {
   given <- factor(letters)
-  expect_error(
-    to_lgl(given),
-    class = .compile_dash("stbl", "error", "incompatible_type")
-  )
+  expect_pkg_error_classes(to_lgl(given), "stbl", "incompatible_type")
   expect_snapshot(
     to_lgl(given),
     error = TRUE
@@ -203,10 +198,7 @@ test_that("to_lgl() errors for other types (#21, #273)", {
   )
 
   given <- mean
-  expect_error(
-    to_lgl(given),
-    class = .compile_dash("stbl", "error", "coerce", "logical")
-  )
+  expect_pkg_error_classes(to_lgl(given), "stbl", "coerce", "logical")
   expect_snapshot(
     to_lgl(given),
     error = TRUE
@@ -227,10 +219,7 @@ test_that("to_lgl_scalar() allows length-1 lgls through (#32, #189)", {
 
 test_that("to_lgl_scalar() errors for non-scalars (#32)", {
   given <- c(TRUE, FALSE, TRUE)
-  expect_error(
-    to_lgl_scalar(given),
-    class = .compile_dash("stbl", "error", "non_scalar")
-  )
+  expect_pkg_error_classes(to_lgl_scalar(given), "stbl", "non_scalar")
   expect_snapshot(
     to_lgl_scalar(given),
     error = TRUE
@@ -243,10 +232,7 @@ test_that("to_lgl_scalar() errors for non-scalars (#32)", {
 
 test_that("to_lgl_scalar() errors for bad characters (#32)", {
   given <- "a"
-  expect_error(
-    to_lgl_scalar(given),
-    class = .compile_dash("stbl", "error", "incompatible_type")
-  )
+  expect_pkg_error_classes(to_lgl_scalar(given), "stbl", "incompatible_type")
   expect_snapshot(
     to_lgl_scalar(given),
     error = TRUE
@@ -259,10 +245,7 @@ test_that("to_lgl_scalar() errors for bad characters (#32)", {
 
 test_that("to_lgl_scalar() respects allow_null (#32, #189)", {
   given <- NULL
-  expect_error(
-    to_lgl_scalar(given),
-    class = .compile_dash("stbl", "error", "bad_null")
-  )
+  expect_pkg_error_classes(to_lgl_scalar(given), "stbl", "bad_null")
   expect_snapshot(
     to_lgl_scalar(given),
     error = TRUE

--- a/tests/testthat/test-to_lgl.R
+++ b/tests/testthat/test-to_lgl.R
@@ -176,31 +176,30 @@ test_that("to_lgl errors for bad factors (#21)", {
   )
 })
 
-test_that("to_lgl() works for lists (#21)", {
+test_that("to_lgl() works for lists (#21, #273)", {
   expect_identical(
     to_lgl(list(TRUE, FALSE, 1, 0, "T", "F")),
     as.logical(c(1, 0, 1, 0, 1, 0))
   )
   expect_identical(to_lgl(list(list(TRUE), 0L)), c(TRUE, FALSE))
-  expect_error(
+  expect_pkg_error_snapshot(
     to_lgl(list(TRUE, 1:5)),
-    class = .compile_dash("stbl", "error", "coerce", "logical")
+    "stbl",
+    "incompatible_type"
   )
 })
 
-test_that("to_lgl() errors for other types (#21)", {
+test_that("to_lgl() errors for other types (#21, #273)", {
   given <- list(1, 1:10)
-  expect_error(
+  expect_pkg_error_snapshot(
     to_lgl(given),
-    class = .compile_dash("stbl", "error", "coerce", "logical")
+    "stbl",
+    "incompatible_type"
   )
-  expect_snapshot(
-    to_lgl(given),
-    error = TRUE
-  )
-  expect_snapshot(
+  expect_pkg_error_snapshot(
     wrapped_to_lgl(given),
-    error = TRUE
+    "stbl",
+    "incompatible_type"
   )
 
   given <- mean

--- a/tests/testthat/test-to_lst.R
+++ b/tests/testthat/test-to_lst.R
@@ -13,9 +13,10 @@ test_that("to_lst() works for NULL (#157)", {
 
 test_that("to_lst() respects allow_null (#157)", {
   given <- NULL
-  expect_error(
+  expect_pkg_error_classes(
     to_lst(given, allow_null = FALSE),
-    class = .compile_dash("stbl", "error", "bad_null")
+    "stbl",
+    "bad_null"
   )
   expect_snapshot(
     to_lst(given, allow_null = FALSE),
@@ -58,10 +59,7 @@ test_that("to_lst() works for character vectors (#157)", {
 
 test_that("to_lst() errors by default for functions (#157)", {
   given <- function(x) x + 1
-  expect_error(
-    to_lst(given),
-    class = .compile_dash("stbl", "error", "bad_function")
-  )
+  expect_pkg_error_classes(to_lst(given), "stbl", "bad_function")
   expect_snapshot(
     to_lst(given),
     error = TRUE
@@ -83,9 +81,11 @@ test_that("to_lst() works for functions with coerce_function = TRUE (#157)", {
 
 test_that("to_lst() errors informatively for primitives (#157)", {
   given <- is.na
-  expect_error(
+  expect_pkg_error_classes(
     to_lst(given, coerce_function = TRUE),
-    class = .compile_dash("stbl", "error", "coerce", "list")
+    "stbl",
+    "coerce",
+    "list"
   )
   expect_snapshot(
     to_lst(given, coerce_function = TRUE),

--- a/tests/testthat/test-to_null.R
+++ b/tests/testthat/test-to_null.R
@@ -4,9 +4,10 @@ test_that(".to_null() works on the happy path (#129)", {
 
 test_that(".to_null() errors when NULL isn't allowed (#129)", {
   given <- NULL
-  expect_error(
+  expect_pkg_error_classes(
     .to_null(given, allow_null = FALSE),
-    class = .compile_dash("stbl", "error", "bad_null")
+    "stbl",
+    "bad_null"
   )
   expect_snapshot(
     .to_null(given, allow_null = FALSE),
@@ -26,18 +27,20 @@ test_that(".to_null() coerces anything to NULL (#129)", {
 })
 
 test_that(".to_null() errors for bad allow_null (#129)", {
-  expect_error(
+  expect_pkg_error_classes(
     .to_null(NULL, allow_null = NULL),
-    class = .compile_dash("stbl", "error", "bad_null")
+    "stbl",
+    "bad_null"
   )
   expect_snapshot(
     .to_null(NULL, allow_null = NULL),
     error = TRUE
   )
 
-  expect_error(
+  expect_pkg_error_classes(
     .to_null(NULL, allow_null = "fish"),
-    class = .compile_dash("stbl", "error", "incompatible_type")
+    "stbl",
+    "incompatible_type"
   )
   expect_snapshot(
     .to_null(NULL, allow_null = "fish"),
@@ -50,10 +53,7 @@ test_that(".to_null() errors for bad allow_null (#129)", {
 })
 
 test_that(".to_null() errors informatively for missing value (#129)", {
-  expect_error(
-    .to_null(),
-    class = .compile_dash("stbl", "error", "must")
-  )
+  expect_pkg_error_classes(.to_null(), "stbl", "must")
   expect_snapshot(
     .to_null(),
     error = TRUE


### PR DESCRIPTION
Closes #273.