### PR TITLE
chore: convert remaining expect_pkg_error_classes() + expect_snapshot() pairs to expect_pkg_error_snapshot()

### DIFF
--- a/tests/testthat/_snaps/aaa-conditions.md
+++ b/tests/testthat/_snaps/aaa-conditions.md
@@ -1,8 +1,10 @@
 # .stbl_abort() throws the expected error (#95)
 
     Code
-      .stbl_abort("A message.", "a_subclass")
-    Condition
+      (expect_pkg_error_classes(.stbl_abort("A message.", "a_subclass"), "stbl",
+      "a_subclass"))
+    Output
+      <error/stbl-error-a_subclass>
       Error:
       ! A message.
 
@@ -24,8 +26,10 @@
 # .stop_cant_coerce() throws the expected error (#95)
 
     Code
-      .stop_cant_coerce("character", "integer", "my_arg", rlang::current_env())
-    Condition
+      (expect_pkg_error_classes(.stop_cant_coerce("character", "integer", "my_arg",
+        rlang::current_env()), "stbl", "coerce", "integer"))
+    Output
+      <error/stbl-error-coerce-integer>
       Error:
       ! Can't coerce `my_arg` <character> to <integer>.
 
@@ -42,16 +46,20 @@
 # .stop_must() throws the expected error (#95)
 
     Code
-      .stop_must("must be a foo.", "my_arg", rlang::current_env())
-    Condition
+      (expect_pkg_error_classes(.stop_must("must be a foo.", "my_arg", rlang::current_env()),
+      "stbl", "must"))
+    Output
+      <error/stbl-error-must>
       Error:
       ! `my_arg` must be a foo.
 
 # .stop_must() handles subclasses (#95)
 
     Code
-      .stop_must("must be a foo.", "my_arg", rlang::current_env(), subclass = "my_custom_class")
-    Condition
+      (expect_pkg_error_classes(.stop_must("must be a foo.", "my_arg", rlang::current_env(),
+      subclass = "my_custom_class"), "stbl", "my_custom_class"))
+    Output
+      <error/stbl-error-my_custom_class>
       Error:
       ! `my_arg` must be a foo.
 
@@ -68,17 +76,21 @@
 # .stop_null() throws the expected error (#95)
 
     Code
-      .stop_null("my_arg", rlang::current_env())
-    Condition
+      (expect_pkg_error_classes(.stop_null("my_arg", rlang::current_env()), "stbl",
+      "bad_null"))
+    Output
+      <error/stbl-error-bad_null>
       Error:
       ! `my_arg` must not be <NULL>.
 
 # .stop_incompatible() throws the expected error (#95)
 
     Code
-      .stop_incompatible("character", integer(), c(FALSE, TRUE, FALSE, TRUE),
-      "some reason", "my_arg", rlang::current_env())
-    Condition
+      (expect_pkg_error_classes(.stop_incompatible("character", integer(), c(FALSE,
+        TRUE, FALSE, TRUE), "some reason", "my_arg", rlang::current_env()), "stbl",
+      "incompatible_type"))
+    Output
+      <error/stbl-error-incompatible_type>
       Error:
       ! `my_arg` <character> must be coercible to <integer>
       x Can't convert some values due to some reason.
@@ -87,9 +99,11 @@
 # .stop_incompatible() passes dots (#95)
 
     Code
-      .stop_incompatible("character", integer(), c(FALSE, TRUE, FALSE, TRUE),
-      "some reason", "my_arg", rlang::current_env(), .internal = TRUE)
-    Condition
+      (expect_pkg_error_classes(.stop_incompatible("character", integer(), c(FALSE,
+        TRUE, FALSE, TRUE), "some reason", "my_arg", rlang::current_env(), .internal = TRUE),
+      "stbl", "incompatible_type"))
+    Output
+      <error/stbl-error-incompatible_type>
       Error:
       ! `my_arg` <character> must be coercible to <integer>
       x Can't convert some values due to some reason.

--- a/tests/testthat/_snaps/pkg_abort.md
+++ b/tests/testthat/_snaps/pkg_abort.md
@@ -19,8 +19,10 @@
 # pkg_abort() passes dots to cli_abort() (#136)
 
     Code
-      wrapped_abort("A message.", "a_subclass", .internal = TRUE)
-    Condition
+      (expect_pkg_error_classes(wrapped_abort("A message.", "a_subclass", .internal = TRUE),
+      "wrapped", "a_subclass"))
+    Output
+      <error/wrapped-error-a_subclass>
       Error in `wrapped_abort()`:
       ! A message.
       i This is an internal error.

--- a/tests/testthat/_snaps/specify_cls.md
+++ b/tests/testthat/_snaps/specify_cls.md
@@ -36,8 +36,11 @@
 # The function built via specify_cls errors informatively for duplicated args (#150, #153, #161)
 
     Code
-      no_null(NULL, allow_null = FALSE)
-    Condition
+      (expect_pkg_error_classes({
+        no_null(NULL, allow_null = FALSE)
+      }, "stbl", "duplicate_args"))
+    Output
+      <error/stbl-error-duplicate_args>
       Error in `no_null()`:
       ! Arguments passed via `...` cannot duplicate specification.
       i Duplicated arguments: `allow_null`

--- a/tests/testthat/_snaps/stabilize_arg.md
+++ b/tests/testthat/_snaps/stabilize_arg.md
@@ -21,24 +21,30 @@
 # stabilize_arg() rejects NULLs when asked (#11, #58, #99)
 
     Code
-      stabilize_arg(given, allow_null = FALSE)
-    Condition
+      (expect_pkg_error_classes(stabilize_arg(given, allow_null = FALSE), "stbl",
+      "bad_null"))
+    Output
+      <error/stbl-error-bad_null>
       Error:
       ! `given` must not be <NULL>.
 
 ---
 
     Code
-      wrapped_stabilize_arg(given, allow_null = FALSE)
-    Condition
+      (expect_pkg_error_classes(wrapped_stabilize_arg(given, allow_null = FALSE),
+      "stbl", "bad_null"))
+    Output
+      <error/stbl-error-bad_null>
       Error in `wrapped_stabilize_arg()`:
       ! `val` must not be <NULL>.
 
 # stabilize_arg() checks NAs (#11, #58, #99)
 
     Code
-      stabilize_arg(given, allow_na = FALSE)
-    Condition
+      (expect_pkg_error_classes(stabilize_arg(given, allow_na = FALSE), "stbl",
+      "bad_na"))
+    Output
+      <error/stbl-error-bad_na>
       Error:
       ! `given` must not contain NA values.
       * NA locations: 4 and 7
@@ -46,8 +52,10 @@
 ---
 
     Code
-      wrapped_stabilize_arg(given, allow_na = FALSE)
-    Condition
+      (expect_pkg_error_classes(wrapped_stabilize_arg(given, allow_na = FALSE),
+      "stbl", "bad_na"))
+    Output
+      <error/stbl-error-bad_na>
       Error in `wrapped_stabilize_arg()`:
       ! `val` must not contain NA values.
       * NA locations: 4 and 7
@@ -55,8 +63,10 @@
 # stabilize_arg() checks size args (#11, #58, #99)
 
     Code
-      stabilize_arg(given, min_size = 2, max_size = 1)
-    Condition
+      (expect_pkg_error_classes(stabilize_arg(given, min_size = 2, max_size = 1),
+      "stbl", "size_x_vs_y"))
+    Output
+      <error/stbl-error-size_x_vs_y>
       Error:
       ! `min_size` can't be larger than `max_size`.
       * `min_size` = 2
@@ -65,8 +75,10 @@
 ---
 
     Code
-      wrapped_stabilize_arg(given, min_size = 2, max_size = 1)
-    Condition
+      (expect_pkg_error_classes(wrapped_stabilize_arg(given, min_size = 2, max_size = 1),
+      "stbl", "size_x_vs_y"))
+    Output
+      <error/stbl-error-size_x_vs_y>
       Error in `wrapped_stabilize_arg()`:
       ! `min_size` can't be larger than `max_size`.
       * `min_size` = 2
@@ -75,8 +87,10 @@
 # stabilize_arg() checks min_size (#11, #58, #99)
 
     Code
-      stabilize_arg(given, min_size = 11)
-    Condition
+      (expect_pkg_error_classes(stabilize_arg(given, min_size = 11), "stbl",
+      "size_too_small"))
+    Output
+      <error/stbl-error-size_too_small>
       Error:
       ! `given` must have size >= 11.
       x 3 is too small.
@@ -84,8 +98,10 @@
 ---
 
     Code
-      wrapped_stabilize_arg(given, min_size = 11)
-    Condition
+      (expect_pkg_error_classes(wrapped_stabilize_arg(given, min_size = 11), "stbl",
+      "size_too_small"))
+    Output
+      <error/stbl-error-size_too_small>
       Error in `wrapped_stabilize_arg()`:
       ! `val` must have size >= 11.
       x 3 is too small.
@@ -93,8 +109,10 @@
 # stabilize_arg() checks max_size (#11, #58)
 
     Code
-      stabilize_arg(given, max_size = 2)
-    Condition
+      (expect_pkg_error_classes(stabilize_arg(given, max_size = 2), "stbl",
+      "size_too_large"))
+    Output
+      <error/stbl-error-size_too_large>
       Error:
       ! `given` must have size <= 2.
       x 3 is too big.
@@ -102,8 +120,10 @@
 ---
 
     Code
-      wrapped_stabilize_arg(given, max_size = 2)
-    Condition
+      (expect_pkg_error_classes(wrapped_stabilize_arg(given, max_size = 2), "stbl",
+      "size_too_large"))
+    Output
+      <error/stbl-error-size_too_large>
       Error in `wrapped_stabilize_arg()`:
       ! `val` must have size <= 2.
       x 3 is too big.
@@ -111,8 +131,9 @@
 # stabilize_arg_scalar() errors for non-scalars (#12, #58)
 
     Code
-      stabilize_arg_scalar(given)
-    Condition
+      (expect_pkg_error_classes(stabilize_arg_scalar(given), "stbl", "non_scalar"))
+    Output
+      <error/stbl-error-non_scalar>
       Error:
       ! `given` must be a single <integer>.
       x `given` has 10 values.
@@ -120,8 +141,10 @@
 ---
 
     Code
-      wrapped_stabilize_arg_scalar(given)
-    Condition
+      (expect_pkg_error_classes(wrapped_stabilize_arg_scalar(given), "stbl",
+      "non_scalar"))
+    Output
+      <error/stbl-error-non_scalar>
       Error in `wrapped_stabilize_arg_scalar()`:
       ! `val` must be a single <integer>.
       x `val` has 10 values.
@@ -129,8 +152,10 @@
 # stabilize_arg_scalar() respects allow_null (#12, #58)
 
     Code
-      stabilize_arg_scalar(given, allow_null = FALSE)
-    Condition
+      (expect_pkg_error_classes(stabilize_arg_scalar(given, allow_null = FALSE),
+      "stbl", "non_scalar"))
+    Output
+      <error/stbl-error-non_scalar>
       Error:
       ! `given` must be a single <non-NULL>.
       x `given` has no values.
@@ -138,8 +163,10 @@
 ---
 
     Code
-      wrapped_stabilize_arg_scalar(given, allow_null = FALSE)
-    Condition
+      (expect_pkg_error_classes(wrapped_stabilize_arg_scalar(given, allow_null = FALSE),
+      "stbl", "non_scalar"))
+    Output
+      <error/stbl-error-non_scalar>
       Error in `wrapped_stabilize_arg_scalar()`:
       ! `val` must be a single <non-NULL>.
       x `val` has no values.
@@ -147,8 +174,10 @@
 # stabilize_arg_scalar() errors on weird internal arg values (#12, #58)
 
     Code
-      stabilize_arg_scalar(given, allow_null = c(TRUE, FALSE))
-    Condition
+      (expect_pkg_error_classes(stabilize_arg_scalar(given, allow_null = c(TRUE,
+        FALSE)), "stbl", "non_scalar"))
+    Output
+      <error/stbl-error-non_scalar>
       Error:
       ! `allow_null` must be a single <logical>.
       x `allow_null` has 2 values.

--- a/tests/testthat/_snaps/stabilize_chr.md
+++ b/tests/testthat/_snaps/stabilize_chr.md
@@ -1,8 +1,10 @@
 # stabilize_chr() errors for bad regex matches (#27, #52)
 
     Code
-      stabilize_chr(given, regex = pattern)
-    Condition
+      (expect_pkg_error_classes(stabilize_chr(given, regex = pattern), "stbl", "must")
+      )
+    Output
+      <error/stbl-error-must>
       Error:
       ! `given` must match the regex pattern "^\\d{5}(?:[-\\s]\\d{4})?$"
       x Some values fail the check.
@@ -12,8 +14,10 @@
 ---
 
     Code
-      wrapped_stabilize_chr(given, regex = pattern)
-    Condition
+      (expect_pkg_error_classes(wrapped_stabilize_chr(given, regex = pattern), "stbl",
+      "must"))
+    Output
+      <error/stbl-error-must>
       Error in `wrapped_stabilize_chr()`:
       ! `val` must match the regex pattern "^\\d{5}(?:[-\\s]\\d{4})?$"
       x Some values fail the check.
@@ -30,8 +34,10 @@
 ---
 
     Code
-      stabilize_chr(c("example.com", "not a url"), regex = url_regex)
-    Condition
+      (expect_pkg_error_classes(stabilize_chr(c("example.com", "not a url"), regex = url_regex),
+      "stbl", "must"))
+    Output
+      <error/stbl-error-must>
       Error:
       ! `c("example.com", "not a url")` must match the regex pattern "^(?:(?:(?:https?|ftp):)?\\/\\/)?(?:\\S+(?::\\S*)?@)?(?:(?!(?:10|127)(?:\\.\\d{1,3}){3})(?!(?:169\\.254|192\\.168)(?:\\.\\d{1,3}){2})(?!172\\.(?:1[6-9]|2\\d|3[0-1])(?:\\.\\d{1,3}){2})(?:[1-9]\\d?|1\\d\\d|2[01]\\d|22[0-3])(?:\\.(?:1?\\d{1,2}|2[0-4]\\d|25[0-5])){2}(?:\\.(?:[1-9]\\d?|1\\d\\d|2[0-4]\\d|25[0-4]))|(?:(?:[a-z0-9\\u00a1-\\uffff][a-z0-9\\u00a1-\\uffff_-]{0,62})?[a-z0-9\\u00a1-\\uffff]\\.)+(?:[a-z\\u00a1-\\uffff]{2,}\\.?))(?::\\d{2,5})?(?:[/?#]\\S*)?$"
       x Some values fail the check.
@@ -41,8 +47,10 @@
 # stabilize_chr() allows for customized error messages (#52)
 
     Code
-      stabilize_chr(c("not a url", "example.com"), regex = c(`must be a url.` = url_regex))
-    Condition
+      (expect_pkg_error_classes(stabilize_chr(c("not a url", "example.com"), regex = c(
+        `must be a url.` = url_regex)), "stbl", "must"))
+    Output
+      <error/stbl-error-must>
       Error:
       ! `c("not a url", "example.com")` must be a url.
       x Some values fail the check.
@@ -52,8 +60,10 @@
 # stabilize_chr() works with regex that contains braces (#52)
 
     Code
-      stabilize_chr(c("b", "aa"), regex = "a{1,3}")
-    Condition
+      (expect_pkg_error_classes(stabilize_chr(c("b", "aa"), regex = "a{1,3}"), "stbl",
+      "must"))
+    Output
+      <error/stbl-error-must>
       Error:
       ! `c("b", "aa")` must match the regex pattern "a{1,3}"
       x Some values fail the check.
@@ -63,8 +73,9 @@
 # stabilize_chr() accepts negated regex args (#85)
 
     Code
-      stabilize_chr(given, regex = regex)
-    Condition
+      (expect_pkg_error_classes(stabilize_chr(given, regex = regex), "stbl", "must"))
+    Output
+      <error/stbl-error-must>
       Error:
       ! `given` must not match the regex pattern "c"
       x Some values fail the check.
@@ -74,8 +85,9 @@
 # stabilize_chr() accepts multiple regex rules (#86, #85)
 
     Code
-      stabilize_chr(given, regex = rules)
-    Condition
+      (expect_pkg_error_classes(stabilize_chr(given, regex = rules), "stbl", "must"))
+    Output
+      <error/stbl-error-must>
       Error:
       ! `given` must match the regex pattern "a"
       x Some values fail the check.
@@ -89,8 +101,10 @@
 # stabilize_chr() works with stringr::fixed() (#87)
 
     Code
-      stabilize_chr(c("a.b", "acb"), regex = stringr::fixed("a.b"))
-    Condition
+      (expect_pkg_error_classes(stabilize_chr(c("a.b", "acb"), regex = stringr::fixed(
+        "a.b")), "stbl", "must"))
+    Output
+      <error/stbl-error-must>
       Error:
       ! `c("a.b", "acb")` must match the regex pattern "a.b"
       x Some values fail the check.
@@ -100,8 +114,10 @@
 # stabilize_chr() works with stringr::coll() (#87)
 
     Code
-      stabilize_chr(c("a", "A"), regex = stringr::coll("a"))
-    Condition
+      (expect_pkg_error_classes(stabilize_chr(c("a", "A"), regex = stringr::coll("a")),
+      "stbl", "must"))
+    Output
+      <error/stbl-error-must>
       Error:
       ! `c("a", "A")` must match the regex pattern "a"
       x Some values fail the check.
@@ -111,8 +127,10 @@
 # stabilize_chr() works with stringr::regex() (#87)
 
     Code
-      stabilize_chr(c("A", "B"), regex = stringr::regex("a", ignore_case = TRUE))
-    Condition
+      (expect_pkg_error_classes(stabilize_chr(c("A", "B"), regex = stringr::regex("a",
+        ignore_case = TRUE)), "stbl", "must"))
+    Output
+      <error/stbl-error-must>
       Error:
       ! `c("A", "B")` must match the regex pattern "a"
       x Some values fail the check.
@@ -122,24 +140,28 @@
 # stabilize_chr_scalar() respects allow_null (#22, #189)
 
     Code
-      stabilize_chr_scalar(given)
-    Condition
+      (expect_pkg_error_classes(stabilize_chr_scalar(given), "stbl", "bad_null"))
+    Output
+      <error/stbl-error-bad_null>
       Error:
       ! `given` must not be <NULL>.
 
 ---
 
     Code
-      wrapped_stabilize_chr_scalar(given)
-    Condition
+      (expect_pkg_error_classes(wrapped_stabilize_chr_scalar(given), "stbl",
+      "bad_null"))
+    Output
+      <error/stbl-error-bad_null>
       Error in `wrapped_stabilize_chr_scalar()`:
       ! `val` must not be <NULL>.
 
 # stabilize_chr_scalar() errors for non-scalars (#22)
 
     Code
-      stabilize_chr_scalar(given)
-    Condition
+      (expect_pkg_error_classes(stabilize_chr_scalar(given), "stbl", "non_scalar"))
+    Output
+      <error/stbl-error-non_scalar>
       Error:
       ! `given` must be a single <character>.
       x `given` has 26 values.
@@ -147,8 +169,10 @@
 ---
 
     Code
-      wrapped_stabilize_chr_scalar(given)
-    Condition
+      (expect_pkg_error_classes(wrapped_stabilize_chr_scalar(given), "stbl",
+      "non_scalar"))
+    Output
+      <error/stbl-error-non_scalar>
       Error in `wrapped_stabilize_chr_scalar()`:
       ! `val` must be a single <character>.
       x `val` has 26 values.
@@ -156,8 +180,10 @@
 # stabilize_chr_scalar() works with regex that contains braces (#52)
 
     Code
-      stabilize_chr_scalar("b", regex = "a{1,3}")
-    Condition
+      (expect_pkg_error_classes(stabilize_chr_scalar("b", regex = "a{1,3}"), "stbl",
+      "must"))
+    Output
+      <error/stbl-error-must>
       Error:
       ! `"b"` must match the regex pattern "a{1,3}"
       x "b" fails the check.

--- a/tests/testthat/_snaps/stabilize_dbl.md
+++ b/tests/testthat/_snaps/stabilize_dbl.md
@@ -1,8 +1,10 @@
 # stabilize_dbl() checks min_value (#23, #176)
 
     Code
-      stabilize_dbl(given, min_value = 11.1)
-    Condition
+      (expect_pkg_error_classes(stabilize_dbl(given, min_value = 11.1), "stbl",
+      "outside_range"))
+    Output
+      <error/stbl-error-outside_range>
       Error:
       ! `given` must be >= 11.1.
       i Some values are too low.
@@ -21,8 +23,10 @@
 ---
 
     Code
-      wrapped_stabilize_dbl(given, min_value = 11.1)
-    Condition
+      (expect_pkg_error_classes(wrapped_stabilize_dbl(given, min_value = 11.1),
+      "stbl", "outside_range"))
+    Output
+      <error/stbl-error-outside_range>
       Error in `wrapped_stabilize_dbl()`:
       ! `val` must be >= 11.1.
       i Some values are too low.
@@ -32,8 +36,10 @@
 # stabilize_dbl() checks max_value (#23, #176)
 
     Code
-      stabilize_dbl(given, max_value = 4.1)
-    Condition
+      (expect_pkg_error_classes(stabilize_dbl(given, max_value = 4.1), "stbl",
+      "outside_range"))
+    Output
+      <error/stbl-error-outside_range>
       Error:
       ! `given` must be <= 4.1.
       i Some values are too high.
@@ -43,8 +49,10 @@
 ---
 
     Code
-      wrapped_stabilize_dbl(given, max_value = 4.1)
-    Condition
+      (expect_pkg_error_classes(wrapped_stabilize_dbl(given, max_value = 4.1), "stbl",
+      "outside_range"))
+    Output
+      <error/stbl-error-outside_range>
       Error in `wrapped_stabilize_dbl()`:
       ! `val` must be <= 4.1.
       i Some values are too high.
@@ -54,24 +62,28 @@
 # stabilize_dbl_scalar() respects allow_null (#23, #189)
 
     Code
-      stabilize_dbl_scalar(given)
-    Condition
+      (expect_pkg_error_classes(stabilize_dbl_scalar(given), "stbl", "bad_null"))
+    Output
+      <error/stbl-error-bad_null>
       Error:
       ! `given` must not be <NULL>.
 
 ---
 
     Code
-      wrapped_stabilize_dbl_scalar(given)
-    Condition
+      (expect_pkg_error_classes(wrapped_stabilize_dbl_scalar(given), "stbl",
+      "bad_null"))
+    Output
+      <error/stbl-error-bad_null>
       Error in `wrapped_stabilize_dbl_scalar()`:
       ! `val` must not be <NULL>.
 
 # stabilize_dbl_scalar() errors on non-scalars (#23)
 
     Code
-      stabilize_dbl_scalar(given)
-    Condition
+      (expect_pkg_error_classes(stabilize_dbl_scalar(given), "stbl", "non_scalar"))
+    Output
+      <error/stbl-error-non_scalar>
       Error:
       ! `given` must be a single <numeric>.
       x `given` has 10 values.
@@ -79,8 +91,10 @@
 ---
 
     Code
-      wrapped_stabilize_dbl_scalar(given)
-    Condition
+      (expect_pkg_error_classes(wrapped_stabilize_dbl_scalar(given), "stbl",
+      "non_scalar"))
+    Output
+      <error/stbl-error-non_scalar>
       Error in `wrapped_stabilize_dbl_scalar()`:
       ! `val` must be a single <numeric>.
       x `val` has 10 values.

--- a/tests/testthat/_snaps/stabilize_fct.md
+++ b/tests/testthat/_snaps/stabilize_fct.md
@@ -1,8 +1,10 @@
 # stabilize_fct() throws errors for bad levels (#62, #67)
 
     Code
-      stabilize_fct(letters[1:5], levels = c("a", "c"), to_na = "b")
-    Condition
+      (expect_pkg_error_classes(stabilize_fct(letters[1:5], levels = c("a", "c"),
+      to_na = "b"), "stbl", "fct_levels"))
+    Output
+      <error/stbl-error-fct_levels>
       Error:
       ! Each value of `letters[1:5]` must be in the expected levels.
       i Allowed levels: "a" and "c".
@@ -12,8 +14,10 @@
 ---
 
     Code
-      wrapped_stabilize_fct(letters[1:5], levels = c("a", "c"), to_na = "b")
-    Condition
+      (expect_pkg_error_classes(wrapped_stabilize_fct(letters[1:5], levels = c("a",
+        "c"), to_na = "b"), "stbl", "fct_levels"))
+    Output
+      <error/stbl-error-fct_levels>
       Error in `wrapped_stabilize_fct()`:
       ! Each value of `val` must be in the expected levels.
       i Allowed levels: "a" and "c".
@@ -23,24 +27,28 @@
 # stabilize_fct_scalar() respects allow_null (#62, #189)
 
     Code
-      stabilize_fct_scalar(given)
-    Condition
+      (expect_pkg_error_classes(stabilize_fct_scalar(given), "stbl", "bad_null"))
+    Output
+      <error/stbl-error-bad_null>
       Error:
       ! `given` must not be <NULL>.
 
 ---
 
     Code
-      wrapped_stabilize_fct_scalar(given)
-    Condition
+      (expect_pkg_error_classes(wrapped_stabilize_fct_scalar(given), "stbl",
+      "bad_null"))
+    Output
+      <error/stbl-error-bad_null>
       Error in `wrapped_stabilize_fct_scalar()`:
       ! `val` must not be <NULL>.
 
 # stabilize_fct_scalar() errors for non-scalars (#62)
 
     Code
-      stabilize_fct_scalar(given)
-    Condition
+      (expect_pkg_error_classes(stabilize_fct_scalar(given), "stbl", "non_scalar"))
+    Output
+      <error/stbl-error-non_scalar>
       Error:
       ! `given` must be a single <factor>.
       x `given` has 26 values.
@@ -48,8 +56,10 @@
 ---
 
     Code
-      wrapped_stabilize_fct_scalar(given)
-    Condition
+      (expect_pkg_error_classes(wrapped_stabilize_fct_scalar(given), "stbl",
+      "non_scalar"))
+    Output
+      <error/stbl-error-non_scalar>
       Error in `wrapped_stabilize_fct_scalar()`:
       ! `val` must be a single <factor>.
       x `val` has 26 values.

--- a/tests/testthat/_snaps/stabilize_int.md
+++ b/tests/testthat/_snaps/stabilize_int.md
@@ -1,8 +1,10 @@
 # stabilize_int() checks min_value (#2, #6, #176)
 
     Code
-      stabilize_int(given, min_value = 11)
-    Condition
+      (expect_pkg_error_classes(stabilize_int(given, min_value = 11), "stbl",
+      "outside_range"))
+    Output
+      <error/stbl-error-outside_range>
       Error:
       ! `given` must be >= 11.
       i Some values are too low.
@@ -12,8 +14,10 @@
 ---
 
     Code
-      wrapped_stabilize_int(given, min_value = 11)
-    Condition
+      (expect_pkg_error_classes(wrapped_stabilize_int(given, min_value = 11), "stbl",
+      "outside_range"))
+    Output
+      <error/stbl-error-outside_range>
       Error in `wrapped_stabilize_int()`:
       ! `val` must be >= 11.
       i Some values are too low.
@@ -23,8 +27,10 @@
 # stabilize_int() checks max_value (#5, #176)
 
     Code
-      stabilize_int(given, max_value = 4)
-    Condition
+      (expect_pkg_error_classes(stabilize_int(given, max_value = 4), "stbl",
+      "outside_range"))
+    Output
+      <error/stbl-error-outside_range>
       Error:
       ! `given` must be <= 4.
       i Some values are too high.
@@ -34,8 +40,10 @@
 ---
 
     Code
-      wrapped_stabilize_int(given, max_value = 4)
-    Condition
+      (expect_pkg_error_classes(wrapped_stabilize_int(given, max_value = 4), "stbl",
+      "outside_range"))
+    Output
+      <error/stbl-error-outside_range>
       Error in `wrapped_stabilize_int()`:
       ! `val` must be <= 4.
       i Some values are too high.
@@ -45,24 +53,28 @@
 # stabilize_int_scalar() respects allow_null (#12, #189)
 
     Code
-      stabilize_int_scalar(given)
-    Condition
+      (expect_pkg_error_classes(stabilize_int_scalar(given), "stbl", "bad_null"))
+    Output
+      <error/stbl-error-bad_null>
       Error:
       ! `given` must not be <NULL>.
 
 ---
 
     Code
-      wrapped_stabilize_int_scalar(given)
-    Condition
+      (expect_pkg_error_classes(wrapped_stabilize_int_scalar(given), "stbl",
+      "bad_null"))
+    Output
+      <error/stbl-error-bad_null>
       Error in `wrapped_stabilize_int_scalar()`:
       ! `val` must not be <NULL>.
 
 # stabilize_int_scalar() errors on non-scalars (#12)
 
     Code
-      stabilize_int_scalar(given)
-    Condition
+      (expect_pkg_error_classes(stabilize_int_scalar(given), "stbl", "non_scalar"))
+    Output
+      <error/stbl-error-non_scalar>
       Error:
       ! `given` must be a single <integer>.
       x `given` has 10 values.
@@ -70,8 +82,10 @@
 ---
 
     Code
-      wrapped_stabilize_int_scalar(given)
-    Condition
+      (expect_pkg_error_classes(wrapped_stabilize_int_scalar(given), "stbl",
+      "non_scalar"))
+    Output
+      <error/stbl-error-non_scalar>
       Error in `wrapped_stabilize_int_scalar()`:
       ! `val` must be a single <integer>.
       x `val` has 10 values.

--- a/tests/testthat/_snaps/stabilize_lgl.md
+++ b/tests/testthat/_snaps/stabilize_lgl.md
@@ -1,8 +1,10 @@
 # stabilize_lgl() checks NAs (#28)
 
     Code
-      stabilize_lgl(given, allow_na = FALSE)
-    Condition
+      (expect_pkg_error_classes(stabilize_lgl(given, allow_na = FALSE), "stbl",
+      "bad_na"))
+    Output
+      <error/stbl-error-bad_na>
       Error:
       ! `given` must not contain NA values.
       * NA locations: 2
@@ -10,8 +12,10 @@
 ---
 
     Code
-      wrapped_stabilize_lgl(given, allow_na = FALSE)
-    Condition
+      (expect_pkg_error_classes(wrapped_stabilize_lgl(given, allow_na = FALSE),
+      "stbl", "bad_na"))
+    Output
+      <error/stbl-error-bad_na>
       Error in `wrapped_stabilize_lgl()`:
       ! `val` must not contain NA values.
       * NA locations: 2
@@ -19,8 +23,10 @@
 # stabilize_lgl() checks min_size (#28)
 
     Code
-      stabilize_lgl(given, min_size = 5)
-    Condition
+      (expect_pkg_error_classes(stabilize_lgl(given, min_size = 5), "stbl",
+      "size_too_small"))
+    Output
+      <error/stbl-error-size_too_small>
       Error:
       ! `given` must have size >= 5.
       x 4 is too small.
@@ -28,8 +34,10 @@
 ---
 
     Code
-      wrapped_stabilize_lgl(given, min_size = 5)
-    Condition
+      (expect_pkg_error_classes(wrapped_stabilize_lgl(given, min_size = 5), "stbl",
+      "size_too_small"))
+    Output
+      <error/stbl-error-size_too_small>
       Error in `wrapped_stabilize_lgl()`:
       ! `val` must have size >= 5.
       x 4 is too small.
@@ -37,8 +45,10 @@
 # stabilize_lgl() checks max_size (#28)
 
     Code
-      stabilize_lgl(given, max_size = 3)
-    Condition
+      (expect_pkg_error_classes(stabilize_lgl(given, max_size = 3), "stbl",
+      "size_too_large"))
+    Output
+      <error/stbl-error-size_too_large>
       Error:
       ! `given` must have size <= 3.
       x 4 is too big.
@@ -46,8 +56,10 @@
 ---
 
     Code
-      wrapped_stabilize_lgl(given, max_size = 3)
-    Condition
+      (expect_pkg_error_classes(wrapped_stabilize_lgl(given, max_size = 3), "stbl",
+      "size_too_large"))
+    Output
+      <error/stbl-error-size_too_large>
       Error in `wrapped_stabilize_lgl()`:
       ! `val` must have size <= 3.
       x 4 is too big.
@@ -55,24 +67,28 @@
 # stabilize_lgl_scalar() respects allow_null (#28, #189)
 
     Code
-      stabilize_lgl_scalar(given)
-    Condition
+      (expect_pkg_error_classes(stabilize_lgl_scalar(given), "stbl", "bad_null"))
+    Output
+      <error/stbl-error-bad_null>
       Error:
       ! `given` must not be <NULL>.
 
 ---
 
     Code
-      wrapped_stabilize_lgl_scalar(given)
-    Condition
+      (expect_pkg_error_classes(wrapped_stabilize_lgl_scalar(given), "stbl",
+      "bad_null"))
+    Output
+      <error/stbl-error-bad_null>
       Error in `wrapped_stabilize_lgl_scalar()`:
       ! `val` must not be <NULL>.
 
 # stabilize_lgl_scalar() errors on non-scalars (#28)
 
     Code
-      stabilize_lgl_scalar(given)
-    Condition
+      (expect_pkg_error_classes(stabilize_lgl_scalar(given), "stbl", "non_scalar"))
+    Output
+      <error/stbl-error-non_scalar>
       Error:
       ! `given` must be a single <logical>.
       x `given` has 3 values.
@@ -80,8 +96,10 @@
 ---
 
     Code
-      wrapped_stabilize_lgl_scalar(given)
-    Condition
+      (expect_pkg_error_classes(wrapped_stabilize_lgl_scalar(given), "stbl",
+      "non_scalar"))
+    Output
+      <error/stbl-error-non_scalar>
       Error in `wrapped_stabilize_lgl_scalar()`:
       ! `val` must be a single <logical>.
       x `val` has 3 values.

--- a/tests/testthat/_snaps/stabilize_lst.md
+++ b/tests/testthat/_snaps/stabilize_lst.md
@@ -1,40 +1,50 @@
 # stabilize_lst() respects .allow_null (#110)
 
     Code
-      stabilize_lst(NULL, .allow_null = FALSE)
-    Condition
+      (expect_pkg_error_classes(stabilize_lst(NULL, .allow_null = FALSE), "stbl",
+      "bad_null"))
+    Output
+      <error/stbl-error-bad_null>
       Error:
       ! `NULL` must not be <NULL>.
 
 ---
 
     Code
-      wrapped_stabilize_lst(NULL, .allow_null = FALSE)
-    Condition
+      (expect_pkg_error_classes(wrapped_stabilize_lst(NULL, .allow_null = FALSE),
+      "stbl", "bad_null"))
+    Output
+      <error/stbl-error-bad_null>
       Error in `wrapped_stabilize_lst()`:
       ! `val` must not be <NULL>.
 
 # stabilize_lst() errors when required named element is missing (#110)
 
     Code
-      stabilize_lst(list(foo = "a"), name = specify_chr_scalar())
-    Condition
+      (expect_pkg_error_classes(stabilize_lst(list(foo = "a"), name = specify_chr_scalar()),
+      "stbl", "missing_element"))
+    Output
+      <error/stbl-error-missing_element>
       Error:
       ! `list(foo = "a")` must contain element "name".
 
 ---
 
     Code
-      wrapped_stabilize_lst(list(foo = "a"), name = specify_chr_scalar())
-    Condition
+      (expect_pkg_error_classes(wrapped_stabilize_lst(list(foo = "a"), name = specify_chr_scalar()),
+      "stbl", "missing_element"))
+    Output
+      <error/stbl-error-missing_element>
       Error in `wrapped_stabilize_lst()`:
       ! `val` must contain element "name".
 
 # stabilize_lst() errors informatively when element fails validation (#110)
 
     Code
-      stabilize_lst(list(count = "not-an-int"), count = specify_int_scalar())
-    Condition
+      (expect_pkg_error_classes(stabilize_lst(list(count = "not-an-int"), count = specify_int_scalar()),
+      "stbl", "incompatible_type"))
+    Output
+      <error/stbl-error-incompatible_type>
       Error:
       ! `list(count = "not-an-int")[["count"]]` <character> must be coercible to <integer>
       x Can't convert some values due to incompatible values.
@@ -43,8 +53,10 @@
 # stabilize_lst() errors on extra named elements by default (#110)
 
     Code
-      stabilize_lst(list(a = 1L, b = 2L))
-    Condition
+      (expect_pkg_error_classes(stabilize_lst(list(a = 1L, b = 2L)), "stbl",
+      "bad_named"))
+    Output
+      <error/stbl-error-bad_named>
       Error:
       ! `list(a = 1L, b = 2L)` must not contain extra named elements.
       x Extra elements: "a" and "b"
@@ -52,8 +64,10 @@
 ---
 
     Code
-      wrapped_stabilize_lst(list(a = 1L, b = 2L))
-    Condition
+      (expect_pkg_error_classes(wrapped_stabilize_lst(list(a = 1L, b = 2L)), "stbl",
+      "bad_named"))
+    Output
+      <error/stbl-error-bad_named>
       Error in `wrapped_stabilize_lst()`:
       ! `val` must not contain extra named elements.
       x Extra elements: "a" and "b"
@@ -61,8 +75,9 @@
 # stabilize_lst() errors on unnamed elements by default (#110)
 
     Code
-      stabilize_lst(list(1L, 2L))
-    Condition
+      (expect_pkg_error_classes(stabilize_lst(list(1L, 2L)), "stbl", "bad_unnamed"))
+    Output
+      <error/stbl-error-bad_unnamed>
       Error:
       ! `list(1L, 2L)` must not contain unnamed elements.
       x Unnamed positions: 1 and 2
@@ -70,8 +85,10 @@
 ---
 
     Code
-      wrapped_stabilize_lst(list(1L, 2L))
-    Condition
+      (expect_pkg_error_classes(wrapped_stabilize_lst(list(1L, 2L)), "stbl",
+      "bad_unnamed"))
+    Output
+      <error/stbl-error-bad_unnamed>
       Error in `wrapped_stabilize_lst()`:
       ! `val` must not contain unnamed elements.
       x Unnamed positions: 1 and 2
@@ -79,8 +96,10 @@
 # stabilize_lst() enforces .min_size (#110)
 
     Code
-      stabilize_lst(list(a = 1L), .named = specify_int_scalar(), .min_size = 2)
-    Condition
+      (expect_pkg_error_classes(stabilize_lst(list(a = 1L), .named = specify_int_scalar(),
+      .min_size = 2), "stbl", "size_too_small"))
+    Output
+      <error/stbl-error-size_too_small>
       Error:
       ! `list(a = 1L)` must have size >= 2.
       x 1 is too small.
@@ -88,16 +107,20 @@
 # stabilize_lst() validates nested lists (#110)
 
     Code
-      stabilize_lst(list(aes = list(x = mtcars, y = "hp")), aes = spec_aes)
-    Condition
+      (expect_pkg_error_classes(stabilize_lst(list(aes = list(x = mtcars, y = "hp")),
+      aes = spec_aes), "stbl", "coerce", "character"))
+    Output
+      <error/stbl-error-coerce-character>
       Error:
       ! Can't coerce `list(aes = list(x = mtcars, y = "hp"))[["aes"]][["x"]]` <data.frame> to <character>.
 
 # .check_duplicate_names(): errors on duplicate names by default (#110)
 
     Code
-      stabilize_lst(list(a = 1L, a = 2L), .named = specify_int_scalar())
-    Condition
+      (expect_pkg_error_classes(stabilize_lst(list(a = 1L, a = 2L), .named = specify_int_scalar()),
+      "stbl", "duplicate_names"))
+    Output
+      <error/stbl-error-duplicate_names>
       Error:
       ! `list(a = 1L, a = 2L)` must not contain duplicate names.
       x Duplicate name: "a"
@@ -105,8 +128,10 @@
 ---
 
     Code
-      wrapped_stabilize_lst(list(a = 1L, a = 2L), .named = specify_int_scalar())
-    Condition
+      (expect_pkg_error_classes(wrapped_stabilize_lst(list(a = 1L, a = 2L), .named = specify_int_scalar()),
+      "stbl", "duplicate_names"))
+    Output
+      <error/stbl-error-duplicate_names>
       Error in `wrapped_stabilize_lst()`:
       ! `val` must not contain duplicate names.
       x Duplicate name: "a"

--- a/tests/testthat/_snaps/stabilize_present.md
+++ b/tests/testthat/_snaps/stabilize_present.md
@@ -1,8 +1,9 @@
 # stabilize_present() errors for NULL (#110)
 
     Code
-      stabilize_present(NULL)
-    Condition
+      (expect_pkg_error_classes(stabilize_present(NULL), "stbl", "bad_null"))
+    Output
+      <error/stbl-error-bad_null>
       Error:
       ! `NULL` must not be <NULL>.
 

--- a/tests/testthat/_snaps/to_dbl.md
+++ b/tests/testthat/_snaps/to_dbl.md
@@ -1,40 +1,49 @@
 # to_dbl() respects allow_null (#23)
 
     Code
-      to_dbl(given, allow_null = FALSE)
-    Condition
+      (expect_pkg_error_classes(to_dbl(given, allow_null = FALSE), "stbl", "bad_null")
+      )
+    Output
+      <error/stbl-error-bad_null>
       Error:
       ! `given` must not be <NULL>.
 
 ---
 
     Code
-      wrapped_to_dbl(given, allow_null = FALSE)
-    Condition
+      (expect_pkg_error_classes(wrapped_to_dbl(given, allow_null = FALSE), "stbl",
+      "bad_null"))
+    Output
+      <error/stbl-error-bad_null>
       Error in `wrapped_to_dbl()`:
       ! `val` must not be <NULL>.
 
 # to_dbl() respects coerce_character (#23)
 
     Code
-      to_dbl(given, coerce_character = FALSE)
-    Condition
+      (expect_pkg_error_classes(to_dbl(given, coerce_character = FALSE), "stbl",
+      "coerce", "double"))
+    Output
+      <error/stbl-error-coerce-double>
       Error:
       ! Can't coerce `given` <character> to <double>.
 
 ---
 
     Code
-      wrapped_to_dbl(given, coerce_character = FALSE)
-    Condition
+      (expect_pkg_error_classes(wrapped_to_dbl(given, coerce_character = FALSE),
+      "stbl", "coerce", "double"))
+    Output
+      <error/stbl-error-coerce-double>
       Error in `wrapped_to_dbl()`:
       ! Can't coerce `val` <character> to <double>.
 
 # to_dbl() errors informatively for bad chrs (#23)
 
     Code
-      to_dbl(given)
-    Condition
+      (expect_pkg_error_classes(to_dbl(given), "stbl", "incompatible_type"))
+    Output
+      <error/stbl-error-incompatible_type>
       Error:
       ! `given` <character> must be coercible to <double>
       x Can't convert some values due to incompatible values.
@@ -43,8 +52,9 @@
 ---
 
     Code
-      wrapped_to_dbl(given)
-    Condition
+      (expect_pkg_error_classes(wrapped_to_dbl(given), "stbl", "incompatible_type"))
+    Output
+      <error/stbl-error-incompatible_type>
       Error in `wrapped_to_dbl()`:
       ! `val` <character> must be coercible to <double>
       x Can't convert some values due to incompatible values.
@@ -53,8 +63,9 @@
 # to_dbl() errors informatively for bad complexes (#23)
 
     Code
-      to_dbl(given)
-    Condition
+      (expect_pkg_error_classes(to_dbl(given), "stbl", "incompatible_type"))
+    Output
+      <error/stbl-error-incompatible_type>
       Error:
       ! `given` <complex> must be coercible to <double>
       x Can't convert some values due to non-zero complex components.
@@ -63,8 +74,9 @@
 ---
 
     Code
-      wrapped_to_dbl(given)
-    Condition
+      (expect_pkg_error_classes(wrapped_to_dbl(given), "stbl", "incompatible_type"))
+    Output
+      <error/stbl-error-incompatible_type>
       Error in `wrapped_to_dbl()`:
       ! `val` <complex> must be coercible to <double>
       x Can't convert some values due to non-zero complex components.
@@ -73,24 +85,29 @@
 # to_dbl() respects coerce_factor (#23)
 
     Code
-      to_dbl(given, coerce_factor = FALSE)
-    Condition
+      (expect_pkg_error_classes(to_dbl(given, coerce_factor = FALSE), "stbl",
+      "coerce", "double"))
+    Output
+      <error/stbl-error-coerce-double>
       Error:
       ! Can't coerce `given` <factor> to <double>.
 
 ---
 
     Code
-      wrapped_to_dbl(given, coerce_factor = FALSE)
-    Condition
+      (expect_pkg_error_classes(wrapped_to_dbl(given, coerce_factor = FALSE), "stbl",
+      "coerce", "double"))
+    Output
+      <error/stbl-error-coerce-double>
       Error in `wrapped_to_dbl()`:
       ! Can't coerce `val` <factor> to <double>.
 
 # to_dbl() errors informatively for bad factors (#23)
 
     Code
-      to_dbl(given)
-    Condition
+      (expect_pkg_error_classes(to_dbl(given), "stbl", "incompatible_type"))
+    Output
+      <error/stbl-error-incompatible_type>
       Error:
       ! `given` <factor> must be coercible to <double>
       x Can't convert some values due to incompatible values.
@@ -99,8 +116,9 @@
 ---
 
     Code
-      wrapped_to_dbl(given)
-    Condition
+      (expect_pkg_error_classes(wrapped_to_dbl(given), "stbl", "incompatible_type"))
+    Output
+      <error/stbl-error-incompatible_type>
       Error in `wrapped_to_dbl()`:
       ! `val` <factor> must be coercible to <double>
       x Can't convert some values due to incompatible values.
@@ -120,8 +138,9 @@
 # to_dbl_scalar() provides informative error messages (#23)
 
     Code
-      to_dbl_scalar(given)
-    Condition
+      (expect_pkg_error_classes(to_dbl_scalar(given), "stbl", "non_scalar"))
+    Output
+      <error/stbl-error-non_scalar>
       Error:
       ! `given` must be a single <numeric>.
       x `given` has 2 values.
@@ -129,8 +148,9 @@
 ---
 
     Code
-      wrapped_to_dbl_scalar(given)
-    Condition
+      (expect_pkg_error_classes(wrapped_to_dbl_scalar(given), "stbl", "non_scalar"))
+    Output
+      <error/stbl-error-non_scalar>
       Error in `wrapped_to_dbl_scalar()`:
       ! `val` must be a single <numeric>.
       x `val` has 2 values.
@@ -138,24 +158,27 @@
 # to_dbl_scalar() respects allow_null (#23, #189)
 
     Code
-      to_dbl_scalar(given)
-    Condition
+      (expect_pkg_error_classes(to_dbl_scalar(given), "stbl", "bad_null"))
+    Output
+      <error/stbl-error-bad_null>
       Error:
       ! `given` must not be <NULL>.
 
 ---
 
     Code
-      wrapped_to_dbl_scalar(given)
-    Condition
+      (expect_pkg_error_classes(wrapped_to_dbl_scalar(given), "stbl", "bad_null"))
+    Output
+      <error/stbl-error-bad_null>
       Error in `wrapped_to_dbl_scalar()`:
       ! `val` must not be <NULL>.
 
 # to_dbl_scalar respects allow_zero_length (#23, #43, #45, #189)
 
     Code
-      to_dbl_scalar(given)
-    Condition
+      (expect_pkg_error_classes(to_dbl_scalar(given), "stbl", "bad_empty"))
+    Output
+      <error/stbl-error-bad_empty>
       Error:
       ! `given` must be a single <numeric (non-empty)>.
       x `given` has no values.

--- a/tests/testthat/_snaps/to_df.md
+++ b/tests/testthat/_snaps/to_df.md
@@ -1,16 +1,19 @@
 # to_df() respects allow_null (#201)
 
     Code
-      to_df(NULL, allow_null = FALSE)
-    Condition
+      (expect_pkg_error_classes(to_df(NULL, allow_null = FALSE), "stbl", "bad_null"))
+    Output
+      <error/stbl-error-bad_null>
       Error:
       ! `NULL` must not be <NULL>.
 
 ---
 
     Code
-      wrapped_to_df(NULL, allow_null = FALSE)
-    Condition
+      (expect_pkg_error_classes(wrapped_to_df(NULL, allow_null = FALSE), "stbl",
+      "bad_null"))
+    Output
+      <error/stbl-error-bad_null>
       Error in `wrapped_to_df()`:
       ! `val` must not be <NULL>.
 
@@ -37,8 +40,9 @@
 # to_df() errors for a list with incompatible column lengths (#201)
 
     Code
-      to_df(list(a = 1:3, b = 1:2))
-    Condition
+      (expect_pkg_error_classes(to_df(list(a = 1:3, b = 1:2)), "stbl", "jagged"))
+    Output
+      <error/stbl-error-jagged>
       Error:
       ! Can't coerce `list(a = 1:3, b = 1:2)` <list> to <data.frame>.
       i All list elements must have length 3 or 1.
@@ -47,8 +51,10 @@
 ---
 
     Code
-      wrapped_to_df(list(a = 1:3, b = 1:2))
-    Condition
+      (expect_pkg_error_classes(wrapped_to_df(list(a = 1:3, b = 1:2)), "stbl",
+      "jagged"))
+    Output
+      <error/stbl-error-jagged>
       Error in `wrapped_to_df()`:
       ! Can't coerce `val` <list> to <data.frame>.
       i All list elements must have length 3 or 1.
@@ -57,24 +63,29 @@
 # to_df() errors for an unnamed list (#203)
 
     Code
-      to_df(list(1, 2))
-    Condition
+      (expect_pkg_error_classes(to_df(list(1, 2)), "stbl", "bad_named"))
+    Output
+      <error/stbl-error-bad_named>
       Error:
       ! `list(1, 2)` must have all elements named.
 
 # to_df() errors for non-coercible types (#201)
 
     Code
-      to_df("not a data frame")
-    Condition
+      (expect_pkg_error_classes(to_df("not a data frame"), "stbl", "coerce",
+      "data.frame"))
+    Output
+      <error/stbl-error-coerce-data.frame>
       Error:
       ! Can't coerce `"not a data frame"` <character> to <data.frame>.
 
 # to_df.default() errors for non-coercible types (#201)
 
     Code
-      to_df(as.Date("2024-01-01"))
-    Condition
+      (expect_pkg_error_classes(to_df(as.Date("2024-01-01")), "stbl", "coerce",
+      "data.frame"))
+    Output
+      <error/stbl-error-coerce-data.frame>
       Error:
       ! Can't coerce `as.Date("2024-01-01")` <Date> to <data.frame>.
 

--- a/tests/testthat/_snaps/to_fct.md
+++ b/tests/testthat/_snaps/to_fct.md
@@ -1,8 +1,10 @@
 # to_fct() throws errors for bad levels (#62, #67, #177)
 
     Code
-      to_fct(letters[1:5], levels = c("a", "c"), to_na = "b")
-    Condition
+      (expect_pkg_error_classes(to_fct(letters[1:5], levels = c("a", "c"), to_na = "b"),
+      "stbl", "fct_levels"))
+    Output
+      <error/stbl-error-fct_levels>
       Error:
       ! Each value of `letters[1:5]` must be in the expected levels.
       i Allowed levels: "a" and "c".
@@ -12,8 +14,10 @@
 ---
 
     Code
-      wrapped_to_fct(letters[1:5], levels = c("a", "c"), to_na = "b")
-    Condition
+      (expect_pkg_error_classes(wrapped_to_fct(letters[1:5], levels = c("a", "c"),
+      to_na = "b"), "stbl", "fct_levels"))
+    Output
+      <error/stbl-error-fct_levels>
       Error in `wrapped_to_fct()`:
       ! Each value of `val` must be in the expected levels.
       i Allowed levels: "a" and "c".
@@ -23,16 +27,20 @@
 # to_fct() respects allow_null (#62)
 
     Code
-      to_fct(given, allow_null = FALSE)
-    Condition
+      (expect_pkg_error_classes(to_fct(given, allow_null = FALSE), "stbl", "bad_null")
+      )
+    Output
+      <error/stbl-error-bad_null>
       Error:
       ! `given` must not be <NULL>.
 
 ---
 
     Code
-      wrapped_to_fct(given, allow_null = FALSE)
-    Condition
+      (expect_pkg_error_classes(wrapped_to_fct(given, allow_null = FALSE), "stbl",
+      "bad_null"))
+    Output
+      <error/stbl-error-bad_null>
       Error in `wrapped_to_fct()`:
       ! `val` must not be <NULL>.
 
@@ -50,32 +58,36 @@
 # to_fct() errors for things that can't be coerced (#62, #273)
 
     Code
-      to_fct(given)
-    Condition
+      (expect_pkg_error_classes(to_fct(given), "stbl", "coerce", "factor"))
+    Output
+      <error/stbl-error-coerce-factor>
       Error:
       ! Can't coerce `given` <function> to <factor>.
 
 ---
 
     Code
-      wrapped_to_fct(given)
-    Condition
+      (expect_pkg_error_classes(wrapped_to_fct(given), "stbl", "coerce", "factor"))
+    Output
+      <error/stbl-error-coerce-factor>
       Error in `wrapped_to_fct()`:
       ! Can't coerce `val` <function> to <factor>.
 
 ---
 
     Code
-      to_fct(given)
-    Condition
+      (expect_pkg_error_classes(to_fct(given), "stbl", "coerce", "factor"))
+    Output
+      <error/stbl-error-coerce-factor>
       Error:
       ! Can't coerce `given` <data.frame> to <factor>.
 
 ---
 
     Code
-      wrapped_to_fct(given)
-    Condition
+      (expect_pkg_error_classes(wrapped_to_fct(given), "stbl", "coerce", "factor"))
+    Output
+      <error/stbl-error-coerce-factor>
       Error in `wrapped_to_fct()`:
       ! Can't coerce `val` <data.frame> to <factor>.
 
@@ -104,8 +116,9 @@
 # to_fct_scalar() provides informative error messages (#62)
 
     Code
-      to_fct_scalar(given)
-    Condition
+      (expect_pkg_error_classes(to_fct_scalar(given), "stbl", "non_scalar"))
+    Output
+      <error/stbl-error-non_scalar>
       Error:
       ! `given` must be a single <factor>.
       x `given` has 26 values.
@@ -113,8 +126,9 @@
 ---
 
     Code
-      wrapped_to_fct_scalar(given)
-    Condition
+      (expect_pkg_error_classes(wrapped_to_fct_scalar(given), "stbl", "non_scalar"))
+    Output
+      <error/stbl-error-non_scalar>
       Error in `wrapped_to_fct_scalar()`:
       ! `val` must be a single <factor>.
       x `val` has 26 values.
@@ -122,8 +136,9 @@
 # to_fct_scalar respects allow_zero_length (#62, #43, #45, #189)
 
     Code
-      to_fct_scalar(given)
-    Condition
+      (expect_pkg_error_classes(to_fct_scalar(given), "stbl", "bad_empty"))
+    Output
+      <error/stbl-error-bad_empty>
       Error:
       ! `given` must be a single <factor (non-empty)>.
       x `given` has no values.
@@ -131,8 +146,10 @@
 # to_fct() errors for ints with unexpected levels (#241)
 
     Code
-      to_fct(given, levels = c("1", "2"))
-    Condition
+      (expect_pkg_error_classes(to_fct(given, levels = c("1", "2")), "stbl",
+      "fct_levels"))
+    Output
+      <error/stbl-error-fct_levels>
       Error:
       ! Each value of `<chr>` must be in the expected levels.
       i Allowed levels: "1" and "2".
@@ -141,8 +158,10 @@
 ---
 
     Code
-      wrapped_to_fct(given, levels = c("1", "2"))
-    Condition
+      (expect_pkg_error_classes(wrapped_to_fct(given, levels = c("1", "2")), "stbl",
+      "fct_levels"))
+    Output
+      <error/stbl-error-fct_levels>
       Error in `wrapped_to_fct()`:
       ! Each value of `<chr>` must be in the expected levels.
       i Allowed levels: "1" and "2".

--- a/tests/testthat/_snaps/to_int.md
+++ b/tests/testthat/_snaps/to_int.md
@@ -1,24 +1,29 @@
 # to_int() respects allow_null (#2)
 
     Code
-      to_int(given, allow_null = FALSE)
-    Condition
+      (expect_pkg_error_classes(to_int(given, allow_null = FALSE), "stbl", "bad_null")
+      )
+    Output
+      <error/stbl-error-bad_null>
       Error:
       ! `given` must not be <NULL>.
 
 ---
 
     Code
-      wrapped_to_int(given, allow_null = FALSE)
-    Condition
+      (expect_pkg_error_classes(wrapped_to_int(given, allow_null = FALSE), "stbl",
+      "bad_null"))
+    Output
+      <error/stbl-error-bad_null>
       Error in `wrapped_to_int()`:
       ! `val` must not be <NULL>.
 
 # to_int() errors for dbls that would lose precision (#2, #217)
 
     Code
-      to_int(given)
-    Condition
+      (expect_pkg_error_classes(to_int(given), "stbl", "incompatible_type"))
+    Output
+      <error/stbl-error-incompatible_type>
       Error:
       ! `given` <double> must be coercible to <integer>
       x Can't convert some values due to loss of precision.
@@ -27,8 +32,9 @@
 ---
 
     Code
-      wrapped_to_int(given)
-    Condition
+      (expect_pkg_error_classes(wrapped_to_int(given), "stbl", "incompatible_type"))
+    Output
+      <error/stbl-error-incompatible_type>
       Error in `wrapped_to_int()`:
       ! `val` <double> must be coercible to <integer>
       x Can't convert some values due to loss of precision.
@@ -37,8 +43,9 @@
 ---
 
     Code
-      to_int(given)
-    Condition
+      (expect_pkg_error_classes(to_int(given), "stbl", "incompatible_type"))
+    Output
+      <error/stbl-error-incompatible_type>
       Error:
       ! `given` <double> must be coercible to <integer>
       x Can't convert some values due to loss of precision.
@@ -47,8 +54,9 @@
 ---
 
     Code
-      wrapped_to_int(given)
-    Condition
+      (expect_pkg_error_classes(wrapped_to_int(given), "stbl", "incompatible_type"))
+    Output
+      <error/stbl-error-incompatible_type>
       Error in `wrapped_to_int()`:
       ! `val` <double> must be coercible to <integer>
       x Can't convert some values due to loss of precision.
@@ -57,24 +65,29 @@
 # to_int() respects coerce_character (#14)
 
     Code
-      to_int(given, coerce_character = FALSE)
-    Condition
+      (expect_pkg_error_classes(to_int(given, coerce_character = FALSE), "stbl",
+      "coerce", "integer"))
+    Output
+      <error/stbl-error-coerce-integer>
       Error:
       ! Can't coerce `given` <character> to <integer>.
 
 ---
 
     Code
-      wrapped_to_int(given, coerce_character = FALSE)
-    Condition
+      (expect_pkg_error_classes(wrapped_to_int(given, coerce_character = FALSE),
+      "stbl", "coerce", "integer"))
+    Output
+      <error/stbl-error-coerce-integer>
       Error in `wrapped_to_int()`:
       ! Can't coerce `val` <character> to <integer>.
 
 # to_int() errors informatively for bad chrs (#2)
 
     Code
-      to_int(given)
-    Condition
+      (expect_pkg_error_classes(to_int(given), "stbl", "incompatible_type"))
+    Output
+      <error/stbl-error-incompatible_type>
       Error:
       ! `given` <character> must be coercible to <integer>
       x Can't convert some values due to loss of precision.
@@ -83,8 +96,9 @@
 ---
 
     Code
-      wrapped_to_int(given)
-    Condition
+      (expect_pkg_error_classes(wrapped_to_int(given), "stbl", "incompatible_type"))
+    Output
+      <error/stbl-error-incompatible_type>
       Error in `wrapped_to_int()`:
       ! `val` <character> must be coercible to <integer>
       x Can't convert some values due to loss of precision.
@@ -93,8 +107,9 @@
 ---
 
     Code
-      to_int(given)
-    Condition
+      (expect_pkg_error_classes(to_int(given), "stbl", "incompatible_type"))
+    Output
+      <error/stbl-error-incompatible_type>
       Error:
       ! `given` <character> must be coercible to <integer>
       x Can't convert some values due to incompatible values.
@@ -103,8 +118,9 @@
 ---
 
     Code
-      wrapped_to_int(given)
-    Condition
+      (expect_pkg_error_classes(wrapped_to_int(given), "stbl", "incompatible_type"))
+    Output
+      <error/stbl-error-incompatible_type>
       Error in `wrapped_to_int()`:
       ! `val` <character> must be coercible to <integer>
       x Can't convert some values due to incompatible values.
@@ -113,8 +129,9 @@
 # to_int() errors informatively for bad complexes (#2)
 
     Code
-      to_int(given)
-    Condition
+      (expect_pkg_error_classes(to_int(given), "stbl", "incompatible_type"))
+    Output
+      <error/stbl-error-incompatible_type>
       Error:
       ! `given` <complex> must be coercible to <integer>
       x Can't convert some values due to non-zero complex components.
@@ -123,8 +140,9 @@
 ---
 
     Code
-      wrapped_to_int(given)
-    Condition
+      (expect_pkg_error_classes(wrapped_to_int(given), "stbl", "incompatible_type"))
+    Output
+      <error/stbl-error-incompatible_type>
       Error in `wrapped_to_int()`:
       ! `val` <complex> must be coercible to <integer>
       x Can't convert some values due to non-zero complex components.
@@ -133,8 +151,9 @@
 # to_int() errors for complexes that would lose precision (#noissue)
 
     Code
-      to_int(given)
-    Condition
+      (expect_pkg_error_classes(to_int(given), "stbl", "incompatible_type"))
+    Output
+      <error/stbl-error-incompatible_type>
       Error:
       ! `given` <complex> must be coercible to <integer>
       x Can't convert some values due to loss of precision.
@@ -143,8 +162,9 @@
 ---
 
     Code
-      wrapped_to_int(given)
-    Condition
+      (expect_pkg_error_classes(wrapped_to_int(given), "stbl", "incompatible_type"))
+    Output
+      <error/stbl-error-incompatible_type>
       Error in `wrapped_to_int()`:
       ! `val` <complex> must be coercible to <integer>
       x Can't convert some values due to loss of precision.
@@ -153,8 +173,9 @@
 ---
 
     Code
-      to_int(given)
-    Condition
+      (expect_pkg_error_classes(to_int(given), "stbl", "incompatible_type"))
+    Output
+      <error/stbl-error-incompatible_type>
       Error:
       ! `given` <complex> must be coercible to <integer>
       x Can't convert some values due to loss of precision.
@@ -163,8 +184,9 @@
 ---
 
     Code
-      wrapped_to_int(given)
-    Condition
+      (expect_pkg_error_classes(wrapped_to_int(given), "stbl", "incompatible_type"))
+    Output
+      <error/stbl-error-incompatible_type>
       Error in `wrapped_to_int()`:
       ! `val` <complex> must be coercible to <integer>
       x Can't convert some values due to loss of precision.
@@ -173,24 +195,29 @@
 # to_int() respects coerce_factor (#14)
 
     Code
-      to_int(given, coerce_factor = FALSE)
-    Condition
+      (expect_pkg_error_classes(to_int(given, coerce_factor = FALSE), "stbl",
+      "coerce", "integer"))
+    Output
+      <error/stbl-error-coerce-integer>
       Error:
       ! Can't coerce `given` <factor> to <integer>.
 
 ---
 
     Code
-      wrapped_to_int(given, coerce_factor = FALSE)
-    Condition
+      (expect_pkg_error_classes(wrapped_to_int(given, coerce_factor = FALSE), "stbl",
+      "coerce", "integer"))
+    Output
+      <error/stbl-error-coerce-integer>
       Error in `wrapped_to_int()`:
       ! Can't coerce `val` <factor> to <integer>.
 
 # to_int() errors informatively for bad factors (#4)
 
     Code
-      to_int(given)
-    Condition
+      (expect_pkg_error_classes(to_int(given), "stbl", "incompatible_type"))
+    Output
+      <error/stbl-error-incompatible_type>
       Error:
       ! `given` <factor> must be coercible to <integer>
       x Can't convert some values due to incompatible values.
@@ -199,8 +226,9 @@
 ---
 
     Code
-      wrapped_to_int(given)
-    Condition
+      (expect_pkg_error_classes(wrapped_to_int(given), "stbl", "incompatible_type"))
+    Output
+      <error/stbl-error-incompatible_type>
       Error in `wrapped_to_int()`:
       ! `val` <factor> must be coercible to <integer>
       x Can't convert some values due to incompatible values.
@@ -220,8 +248,9 @@
 # to_int_scalar() provides informative error messages (#12)
 
     Code
-      to_int_scalar(given)
-    Condition
+      (expect_pkg_error_classes(to_int_scalar(given), "stbl", "non_scalar"))
+    Output
+      <error/stbl-error-non_scalar>
       Error:
       ! `given` must be a single <integer>.
       x `given` has 10 values.
@@ -229,8 +258,9 @@
 ---
 
     Code
-      wrapped_to_int_scalar(given)
-    Condition
+      (expect_pkg_error_classes(wrapped_to_int_scalar(given), "stbl", "non_scalar"))
+    Output
+      <error/stbl-error-non_scalar>
       Error in `wrapped_to_int_scalar()`:
       ! `val` must be a single <integer>.
       x `val` has 10 values.
@@ -238,24 +268,27 @@
 # to_int_scalar() respects allow_null (#12, #189)
 
     Code
-      to_int_scalar(given)
-    Condition
+      (expect_pkg_error_classes(to_int_scalar(given), "stbl", "bad_null"))
+    Output
+      <error/stbl-error-bad_null>
       Error:
       ! `given` must not be <NULL>.
 
 ---
 
     Code
-      wrapped_to_int_scalar(given)
-    Condition
+      (expect_pkg_error_classes(wrapped_to_int_scalar(given), "stbl", "bad_null"))
+    Output
+      <error/stbl-error-bad_null>
       Error in `wrapped_to_int_scalar()`:
       ! `val` must not be <NULL>.
 
 # to_int_scalar respects allow_zero_length (#12, #43, #45, #189)
 
     Code
-      to_int_scalar(given)
-    Condition
+      (expect_pkg_error_classes(to_int_scalar(given), "stbl", "bad_empty"))
+    Output
+      <error/stbl-error-bad_empty>
       Error:
       ! `given` must be a single <integer (non-empty)>.
       x `given` has no values.

--- a/tests/testthat/_snaps/to_lgl.md
+++ b/tests/testthat/_snaps/to_lgl.md
@@ -1,24 +1,29 @@
 # to_lgl() respects allow_null (#21)
 
     Code
-      to_lgl(given, allow_null = FALSE)
-    Condition
+      (expect_pkg_error_classes(to_lgl(given, allow_null = FALSE), "stbl", "bad_null")
+      )
+    Output
+      <error/stbl-error-bad_null>
       Error:
       ! `given` must not be <NULL>.
 
 ---
 
     Code
-      wrapped_to_lgl(given, allow_null = FALSE)
-    Condition
+      (expect_pkg_error_classes(wrapped_to_lgl(given, allow_null = FALSE), "stbl",
+      "bad_null"))
+    Output
+      <error/stbl-error-bad_null>
       Error in `wrapped_to_lgl()`:
       ! `val` must not be <NULL>.
 
 # to_lgl() errors for bad characters (#21)
 
     Code
-      to_lgl(letters)
-    Condition
+      (expect_pkg_error_classes(to_lgl(letters), "stbl", "incompatible_type"))
+    Output
+      <error/stbl-error-incompatible_type>
       Error:
       ! `letters` <character> must be coercible to <logical>
       x Can't convert some values due to incompatible values.
@@ -27,8 +32,9 @@
 ---
 
     Code
-      wrapped_to_lgl(letters)
-    Condition
+      (expect_pkg_error_classes(wrapped_to_lgl(letters), "stbl", "incompatible_type"))
+    Output
+      <error/stbl-error-incompatible_type>
       Error in `wrapped_to_lgl()`:
       ! `val` <character> must be coercible to <logical>
       x Can't convert some values due to incompatible values.
@@ -37,8 +43,9 @@
 # to_lgl errors for bad factors (#21)
 
     Code
-      to_lgl(given)
-    Condition
+      (expect_pkg_error_classes(to_lgl(given), "stbl", "incompatible_type"))
+    Output
+      <error/stbl-error-incompatible_type>
       Error:
       ! `given` <factor> must be coercible to <logical>
       x Can't convert some values due to incompatible values.
@@ -47,8 +54,9 @@
 ---
 
     Code
-      wrapped_to_lgl(given)
-    Condition
+      (expect_pkg_error_classes(wrapped_to_lgl(given), "stbl", "incompatible_type"))
+    Output
+      <error/stbl-error-incompatible_type>
       Error in `wrapped_to_lgl()`:
       ! `val` <factor> must be coercible to <logical>
       x Can't convert some values due to incompatible values.
@@ -90,24 +98,27 @@
 ---
 
     Code
-      to_lgl(given)
-    Condition
+      (expect_pkg_error_classes(to_lgl(given), "stbl", "coerce", "logical"))
+    Output
+      <error/stbl-error-coerce-logical>
       Error:
       ! Can't coerce `given` <function> to <logical>.
 
 ---
 
     Code
-      wrapped_to_lgl(given)
-    Condition
+      (expect_pkg_error_classes(wrapped_to_lgl(given), "stbl", "coerce", "logical"))
+    Output
+      <error/stbl-error-coerce-logical>
       Error in `wrapped_to_lgl()`:
       ! Can't coerce `val` <function> to <logical>.
 
 # to_lgl_scalar() errors for non-scalars (#32)
 
     Code
-      to_lgl_scalar(given)
-    Condition
+      (expect_pkg_error_classes(to_lgl_scalar(given), "stbl", "non_scalar"))
+    Output
+      <error/stbl-error-non_scalar>
       Error:
       ! `given` must be a single <logical>.
       x `given` has 3 values.
@@ -115,8 +126,9 @@
 ---
 
     Code
-      wrapped_to_lgl_scalar(given)
-    Condition
+      (expect_pkg_error_classes(wrapped_to_lgl_scalar(given), "stbl", "non_scalar"))
+    Output
+      <error/stbl-error-non_scalar>
       Error in `wrapped_to_lgl_scalar()`:
       ! `val` must be a single <logical>.
       x `val` has 3 values.
@@ -124,8 +136,9 @@
 # to_lgl_scalar() errors for bad characters (#32)
 
     Code
-      to_lgl_scalar(given)
-    Condition
+      (expect_pkg_error_classes(to_lgl_scalar(given), "stbl", "incompatible_type"))
+    Output
+      <error/stbl-error-incompatible_type>
       Error:
       ! `given` <character> must be coercible to <logical>
       x Can't convert some values due to incompatible values.
@@ -134,8 +147,10 @@
 ---
 
     Code
-      wrapped_to_lgl_scalar(given)
-    Condition
+      (expect_pkg_error_classes(wrapped_to_lgl_scalar(given), "stbl",
+      "incompatible_type"))
+    Output
+      <error/stbl-error-incompatible_type>
       Error in `wrapped_to_lgl_scalar()`:
       ! `val` <character> must be coercible to <logical>
       x Can't convert some values due to incompatible values.
@@ -144,16 +159,18 @@
 # to_lgl_scalar() respects allow_null (#32, #189)
 
     Code
-      to_lgl_scalar(given)
-    Condition
+      (expect_pkg_error_classes(to_lgl_scalar(given), "stbl", "bad_null"))
+    Output
+      <error/stbl-error-bad_null>
       Error:
       ! `given` must not be <NULL>.
 
 ---
 
     Code
-      wrapped_to_lgl_scalar(given)
-    Condition
+      (expect_pkg_error_classes(wrapped_to_lgl_scalar(given), "stbl", "bad_null"))
+    Output
+      <error/stbl-error-bad_null>
       Error in `wrapped_to_lgl_scalar()`:
       ! `val` must not be <NULL>.
 

--- a/tests/testthat/_snaps/to_lst.md
+++ b/tests/testthat/_snaps/to_lst.md
@@ -1,16 +1,20 @@
 # to_lst() respects allow_null (#157)
 
     Code
-      to_lst(given, allow_null = FALSE)
-    Condition
+      (expect_pkg_error_classes(to_lst(given, allow_null = FALSE), "stbl", "bad_null")
+      )
+    Output
+      <error/stbl-error-bad_null>
       Error:
       ! `given` must not be <NULL>.
 
 ---
 
     Code
-      wrapped_to_lst(given, allow_null = FALSE)
-    Condition
+      (expect_pkg_error_classes(wrapped_to_lst(given, allow_null = FALSE), "stbl",
+      "bad_null"))
+    Output
+      <error/stbl-error-bad_null>
       Error in `wrapped_to_lst()`:
       ! `val` must not be <NULL>.
 
@@ -37,32 +41,38 @@
 # to_lst() errors by default for functions (#157)
 
     Code
-      to_lst(given)
-    Condition
+      (expect_pkg_error_classes(to_lst(given), "stbl", "bad_function"))
+    Output
+      <error/stbl-error-bad_function>
       Error:
       ! `given` must not be a <function>.
 
 ---
 
     Code
-      wrapped_to_lst(given)
-    Condition
+      (expect_pkg_error_classes(wrapped_to_lst(given), "stbl", "bad_function"))
+    Output
+      <error/stbl-error-bad_function>
       Error in `wrapped_to_lst()`:
       ! `val` must not be a <function>.
 
 # to_lst() errors informatively for primitives (#157)
 
     Code
-      to_lst(given, coerce_function = TRUE)
-    Condition
+      (expect_pkg_error_classes(to_lst(given, coerce_function = TRUE), "stbl",
+      "coerce", "list"))
+    Output
+      <error/stbl-error-coerce-list>
       Error:
       ! Can't coerce `given` <primitive function> to <list>.
 
 ---
 
     Code
-      wrapped_to_lst(given, coerce_function = TRUE)
-    Condition
+      (expect_pkg_error_classes(wrapped_to_lst(given, coerce_function = TRUE), "stbl",
+      "coerce", "list"))
+    Output
+      <error/stbl-error-coerce-list>
       Error in `wrapped_to_lst()`:
       ! Can't coerce `val` <primitive function> to <list>.
 

--- a/tests/testthat/_snaps/to_null.md
+++ b/tests/testthat/_snaps/to_null.md
@@ -1,32 +1,40 @@
 # .to_null() errors when NULL isn't allowed (#129)
 
     Code
-      .to_null(given, allow_null = FALSE)
-    Condition
+      (expect_pkg_error_classes(.to_null(given, allow_null = FALSE), "stbl",
+      "bad_null"))
+    Output
+      <error/stbl-error-bad_null>
       Error:
       ! `given` must not be <NULL>.
 
 ---
 
     Code
-      wrapped_to_null(given, allow_null = FALSE)
-    Condition
+      (expect_pkg_error_classes(wrapped_to_null(given, allow_null = FALSE), "stbl",
+      "bad_null"))
+    Output
+      <error/stbl-error-bad_null>
       Error in `wrapped_to_null()`:
       ! `val` must not be <NULL>.
 
 # .to_null() errors for bad allow_null (#129)
 
     Code
-      .to_null(NULL, allow_null = NULL)
-    Condition
+      (expect_pkg_error_classes(.to_null(NULL, allow_null = NULL), "stbl", "bad_null")
+      )
+    Output
+      <error/stbl-error-bad_null>
       Error:
       ! `allow_null` must not be <NULL>.
 
 ---
 
     Code
-      .to_null(NULL, allow_null = "fish")
-    Condition
+      (expect_pkg_error_classes(.to_null(NULL, allow_null = "fish"), "stbl",
+      "incompatible_type"))
+    Output
+      <error/stbl-error-incompatible_type>
       Error:
       ! `allow_null` <character> must be coercible to <logical>
       x Can't convert some values due to incompatible values.
@@ -35,8 +43,10 @@
 ---
 
     Code
-      wrapped_to_null(NULL, allow_null = "fish")
-    Condition
+      (expect_pkg_error_classes(wrapped_to_null(NULL, allow_null = "fish"), "stbl",
+      "incompatible_type"))
+    Output
+      <error/stbl-error-incompatible_type>
       Error in `wrapped_to_null()`:
       ! `allow_null` <character> must be coercible to <logical>
       x Can't convert some values due to incompatible values.
@@ -45,8 +55,9 @@
 # .to_null() errors informatively for missing value (#129)
 
     Code
-      .to_null()
-    Condition
+      (expect_pkg_error_classes(.to_null(), "stbl", "must"))
+    Output
+      <error/stbl-error-must>
       Error:
       ! `unknown arg` must not be missing.
 

--- a/tests/testthat/test-aaa-conditions.R
+++ b/tests/testthat/test-aaa-conditions.R
@@ -1,12 +1,8 @@
 test_that(".stbl_abort() throws the expected error (#95)", {
-  expect_pkg_error_classes(
+  expect_pkg_error_snapshot(
     .stbl_abort("A message.", "a_subclass"),
     "stbl",
     "a_subclass"
-  )
-  expect_snapshot(
-    .stbl_abort("A message.", "a_subclass"),
-    error = TRUE
   )
 })
 
@@ -33,15 +29,11 @@ test_that(".stbl_inform() throws the expected message (#213)", {
 })
 
 test_that(".stop_cant_coerce() throws the expected error (#95)", {
-  expect_pkg_error_classes(
+  expect_pkg_error_snapshot(
     .stop_cant_coerce("character", "integer", "my_arg", rlang::current_env()),
     "stbl",
     "coerce",
     "integer"
-  )
-  expect_snapshot(
-    .stop_cant_coerce("character", "integer", "my_arg", rlang::current_env()),
-    error = TRUE
   )
 })
 
@@ -59,19 +51,15 @@ test_that(".stop_cant_coerce() uses additional_msg when provided (#95)", {
 })
 
 test_that(".stop_must() throws the expected error (#95)", {
-  expect_pkg_error_classes(
+  expect_pkg_error_snapshot(
     .stop_must("must be a foo.", "my_arg", rlang::current_env()),
     "stbl",
     "must"
   )
-  expect_snapshot(
-    .stop_must("must be a foo.", "my_arg", rlang::current_env()),
-    error = TRUE
-  )
 })
 
 test_that(".stop_must() handles subclasses (#95)", {
-  expect_pkg_error_classes(
+  expect_pkg_error_snapshot(
     .stop_must(
       "must be a foo.",
       "my_arg",
@@ -80,15 +68,6 @@ test_that(".stop_must() handles subclasses (#95)", {
     ),
     "stbl",
     "my_custom_class"
-  )
-  expect_snapshot(
-    .stop_must(
-      "must be a foo.",
-      "my_arg",
-      rlang::current_env(),
-      subclass = "my_custom_class"
-    ),
-    error = TRUE
   )
 })
 
@@ -112,14 +91,10 @@ test_that(".define_main_msg() works (#95)", {
 })
 
 test_that(".stop_null() throws the expected error (#95)", {
-  expect_pkg_error_classes(
+  expect_pkg_error_snapshot(
     .stop_null("my_arg", rlang::current_env()),
     "stbl",
     "bad_null"
-  )
-  expect_snapshot(
-    .stop_null("my_arg", rlang::current_env()),
-    error = TRUE
   )
 })
 
@@ -134,7 +109,7 @@ test_that(".stop_null() passes dots (#95)", {
 })
 
 test_that(".stop_incompatible() throws the expected error (#95)", {
-  expect_pkg_error_classes(
+  expect_pkg_error_snapshot(
     .stop_incompatible(
       "character",
       integer(),
@@ -145,22 +120,11 @@ test_that(".stop_incompatible() throws the expected error (#95)", {
     ),
     "stbl",
     "incompatible_type"
-  )
-  expect_snapshot(
-    .stop_incompatible(
-      "character",
-      integer(),
-      c(FALSE, TRUE, FALSE, TRUE),
-      "some reason",
-      "my_arg",
-      rlang::current_env()
-    ),
-    error = TRUE
   )
 })
 
 test_that(".stop_incompatible() passes dots (#95)", {
-  expect_pkg_error_classes(
+  expect_pkg_error_snapshot(
     .stop_incompatible(
       "character",
       integer(),
@@ -172,17 +136,5 @@ test_that(".stop_incompatible() passes dots (#95)", {
     ),
     "stbl",
     "incompatible_type"
-  )
-  expect_snapshot(
-    .stop_incompatible(
-      "character",
-      integer(),
-      c(FALSE, TRUE, FALSE, TRUE),
-      "some reason",
-      "my_arg",
-      rlang::current_env(),
-      .internal = TRUE
-    ),
-    error = TRUE
   )
 })

--- a/tests/testthat/test-pkg_abort.R
+++ b/tests/testthat/test-pkg_abort.R
@@ -64,14 +64,10 @@ test_that("pkg_abort() passes dots to cli_abort() (#136)", {
   wrapped_abort <- function(message, subclass, ...) {
     pkg_abort("wrapped", message, subclass, ...)
   }
-  expect_pkg_error_classes(
+  expect_pkg_error_snapshot(
     wrapped_abort("A message.", "a_subclass", .internal = TRUE),
     "wrapped",
-    "a_subclass"
-  )
-  expect_snapshot(
-    wrapped_abort("A message.", "a_subclass", .internal = TRUE),
-    error = TRUE,
+    "a_subclass",
     transform = function(x) {
       stringr::str_replace(
         x,

--- a/tests/testthat/test-specify_cls.R
+++ b/tests/testthat/test-specify_cls.R
@@ -38,18 +38,12 @@ test_that("specify_cls builds the expected function snapshot with at least one a
 
 test_that("The function built via specify_cls errors informatively for duplicated args (#150, #153, #161)", {
   no_null <- specify_cls("chr", list(allow_null = FALSE))
-  expect_pkg_error_classes(
+  expect_pkg_error_snapshot(
     {
       no_null(NULL, allow_null = FALSE)
     },
     "stbl",
     "duplicate_args"
-  )
-  expect_snapshot(
-    {
-      no_null(NULL, allow_null = FALSE)
-    },
-    error = TRUE
   )
 })
 

--- a/tests/testthat/test-stabilize_arg.R
+++ b/tests/testthat/test-stabilize_arg.R
@@ -22,18 +22,15 @@ test_that("stabilize_arg() complains about weird args (#11, #58, #99)", {
 
 test_that("stabilize_arg() rejects NULLs when asked (#11, #58, #99)", {
   given <- NULL
-  expect_pkg_error_classes(
+  expect_pkg_error_snapshot(
     stabilize_arg(given, allow_null = FALSE),
     "stbl",
     "bad_null"
   )
-  expect_snapshot(
-    stabilize_arg(given, allow_null = FALSE),
-    error = TRUE
-  )
-  expect_snapshot(
+  expect_pkg_error_snapshot(
     wrapped_stabilize_arg(given, allow_null = FALSE),
-    error = TRUE
+    "stbl",
+    "bad_null"
   )
 })
 
@@ -42,18 +39,15 @@ test_that("stabilize_arg() checks NAs (#11, #58, #99)", {
   expect_identical(stabilize_arg(given, allow_na = FALSE), given)
 
   given[c(4, 7)] <- NA
-  expect_pkg_error_classes(
+  expect_pkg_error_snapshot(
     stabilize_arg(given, allow_na = FALSE),
     "stbl",
     "bad_na"
   )
-  expect_snapshot(
-    stabilize_arg(given, allow_na = FALSE),
-    error = TRUE
-  )
-  expect_snapshot(
+  expect_pkg_error_snapshot(
     wrapped_stabilize_arg(given, allow_na = FALSE),
-    error = TRUE
+    "stbl",
+    "bad_na"
   )
 })
 
@@ -61,18 +55,15 @@ test_that("stabilize_arg() checks size args (#11, #58, #99)", {
   given <- TRUE
   expect_true(stabilize_arg(given, min_size = 1, max_size = 1))
 
-  expect_pkg_error_classes(
+  expect_pkg_error_snapshot(
     stabilize_arg(given, min_size = 2, max_size = 1),
     "stbl",
     "size_x_vs_y"
   )
-  expect_snapshot(
-    stabilize_arg(given, min_size = 2, max_size = 1),
-    error = TRUE
-  )
-  expect_snapshot(
+  expect_pkg_error_snapshot(
     wrapped_stabilize_arg(given, min_size = 2, max_size = 1),
-    error = TRUE
+    "stbl",
+    "size_x_vs_y"
   )
 })
 
@@ -83,35 +74,29 @@ test_that("stabilize_arg() checks min_size (#11, #58, #99)", {
     given
   )
 
-  expect_pkg_error_classes(
+  expect_pkg_error_snapshot(
     stabilize_arg(given, min_size = 11),
     "stbl",
     "size_too_small"
   )
-  expect_snapshot(
-    stabilize_arg(given, min_size = 11),
-    error = TRUE
-  )
-  expect_snapshot(
+  expect_pkg_error_snapshot(
     wrapped_stabilize_arg(given, min_size = 11),
-    error = TRUE
+    "stbl",
+    "size_too_small"
   )
 })
 
 test_that("stabilize_arg() checks max_size (#11, #58)", {
   given <- 1:3
-  expect_pkg_error_classes(
+  expect_pkg_error_snapshot(
     stabilize_arg(given, max_size = 2),
     "stbl",
     "size_too_large"
   )
-  expect_snapshot(
-    stabilize_arg(given, max_size = 2),
-    error = TRUE
-  )
-  expect_snapshot(
+  expect_pkg_error_snapshot(
     wrapped_stabilize_arg(given, max_size = 2),
-    error = TRUE
+    "stbl",
+    "size_too_large"
   )
 })
 
@@ -123,43 +108,33 @@ test_that("stabilize_arg_scalar() allows length-1 args through (#12)", {
 
 test_that("stabilize_arg_scalar() errors for non-scalars (#12, #58)", {
   given <- 1:10
-  expect_pkg_error_classes(stabilize_arg_scalar(given), "stbl", "non_scalar")
-  expect_snapshot(
-    stabilize_arg_scalar(given),
-    error = TRUE
-  )
-  expect_snapshot(
+  expect_pkg_error_snapshot(stabilize_arg_scalar(given), "stbl", "non_scalar")
+  expect_pkg_error_snapshot(
     wrapped_stabilize_arg_scalar(given),
-    error = TRUE
+    "stbl",
+    "non_scalar"
   )
 })
 
 test_that("stabilize_arg_scalar() respects allow_null (#12, #58)", {
   given <- NULL
-  expect_pkg_error_classes(
+  expect_pkg_error_snapshot(
     stabilize_arg_scalar(given, allow_null = FALSE),
     "stbl",
     "non_scalar"
   )
-  expect_snapshot(
-    stabilize_arg_scalar(given, allow_null = FALSE),
-    error = TRUE
-  )
-  expect_snapshot(
+  expect_pkg_error_snapshot(
     wrapped_stabilize_arg_scalar(given, allow_null = FALSE),
-    error = TRUE
+    "stbl",
+    "non_scalar"
   )
 })
 
 test_that("stabilize_arg_scalar() errors on weird internal arg values (#12, #58)", {
   given <- NULL
-  expect_pkg_error_classes(
+  expect_pkg_error_snapshot(
     stabilize_arg_scalar(given, allow_null = c(TRUE, FALSE)),
     "stbl",
     "non_scalar"
-  )
-  expect_snapshot(
-    stabilize_arg_scalar(given, allow_null = c(TRUE, FALSE)),
-    error = TRUE
   )
 })

--- a/tests/testthat/test-stabilize_chr.R
+++ b/tests/testthat/test-stabilize_chr.R
@@ -15,18 +15,15 @@ test_that("stabilize_chr() works on happy path (#22, #27, #52)", {
 test_that("stabilize_chr() errors for bad regex matches (#27, #52)", {
   given <- c("123456789", "12345-6789")
   pattern <- r"(^\d{5}(?:[-\s]\d{4})?$)"
-  expect_pkg_error_classes(
+  expect_pkg_error_snapshot(
     stabilize_chr(given, regex = pattern),
     "stbl",
     "must"
   )
-  expect_snapshot(
-    stabilize_chr(given, regex = pattern),
-    error = TRUE
-  )
-  expect_snapshot(
+  expect_pkg_error_snapshot(
     wrapped_stabilize_chr(given, regex = pattern),
-    error = TRUE
+    "stbl",
+    "must"
   )
 })
 
@@ -39,52 +36,34 @@ test_that("stabilize_chr() works with complex url regex (#52)", {
       regex = url_regex
     )
   )
-  expect_pkg_error_classes(
+  expect_pkg_error_snapshot(
     stabilize_chr(
       c("example.com", "not a url"),
       regex = url_regex
     ),
     "stbl",
     "must"
-  )
-  expect_snapshot(
-    stabilize_chr(
-      c("example.com", "not a url"),
-      regex = url_regex
-    ),
-    error = TRUE
   )
 })
 
 test_that("stabilize_chr() allows for customized error messages (#52)", {
   skip_if_not_installed("stringi")
   url_regex <- r"(^(?:(?:(?:https?|ftp):)?\/\/)?(?:\S+(?::\S*)?@)?(?:(?!(?:10|127)(?:\.\d{1,3}){3})(?!(?:169\.254|192\.168)(?:\.\d{1,3}){2})(?!172\.(?:1[6-9]|2\d|3[0-1])(?:\.\d{1,3}){2})(?:[1-9]\d?|1\d\d|2[01]\d|22[0-3])(?:\.(?:1?\d{1,2}|2[0-4]\d|25[0-5])){2}(?:\.(?:[1-9]\d?|1\d\d|2[0-4]\d|25[0-4]))|(?:(?:[a-z0-9\u00a1-\uffff][a-z0-9\u00a1-\uffff_-]{0,62})?[a-z0-9\u00a1-\uffff]\.)+(?:[a-z\u00a1-\uffff]{2,}\.?))(?::\d{2,5})?(?:[/?#]\S*)?$)"
-  expect_pkg_error_classes(
+  expect_pkg_error_snapshot(
     stabilize_chr(
       c("not a url", "example.com"),
       regex = c("must be a url." = url_regex)
     ),
     "stbl",
     "must"
-  )
-  expect_snapshot(
-    stabilize_chr(
-      c("not a url", "example.com"),
-      regex = c("must be a url." = url_regex)
-    ),
-    error = TRUE
   )
 })
 
 test_that("stabilize_chr() works with regex that contains braces (#52)", {
-  expect_pkg_error_classes(
+  expect_pkg_error_snapshot(
     stabilize_chr(c("b", "aa"), regex = "a{1,3}"),
     "stbl",
     "must"
-  )
-  expect_snapshot(
-    stabilize_chr(c("b", "aa"), regex = "a{1,3}"),
-    error = TRUE
   )
 })
 
@@ -98,10 +77,10 @@ test_that("stabilize_chr() accepts negated regex args (#85)", {
   )
 
   given <- c("a", "b", "c")
-  expect_pkg_error_classes(stabilize_chr(given, regex = regex), "stbl", "must")
-  expect_snapshot(
+  expect_pkg_error_snapshot(
     stabilize_chr(given, regex = regex),
-    error = TRUE
+    "stbl",
+    "must"
   )
 })
 
@@ -116,10 +95,10 @@ test_that("stabilize_chr() accepts multiple regex rules (#86, #85)", {
     given
   )
   given <- c("apple", "banana", "boat", "plum")
-  expect_pkg_error_classes(stabilize_chr(given, regex = rules), "stbl", "must")
-  expect_snapshot(
+  expect_pkg_error_snapshot(
     stabilize_chr(given, regex = rules),
-    error = TRUE
+    "stbl",
+    "must"
   )
 })
 
@@ -129,14 +108,10 @@ test_that("stabilize_chr() works with stringr::fixed() (#87)", {
     stabilize_chr("a.b", regex = stringr::fixed("a.b")),
     "a.b"
   )
-  expect_pkg_error_classes(
+  expect_pkg_error_snapshot(
     stabilize_chr(c("a.b", "acb"), regex = stringr::fixed("a.b")),
     "stbl",
     "must"
-  )
-  expect_snapshot(
-    stabilize_chr(c("a.b", "acb"), regex = stringr::fixed("a.b")),
-    error = TRUE
   )
 })
 
@@ -146,14 +121,10 @@ test_that("stabilize_chr() works with stringr::coll() (#87)", {
     stabilize_chr("A", regex = stringr::coll("a", ignore_case = TRUE)),
     "A"
   )
-  expect_pkg_error_classes(
+  expect_pkg_error_snapshot(
     stabilize_chr(c("a", "A"), regex = stringr::coll("a")),
     "stbl",
     "must"
-  )
-  expect_snapshot(
-    stabilize_chr(c("a", "A"), regex = stringr::coll("a")),
-    error = TRUE
   )
 })
 
@@ -163,14 +134,10 @@ test_that("stabilize_chr() works with stringr::regex() (#87)", {
     stabilize_chr("A", regex = stringr::regex("a", ignore_case = TRUE)),
     "A"
   )
-  expect_pkg_error_classes(
+  expect_pkg_error_snapshot(
     stabilize_chr(c("A", "B"), regex = stringr::regex("a", ignore_case = TRUE)),
     "stbl",
     "must"
-  )
-  expect_snapshot(
-    stabilize_chr(c("A", "B"), regex = stringr::regex("a", ignore_case = TRUE)),
-    error = TRUE
   )
 })
 
@@ -202,39 +169,29 @@ test_that("stabilize_chr_scalar() allows length-1 chrs through (#22, #189)", {
 
 test_that("stabilize_chr_scalar() respects allow_null (#22, #189)", {
   given <- NULL
-  expect_pkg_error_classes(stabilize_chr_scalar(given), "stbl", "bad_null")
-  expect_snapshot(
-    stabilize_chr_scalar(given),
-    error = TRUE
-  )
-  expect_snapshot(
+  expect_pkg_error_snapshot(stabilize_chr_scalar(given), "stbl", "bad_null")
+  expect_pkg_error_snapshot(
     wrapped_stabilize_chr_scalar(given),
-    error = TRUE
+    "stbl",
+    "bad_null"
   )
 })
 
 test_that("stabilize_chr_scalar() errors for non-scalars (#22)", {
   given <- letters
-  expect_pkg_error_classes(stabilize_chr_scalar(given), "stbl", "non_scalar")
-  expect_snapshot(
-    stabilize_chr_scalar(given),
-    error = TRUE
-  )
-  expect_snapshot(
+  expect_pkg_error_snapshot(stabilize_chr_scalar(given), "stbl", "non_scalar")
+  expect_pkg_error_snapshot(
     wrapped_stabilize_chr_scalar(given),
-    error = TRUE
+    "stbl",
+    "non_scalar"
   )
 })
 
 test_that("stabilize_chr_scalar() works with regex that contains braces (#52)", {
-  expect_pkg_error_classes(
+  expect_pkg_error_snapshot(
     stabilize_chr_scalar("b", regex = "a{1,3}"),
     "stbl",
     "must"
-  )
-  expect_snapshot(
-    stabilize_chr_scalar("b", regex = "a{1,3}"),
-    error = TRUE
   )
 })
 

--- a/tests/testthat/test-stabilize_dbl.R
+++ b/tests/testthat/test-stabilize_dbl.R
@@ -4,39 +4,33 @@ test_that("stabilize_dbl() checks min_value (#23, #176)", {
     stabilize_dbl(given, min_value = 1.1, max_value = 10.1),
     given
   )
-  expect_pkg_error_classes(
+  expect_pkg_error_snapshot(
     stabilize_dbl(given, min_value = 11.1),
     "stbl",
     "outside_range"
-  )
-  expect_snapshot(
-    stabilize_dbl(given, min_value = 11.1),
-    error = TRUE
   )
   expect_snapshot(
     stabilize_dbl(given[[1]], min_value = 11.1),
     error = TRUE
   )
-  expect_snapshot(
+  expect_pkg_error_snapshot(
     wrapped_stabilize_dbl(given, min_value = 11.1),
-    error = TRUE
+    "stbl",
+    "outside_range"
   )
 })
 
 test_that("stabilize_dbl() checks max_value (#23, #176)", {
   given <- 1.1:10.1
-  expect_pkg_error_classes(
+  expect_pkg_error_snapshot(
     stabilize_dbl(given, max_value = 4.1),
     "stbl",
     "outside_range"
   )
-  expect_snapshot(
-    stabilize_dbl(given, max_value = 4.1),
-    error = TRUE
-  )
-  expect_snapshot(
+  expect_pkg_error_snapshot(
     wrapped_stabilize_dbl(given, max_value = 4.1),
-    error = TRUE
+    "stbl",
+    "outside_range"
   )
 })
 
@@ -48,27 +42,21 @@ test_that("stabilize_dbl_scalar() allows length-1 dbls through (#23, #189)", {
 
 test_that("stabilize_dbl_scalar() respects allow_null (#23, #189)", {
   given <- NULL
-  expect_pkg_error_classes(stabilize_dbl_scalar(given), "stbl", "bad_null")
-  expect_snapshot(
-    stabilize_dbl_scalar(given),
-    error = TRUE
-  )
-  expect_snapshot(
+  expect_pkg_error_snapshot(stabilize_dbl_scalar(given), "stbl", "bad_null")
+  expect_pkg_error_snapshot(
     wrapped_stabilize_dbl_scalar(given),
-    error = TRUE
+    "stbl",
+    "bad_null"
   )
 })
 
 test_that("stabilize_dbl_scalar() errors on non-scalars (#23)", {
   given <- 1.1:10.1
-  expect_pkg_error_classes(stabilize_dbl_scalar(given), "stbl", "non_scalar")
-  expect_snapshot(
-    stabilize_dbl_scalar(given),
-    error = TRUE
-  )
-  expect_snapshot(
+  expect_pkg_error_snapshot(stabilize_dbl_scalar(given), "stbl", "non_scalar")
+  expect_pkg_error_snapshot(
     wrapped_stabilize_dbl_scalar(given),
-    error = TRUE
+    "stbl",
+    "non_scalar"
   )
 })
 

--- a/tests/testthat/test-stabilize_fct.R
+++ b/tests/testthat/test-stabilize_fct.R
@@ -3,18 +3,15 @@ test_that("stabilize_fct() works (#62)", {
 })
 
 test_that("stabilize_fct() throws errors for bad levels (#62, #67)", {
-  expect_pkg_error_classes(
+  expect_pkg_error_snapshot(
     stabilize_fct(letters[1:5], levels = c("a", "c"), to_na = "b"),
     "stbl",
     "fct_levels"
   )
-  expect_snapshot(
-    stabilize_fct(letters[1:5], levels = c("a", "c"), to_na = "b"),
-    error = TRUE
-  )
-  expect_snapshot(
+  expect_pkg_error_snapshot(
     wrapped_stabilize_fct(letters[1:5], levels = c("a", "c"), to_na = "b"),
-    error = TRUE
+    "stbl",
+    "fct_levels"
   )
 })
 
@@ -25,27 +22,21 @@ test_that("stabilize_fct_scalar() works (#62, #189)", {
 
 test_that("stabilize_fct_scalar() respects allow_null (#62, #189)", {
   given <- NULL
-  expect_pkg_error_classes(stabilize_fct_scalar(given), "stbl", "bad_null")
-  expect_snapshot(
-    stabilize_fct_scalar(given),
-    error = TRUE
-  )
-  expect_snapshot(
+  expect_pkg_error_snapshot(stabilize_fct_scalar(given), "stbl", "bad_null")
+  expect_pkg_error_snapshot(
     wrapped_stabilize_fct_scalar(given),
-    error = TRUE
+    "stbl",
+    "bad_null"
   )
 })
 
 test_that("stabilize_fct_scalar() errors for non-scalars (#62)", {
   given <- letters
-  expect_pkg_error_classes(stabilize_fct_scalar(given), "stbl", "non_scalar")
-  expect_snapshot(
-    stabilize_fct_scalar(given),
-    error = TRUE
-  )
-  expect_snapshot(
+  expect_pkg_error_snapshot(stabilize_fct_scalar(given), "stbl", "non_scalar")
+  expect_pkg_error_snapshot(
     wrapped_stabilize_fct_scalar(given),
-    error = TRUE
+    "stbl",
+    "non_scalar"
   )
 })
 

--- a/tests/testthat/test-stabilize_int.R
+++ b/tests/testthat/test-stabilize_int.R
@@ -4,35 +4,29 @@ test_that("stabilize_int() checks min_value (#2, #6, #176)", {
     stabilize_int(given, min_value = 1, max_value = 10),
     given
   )
-  expect_pkg_error_classes(
+  expect_pkg_error_snapshot(
     stabilize_int(given, min_value = 11),
     "stbl",
     "outside_range"
   )
-  expect_snapshot(
-    stabilize_int(given, min_value = 11),
-    error = TRUE
-  )
-  expect_snapshot(
+  expect_pkg_error_snapshot(
     wrapped_stabilize_int(given, min_value = 11),
-    error = TRUE
+    "stbl",
+    "outside_range"
   )
 })
 
 test_that("stabilize_int() checks max_value (#5, #176)", {
   given <- 1:10
-  expect_pkg_error_classes(
+  expect_pkg_error_snapshot(
     stabilize_int(given, max_value = 4),
     "stbl",
     "outside_range"
   )
-  expect_snapshot(
-    stabilize_int(given, max_value = 4),
-    error = TRUE
-  )
-  expect_snapshot(
+  expect_pkg_error_snapshot(
     wrapped_stabilize_int(given, max_value = 4),
-    error = TRUE
+    "stbl",
+    "outside_range"
   )
 })
 
@@ -44,27 +38,21 @@ test_that("stabilize_int_scalar() allows length-1 ints through (#12, #189)", {
 
 test_that("stabilize_int_scalar() respects allow_null (#12, #189)", {
   given <- NULL
-  expect_pkg_error_classes(stabilize_int_scalar(given), "stbl", "bad_null")
-  expect_snapshot(
-    stabilize_int_scalar(given),
-    error = TRUE
-  )
-  expect_snapshot(
+  expect_pkg_error_snapshot(stabilize_int_scalar(given), "stbl", "bad_null")
+  expect_pkg_error_snapshot(
     wrapped_stabilize_int_scalar(given),
-    error = TRUE
+    "stbl",
+    "bad_null"
   )
 })
 
 test_that("stabilize_int_scalar() errors on non-scalars (#12)", {
   given <- 1:10
-  expect_pkg_error_classes(stabilize_int_scalar(given), "stbl", "non_scalar")
-  expect_snapshot(
-    stabilize_int_scalar(given),
-    error = TRUE
-  )
-  expect_snapshot(
+  expect_pkg_error_snapshot(stabilize_int_scalar(given), "stbl", "non_scalar")
+  expect_pkg_error_snapshot(
     wrapped_stabilize_int_scalar(given),
-    error = TRUE
+    "stbl",
+    "non_scalar"
   )
 })
 

--- a/tests/testthat/test-stabilize_lgl.R
+++ b/tests/testthat/test-stabilize_lgl.R
@@ -17,52 +17,43 @@ test_that("stabilize_lgl() checks NAs (#28)", {
     stabilize_lgl(given),
     c(TRUE, NA, TRUE, FALSE)
   )
-  expect_pkg_error_classes(
+  expect_pkg_error_snapshot(
     stabilize_lgl(given, allow_na = FALSE),
     "stbl",
     "bad_na"
   )
-  expect_snapshot(
-    stabilize_lgl(given, allow_na = FALSE),
-    error = TRUE
-  )
-  expect_snapshot(
+  expect_pkg_error_snapshot(
     wrapped_stabilize_lgl(given, allow_na = FALSE),
-    error = TRUE
+    "stbl",
+    "bad_na"
   )
 })
 
 test_that("stabilize_lgl() checks min_size (#28)", {
   given <- c("TRUE", NA, "true", "fALSE")
-  expect_pkg_error_classes(
+  expect_pkg_error_snapshot(
     stabilize_lgl(given, min_size = 5),
     "stbl",
     "size_too_small"
   )
-  expect_snapshot(
-    stabilize_lgl(given, min_size = 5),
-    error = TRUE
-  )
-  expect_snapshot(
+  expect_pkg_error_snapshot(
     wrapped_stabilize_lgl(given, min_size = 5),
-    error = TRUE
+    "stbl",
+    "size_too_small"
   )
 })
 
 test_that("stabilize_lgl() checks max_size (#28)", {
   given <- c("TRUE", NA, "true", "fALSE")
-  expect_pkg_error_classes(
+  expect_pkg_error_snapshot(
     stabilize_lgl(given, max_size = 3),
     "stbl",
     "size_too_large"
   )
-  expect_snapshot(
-    stabilize_lgl(given, max_size = 3),
-    error = TRUE
-  )
-  expect_snapshot(
+  expect_pkg_error_snapshot(
     wrapped_stabilize_lgl(given, max_size = 3),
-    error = TRUE
+    "stbl",
+    "size_too_large"
   )
 })
 
@@ -73,27 +64,21 @@ test_that("stabilize_lgl_scalar() allows length-1 lgls through (#28, #189)", {
 
 test_that("stabilize_lgl_scalar() respects allow_null (#28, #189)", {
   given <- NULL
-  expect_pkg_error_classes(stabilize_lgl_scalar(given), "stbl", "bad_null")
-  expect_snapshot(
-    stabilize_lgl_scalar(given),
-    error = TRUE
-  )
-  expect_snapshot(
+  expect_pkg_error_snapshot(stabilize_lgl_scalar(given), "stbl", "bad_null")
+  expect_pkg_error_snapshot(
     wrapped_stabilize_lgl_scalar(given),
-    error = TRUE
+    "stbl",
+    "bad_null"
   )
 })
 
 test_that("stabilize_lgl_scalar() errors on non-scalars (#28)", {
   given <- c(TRUE, FALSE, TRUE)
-  expect_pkg_error_classes(stabilize_lgl_scalar(given), "stbl", "non_scalar")
-  expect_snapshot(
-    stabilize_lgl_scalar(given),
-    error = TRUE
-  )
-  expect_snapshot(
+  expect_pkg_error_snapshot(stabilize_lgl_scalar(given), "stbl", "non_scalar")
+  expect_pkg_error_snapshot(
     wrapped_stabilize_lgl_scalar(given),
-    error = TRUE
+    "stbl",
+    "non_scalar"
   )
 })
 

--- a/tests/testthat/test-stabilize_lst.R
+++ b/tests/testthat/test-stabilize_lst.R
@@ -3,18 +3,15 @@ test_that("stabilize_lst() returns NULL for NULL input by default (#110)", {
 })
 
 test_that("stabilize_lst() respects .allow_null (#110)", {
-  expect_pkg_error_classes(
+  expect_pkg_error_snapshot(
     stabilize_lst(NULL, .allow_null = FALSE),
     "stbl",
     "bad_null"
   )
-  expect_snapshot(
-    stabilize_lst(NULL, .allow_null = FALSE),
-    error = TRUE
-  )
-  expect_snapshot(
+  expect_pkg_error_snapshot(
     wrapped_stabilize_lst(NULL, .allow_null = FALSE),
-    error = TRUE
+    "stbl",
+    "bad_null"
   )
 })
 
@@ -39,23 +36,20 @@ test_that("stabilize_lst() validates required named elements (#110)", {
 })
 
 test_that("stabilize_lst() errors when required named element is missing (#110)", {
-  expect_pkg_error_classes(
+  expect_pkg_error_snapshot(
     stabilize_lst(list(foo = "a"), name = specify_chr_scalar()),
     "stbl",
     "missing_element"
   )
-  expect_snapshot(
-    stabilize_lst(list(foo = "a"), name = specify_chr_scalar()),
-    error = TRUE
-  )
-  expect_snapshot(
+  expect_pkg_error_snapshot(
     wrapped_stabilize_lst(list(foo = "a"), name = specify_chr_scalar()),
-    error = TRUE
+    "stbl",
+    "missing_element"
   )
 })
 
 test_that("stabilize_lst() errors informatively when element fails validation (#110)", {
-  expect_pkg_error_classes(
+  expect_pkg_error_snapshot(
     stabilize_lst(
       list(count = "not-an-int"),
       count = specify_int_scalar()
@@ -63,25 +57,18 @@ test_that("stabilize_lst() errors informatively when element fails validation (#
     "stbl",
     "incompatible_type"
   )
-  expect_snapshot(
-    stabilize_lst(list(count = "not-an-int"), count = specify_int_scalar()),
-    error = TRUE
-  )
 })
 
 test_that("stabilize_lst() errors on extra named elements by default (#110)", {
-  expect_pkg_error_classes(
+  expect_pkg_error_snapshot(
     stabilize_lst(list(a = 1L, b = 2L)),
     "stbl",
     "bad_named"
   )
-  expect_snapshot(
-    stabilize_lst(list(a = 1L, b = 2L)),
-    error = TRUE
-  )
-  expect_snapshot(
+  expect_pkg_error_snapshot(
     wrapped_stabilize_lst(list(a = 1L, b = 2L)),
-    error = TRUE
+    "stbl",
+    "bad_named"
   )
 })
 
@@ -99,14 +86,11 @@ test_that("stabilize_lst() validates extra named elements with .named (#110)", {
 })
 
 test_that("stabilize_lst() errors on unnamed elements by default (#110)", {
-  expect_pkg_error_classes(stabilize_lst(list(1L, 2L)), "stbl", "bad_unnamed")
-  expect_snapshot(
-    stabilize_lst(list(1L, 2L)),
-    error = TRUE
-  )
-  expect_snapshot(
+  expect_pkg_error_snapshot(stabilize_lst(list(1L, 2L)), "stbl", "bad_unnamed")
+  expect_pkg_error_snapshot(
     wrapped_stabilize_lst(list(1L, 2L)),
-    error = TRUE
+    "stbl",
+    "bad_unnamed"
   )
 })
 
@@ -137,14 +121,10 @@ test_that("stabilize_lst() handles mixed named/unnamed lists (#110)", {
 })
 
 test_that("stabilize_lst() enforces .min_size (#110)", {
-  expect_pkg_error_classes(
+  expect_pkg_error_snapshot(
     stabilize_lst(list(a = 1L), .named = specify_int_scalar(), .min_size = 2),
     "stbl",
     "size_too_small"
-  )
-  expect_snapshot(
-    stabilize_lst(list(a = 1L), .named = specify_int_scalar(), .min_size = 2),
-    error = TRUE
   )
 })
 
@@ -168,7 +148,7 @@ test_that("stabilize_lst() validates nested lists (#110)", {
     given
   )
   # data.frame can't be coerced to chr_scalar
-  expect_pkg_error_classes(
+  expect_pkg_error_snapshot(
     stabilize_lst(
       list(aes = list(x = mtcars, y = "hp")),
       aes = spec_aes
@@ -176,10 +156,6 @@ test_that("stabilize_lst() validates nested lists (#110)", {
     "stbl",
     "coerce",
     "character"
-  )
-  expect_snapshot(
-    stabilize_lst(list(aes = list(x = mtcars, y = "hp")), aes = spec_aes),
-    error = TRUE
   )
 })
 
@@ -192,18 +168,15 @@ test_that("stabilize_lst() with unnamed specs errors informatively (#110)", {
 })
 
 test_that(".check_duplicate_names(): errors on duplicate names by default (#110)", {
-  expect_pkg_error_classes(
+  expect_pkg_error_snapshot(
     stabilize_lst(list(a = 1L, a = 2L), .named = specify_int_scalar()),
     "stbl",
     "duplicate_names"
   )
-  expect_snapshot(
-    stabilize_lst(list(a = 1L, a = 2L), .named = specify_int_scalar()),
-    error = TRUE
-  )
-  expect_snapshot(
+  expect_pkg_error_snapshot(
     wrapped_stabilize_lst(list(a = 1L, a = 2L), .named = specify_int_scalar()),
-    error = TRUE
+    "stbl",
+    "duplicate_names"
   )
 })
 

--- a/tests/testthat/test-stabilize_present.R
+++ b/tests/testthat/test-stabilize_present.R
@@ -6,11 +6,7 @@ test_that("stabilize_present() returns any non-NULL value unchanged (#110)", {
 })
 
 test_that("stabilize_present() errors for NULL (#110)", {
-  expect_pkg_error_classes(stabilize_present(NULL), "stbl", "bad_null")
-  expect_snapshot(
-    stabilize_present(NULL),
-    error = TRUE
-  )
+  expect_pkg_error_snapshot(stabilize_present(NULL), "stbl", "bad_null")
 })
 
 test_that("stabilize_present() works as an element spec in stabilize_lst() (#110)", {

--- a/tests/testthat/test-to_dbl.R
+++ b/tests/testthat/test-to_dbl.R
@@ -15,18 +15,15 @@ test_that("to_dbl() works for NULL (#23)", {
 
 test_that("to_dbl() respects allow_null (#23)", {
   given <- NULL
-  expect_pkg_error_classes(
+  expect_pkg_error_snapshot(
     to_dbl(given, allow_null = FALSE),
     "stbl",
     "bad_null"
   )
-  expect_snapshot(
-    to_dbl(given, allow_null = FALSE),
-    error = TRUE
-  )
-  expect_snapshot(
+  expect_pkg_error_snapshot(
     wrapped_to_dbl(given, allow_null = FALSE),
-    error = TRUE
+    "stbl",
+    "bad_null"
   )
 })
 
@@ -45,33 +42,24 @@ test_that("to_dbl() works for chrs (#23)", {
 test_that("to_dbl() respects coerce_character (#23)", {
   expected <- c(1.1, 2.2)
   given <- as.character(expected)
-  expect_pkg_error_classes(
+  expect_pkg_error_snapshot(
     to_dbl(given, coerce_character = FALSE),
     "stbl",
     "coerce",
     "double"
   )
-  expect_snapshot(
-    to_dbl(given, coerce_character = FALSE),
-    error = TRUE
-  )
-  expect_snapshot(
+  expect_pkg_error_snapshot(
     wrapped_to_dbl(given, coerce_character = FALSE),
-    error = TRUE
+    "stbl",
+    "coerce",
+    "double"
   )
 })
 
 test_that("to_dbl() errors informatively for bad chrs (#23)", {
   given <- c("1.1", "a")
-  expect_pkg_error_classes(to_dbl(given), "stbl", "incompatible_type")
-  expect_snapshot(
-    to_dbl(given),
-    error = TRUE
-  )
-  expect_snapshot(
-    wrapped_to_dbl(given),
-    error = TRUE
-  )
+  expect_pkg_error_snapshot(to_dbl(given), "stbl", "incompatible_type")
+  expect_pkg_error_snapshot(wrapped_to_dbl(given), "stbl", "incompatible_type")
 })
 
 test_that("to_dbl() works for complexes (#23)", {
@@ -83,15 +71,8 @@ test_that("to_dbl() works for complexes (#23)", {
 test_that("to_dbl() errors informatively for bad complexes (#23)", {
   given <- as.complex(c(1.1, 2.2))
   given[[1]] <- 1.1 + 1i
-  expect_pkg_error_classes(to_dbl(given), "stbl", "incompatible_type")
-  expect_snapshot(
-    to_dbl(given),
-    error = TRUE
-  )
-  expect_snapshot(
-    wrapped_to_dbl(given),
-    error = TRUE
-  )
+  expect_pkg_error_snapshot(to_dbl(given), "stbl", "incompatible_type")
+  expect_pkg_error_snapshot(wrapped_to_dbl(given), "stbl", "incompatible_type")
 })
 
 test_that("to_dbl() works for factors (#23)", {
@@ -103,33 +84,24 @@ test_that("to_dbl() works for factors (#23)", {
 test_that("to_dbl() respects coerce_factor (#23)", {
   expected <- c(1.1, 3.3)
   given <- factor(expected)
-  expect_pkg_error_classes(
+  expect_pkg_error_snapshot(
     to_dbl(given, coerce_factor = FALSE),
     "stbl",
     "coerce",
     "double"
   )
-  expect_snapshot(
-    to_dbl(given, coerce_factor = FALSE),
-    error = TRUE
-  )
-  expect_snapshot(
+  expect_pkg_error_snapshot(
     wrapped_to_dbl(given, coerce_factor = FALSE),
-    error = TRUE
+    "stbl",
+    "coerce",
+    "double"
   )
 })
 
 test_that("to_dbl() errors informatively for bad factors (#23)", {
   given <- factor(letters)
-  expect_pkg_error_classes(to_dbl(given), "stbl", "incompatible_type")
-  expect_snapshot(
-    to_dbl(given),
-    error = TRUE
-  )
-  expect_snapshot(
-    wrapped_to_dbl(given),
-    error = TRUE
-  )
+  expect_pkg_error_snapshot(to_dbl(given), "stbl", "incompatible_type")
+  expect_pkg_error_snapshot(wrapped_to_dbl(given), "stbl", "incompatible_type")
 })
 
 test_that("to_dbl() works for lists (#128, #273)", {
@@ -155,37 +127,19 @@ test_that("to_dbl_scalar() allows length-1 dbls through (#23)", {
 
 test_that("to_dbl_scalar() provides informative error messages (#23)", {
   given <- c(1.1, 2.2)
-  expect_pkg_error_classes(to_dbl_scalar(given), "stbl", "non_scalar")
-  expect_snapshot(
-    to_dbl_scalar(given),
-    error = TRUE
-  )
-  expect_snapshot(
-    wrapped_to_dbl_scalar(given),
-    error = TRUE
-  )
+  expect_pkg_error_snapshot(to_dbl_scalar(given), "stbl", "non_scalar")
+  expect_pkg_error_snapshot(wrapped_to_dbl_scalar(given), "stbl", "non_scalar")
 })
 
 test_that("to_dbl_scalar() respects allow_null (#23, #189)", {
   given <- NULL
-  expect_pkg_error_classes(to_dbl_scalar(given), "stbl", "bad_null")
-  expect_snapshot(
-    to_dbl_scalar(given),
-    error = TRUE
-  )
-  expect_snapshot(
-    wrapped_to_dbl_scalar(given),
-    error = TRUE
-  )
+  expect_pkg_error_snapshot(to_dbl_scalar(given), "stbl", "bad_null")
+  expect_pkg_error_snapshot(wrapped_to_dbl_scalar(given), "stbl", "bad_null")
 })
 
 test_that("to_dbl_scalar respects allow_zero_length (#23, #43, #45, #189)", {
   given <- double()
-  expect_pkg_error_classes(to_dbl_scalar(given), "stbl", "bad_empty")
-  expect_snapshot(
-    to_dbl_scalar(given),
-    error = TRUE
-  )
+  expect_pkg_error_snapshot(to_dbl_scalar(given), "stbl", "bad_empty")
 })
 
 test_that("to_double() exists (#164)", {

--- a/tests/testthat/test-to_df.R
+++ b/tests/testthat/test-to_df.R
@@ -7,14 +7,15 @@ test_that("to_df() returns NULL for NULL input by default (#201)", {
 })
 
 test_that("to_df() respects allow_null (#201)", {
-  expect_pkg_error_classes(to_df(NULL, allow_null = FALSE), "stbl", "bad_null")
-  expect_snapshot(
+  expect_pkg_error_snapshot(
     to_df(NULL, allow_null = FALSE),
-    error = TRUE
+    "stbl",
+    "bad_null"
   )
-  expect_snapshot(
+  expect_pkg_error_snapshot(
     wrapped_to_df(NULL, allow_null = FALSE),
-    error = TRUE
+    "stbl",
+    "bad_null"
   )
 })
 
@@ -55,35 +56,24 @@ test_that("to_df() coerces a list of equal-length vectors to a data frame (#201)
 })
 
 test_that("to_df() errors for a list with incompatible column lengths (#201)", {
-  expect_pkg_error_classes(to_df(list(a = 1:3, b = 1:2)), "stbl", "jagged")
-  expect_snapshot(
-    to_df(list(a = 1:3, b = 1:2)),
-    error = TRUE
-  )
-  expect_snapshot(
+  expect_pkg_error_snapshot(to_df(list(a = 1:3, b = 1:2)), "stbl", "jagged")
+  expect_pkg_error_snapshot(
     wrapped_to_df(list(a = 1:3, b = 1:2)),
-    error = TRUE
+    "stbl",
+    "jagged"
   )
 })
 
 test_that("to_df() errors for an unnamed list (#203)", {
-  expect_pkg_error_classes(to_df(list(1, 2)), "stbl", "bad_named")
-  expect_snapshot(
-    to_df(list(1, 2)),
-    error = TRUE
-  )
+  expect_pkg_error_snapshot(to_df(list(1, 2)), "stbl", "bad_named")
 })
 
 test_that("to_df() errors for non-coercible types (#201)", {
-  expect_pkg_error_classes(
+  expect_pkg_error_snapshot(
     to_df("not a data frame"),
     "stbl",
     "coerce",
     "data.frame"
-  )
-  expect_snapshot(
-    to_df("not a data frame"),
-    error = TRUE
   )
 })
 
@@ -120,15 +110,11 @@ test_that("to_df() errors for inline vector expressions (#203)", {
 })
 
 test_that("to_df.default() errors for non-coercible types (#201)", {
-  expect_pkg_error_classes(
+  expect_pkg_error_snapshot(
     to_df(as.Date("2024-01-01")),
     "stbl",
     "coerce",
     "data.frame"
-  )
-  expect_snapshot(
-    to_df(as.Date("2024-01-01")),
-    error = TRUE
   )
 })
 

--- a/tests/testthat/test-to_fct.R
+++ b/tests/testthat/test-to_fct.R
@@ -13,18 +13,15 @@ test_that("to_fct() deals with levels of fcts (#62)", {
 })
 
 test_that("to_fct() throws errors for bad levels (#62, #67, #177)", {
-  expect_pkg_error_classes(
+  expect_pkg_error_snapshot(
     to_fct(letters[1:5], levels = c("a", "c"), to_na = "b"),
     "stbl",
     "fct_levels"
   )
-  expect_snapshot(
-    to_fct(letters[1:5], levels = c("a", "c"), to_na = "b"),
-    error = TRUE
-  )
-  expect_snapshot(
+  expect_pkg_error_snapshot(
     wrapped_to_fct(letters[1:5], levels = c("a", "c"), to_na = "b"),
-    error = TRUE
+    "stbl",
+    "fct_levels"
   )
 })
 
@@ -45,18 +42,15 @@ test_that("to_fct() works for NULL (#62)", {
 
 test_that("to_fct() respects allow_null (#62)", {
   given <- NULL
-  expect_pkg_error_classes(
+  expect_pkg_error_snapshot(
     to_fct(given, allow_null = FALSE),
     "stbl",
     "bad_null"
   )
-  expect_snapshot(
-    to_fct(given, allow_null = FALSE),
-    error = TRUE
-  )
-  expect_snapshot(
+  expect_pkg_error_snapshot(
     wrapped_to_fct(given, allow_null = FALSE),
-    error = TRUE
+    "stbl",
+    "bad_null"
   )
 })
 
@@ -78,14 +72,12 @@ test_that("to_fct() works for lists (#64, #273)", {
 
 test_that("to_fct() errors for things that can't be coerced (#62, #273)", {
   given <- mean
-  expect_pkg_error_classes(to_fct(given), "stbl", "coerce", "factor")
-  expect_snapshot(to_fct(given), error = TRUE)
-  expect_snapshot(wrapped_to_fct(given), error = TRUE)
+  expect_pkg_error_snapshot(to_fct(given), "stbl", "coerce", "factor")
+  expect_pkg_error_snapshot(wrapped_to_fct(given), "stbl", "coerce", "factor")
 
   given <- mtcars
-  expect_pkg_error_classes(to_fct(given), "stbl", "coerce", "factor")
-  expect_snapshot(to_fct(given), error = TRUE)
-  expect_snapshot(wrapped_to_fct(given), error = TRUE)
+  expect_pkg_error_snapshot(to_fct(given), "stbl", "coerce", "factor")
+  expect_pkg_error_snapshot(wrapped_to_fct(given), "stbl", "coerce", "factor")
 
   given <- list(a = 1, b = 1:5)
   expect_pkg_error_snapshot(
@@ -112,18 +104,13 @@ test_that("to_fct_scalar() allows length-1 fcts through (#62)", {
 
 test_that("to_fct_scalar() provides informative error messages (#62)", {
   given <- letters
-  expect_pkg_error_classes(to_fct_scalar(given), "stbl", "non_scalar")
-  expect_snapshot(to_fct_scalar(given), error = TRUE)
-  expect_snapshot(wrapped_to_fct_scalar(given), error = TRUE)
+  expect_pkg_error_snapshot(to_fct_scalar(given), "stbl", "non_scalar")
+  expect_pkg_error_snapshot(wrapped_to_fct_scalar(given), "stbl", "non_scalar")
 })
 
 test_that("to_fct_scalar respects allow_zero_length (#62, #43, #45, #189)", {
   given <- factor()
-  expect_pkg_error_classes(to_fct_scalar(given), "stbl", "bad_empty")
-  expect_snapshot(
-    to_fct_scalar(given),
-    error = TRUE
-  )
+  expect_pkg_error_snapshot(to_fct_scalar(given), "stbl", "bad_empty")
 })
 
 test_that("to_factor() exists (#164)", {
@@ -146,18 +133,15 @@ test_that("to_fct() works for ints via C (#241)", {
 
 test_that("to_fct() errors for ints with unexpected levels (#241)", {
   given <- c(1L, 2L, 3L)
-  expect_pkg_error_classes(
+  expect_pkg_error_snapshot(
     to_fct(given, levels = c("1", "2")),
     "stbl",
     "fct_levels"
   )
-  expect_snapshot(
-    to_fct(given, levels = c("1", "2")),
-    error = TRUE
-  )
-  expect_snapshot(
+  expect_pkg_error_snapshot(
     wrapped_to_fct(given, levels = c("1", "2")),
-    error = TRUE
+    "stbl",
+    "fct_levels"
   )
 })
 

--- a/tests/testthat/test-to_int.R
+++ b/tests/testthat/test-to_int.R
@@ -10,18 +10,15 @@ test_that("to_int() works for NULL (#2)", {
 
 test_that("to_int() respects allow_null (#2)", {
   given <- NULL
-  expect_pkg_error_classes(
+  expect_pkg_error_snapshot(
     to_int(given, allow_null = FALSE),
     "stbl",
     "bad_null"
   )
-  expect_snapshot(
-    to_int(given, allow_null = FALSE),
-    error = TRUE
-  )
-  expect_snapshot(
+  expect_pkg_error_snapshot(
     wrapped_to_int(given, allow_null = FALSE),
-    error = TRUE
+    "stbl",
+    "bad_null"
   )
 })
 
@@ -40,26 +37,12 @@ test_that("to_int() works for dbls (#2)", {
 test_that("to_int() errors for dbls that would lose precision (#2, #217)", {
   given <- as.double(1:10)
   given[[4]] <- 1.1
-  expect_pkg_error_classes(to_int(given), "stbl", "incompatible_type")
-  expect_snapshot(
-    to_int(given),
-    error = TRUE
-  )
-  expect_snapshot(
-    wrapped_to_int(given),
-    error = TRUE
-  )
+  expect_pkg_error_snapshot(to_int(given), "stbl", "incompatible_type")
+  expect_pkg_error_snapshot(wrapped_to_int(given), "stbl", "incompatible_type")
 
   given[[4]] <- Inf
-  expect_pkg_error_classes(to_int(given), "stbl", "incompatible_type")
-  expect_snapshot(
-    to_int(given),
-    error = TRUE
-  )
-  expect_snapshot(
-    wrapped_to_int(given),
-    error = TRUE
-  )
+  expect_pkg_error_snapshot(to_int(given), "stbl", "incompatible_type")
+  expect_pkg_error_snapshot(wrapped_to_int(given), "stbl", "incompatible_type")
 })
 
 test_that("to_int() works for chrs (#2)", {
@@ -71,45 +54,29 @@ test_that("to_int() works for chrs (#2)", {
 test_that("to_int() respects coerce_character (#14)", {
   expected <- 1:10
   given <- as.character(expected)
-  expect_pkg_error_classes(
+  expect_pkg_error_snapshot(
     to_int(given, coerce_character = FALSE),
     "stbl",
     "coerce",
     "integer"
   )
-  expect_snapshot(
-    to_int(given, coerce_character = FALSE),
-    error = TRUE
-  )
-  expect_snapshot(
+  expect_pkg_error_snapshot(
     wrapped_to_int(given, coerce_character = FALSE),
-    error = TRUE
+    "stbl",
+    "coerce",
+    "integer"
   )
 })
 
 test_that("to_int() errors informatively for bad chrs (#2)", {
   given <- as.character(1:10)
   given[[4]] <- "1.1"
-  expect_pkg_error_classes(to_int(given), "stbl", "incompatible_type")
-  expect_snapshot(
-    to_int(given),
-    error = TRUE
-  )
-  expect_snapshot(
-    wrapped_to_int(given),
-    error = TRUE
-  )
+  expect_pkg_error_snapshot(to_int(given), "stbl", "incompatible_type")
+  expect_pkg_error_snapshot(wrapped_to_int(given), "stbl", "incompatible_type")
 
   given[[4]] <- "a"
-  expect_pkg_error_classes(to_int(given), "stbl", "incompatible_type")
-  expect_snapshot(
-    to_int(given),
-    error = TRUE
-  )
-  expect_snapshot(
-    wrapped_to_int(given),
-    error = TRUE
-  )
+  expect_pkg_error_snapshot(to_int(given), "stbl", "incompatible_type")
+  expect_pkg_error_snapshot(wrapped_to_int(given), "stbl", "incompatible_type")
 })
 
 test_that("to_int() works for complexes (#2)", {
@@ -121,40 +88,19 @@ test_that("to_int() works for complexes (#2)", {
 test_that("to_int() errors informatively for bad complexes (#2)", {
   given <- as.complex(1:10)
   given[[4]] <- 1 + 1i
-  expect_pkg_error_classes(to_int(given), "stbl", "incompatible_type")
-  expect_snapshot(
-    to_int(given),
-    error = TRUE
-  )
-  expect_snapshot(
-    wrapped_to_int(given),
-    error = TRUE
-  )
+  expect_pkg_error_snapshot(to_int(given), "stbl", "incompatible_type")
+  expect_pkg_error_snapshot(wrapped_to_int(given), "stbl", "incompatible_type")
 })
 
 test_that("to_int() errors for complexes that would lose precision (#noissue)", {
   given <- as.complex(1:10)
   given[[4]] <- 1.5 + 0i
-  expect_pkg_error_classes(to_int(given), "stbl", "incompatible_type")
-  expect_snapshot(
-    to_int(given),
-    error = TRUE
-  )
-  expect_snapshot(
-    wrapped_to_int(given),
-    error = TRUE
-  )
+  expect_pkg_error_snapshot(to_int(given), "stbl", "incompatible_type")
+  expect_pkg_error_snapshot(wrapped_to_int(given), "stbl", "incompatible_type")
 
   given[[4]] <- Inf + 0i
-  expect_pkg_error_classes(to_int(given), "stbl", "incompatible_type")
-  expect_snapshot(
-    to_int(given),
-    error = TRUE
-  )
-  expect_snapshot(
-    wrapped_to_int(given),
-    error = TRUE
-  )
+  expect_pkg_error_snapshot(to_int(given), "stbl", "incompatible_type")
+  expect_pkg_error_snapshot(wrapped_to_int(given), "stbl", "incompatible_type")
 })
 
 test_that("to_int() works for factors (#4)", {
@@ -166,33 +112,24 @@ test_that("to_int() works for factors (#4)", {
 test_that("to_int() respects coerce_factor (#14)", {
   expected <- c(1L, 3L, 5L, 7L)
   given <- factor(expected)
-  expect_pkg_error_classes(
+  expect_pkg_error_snapshot(
     to_int(given, coerce_factor = FALSE),
     "stbl",
     "coerce",
     "integer"
   )
-  expect_snapshot(
-    to_int(given, coerce_factor = FALSE),
-    error = TRUE
-  )
-  expect_snapshot(
+  expect_pkg_error_snapshot(
     wrapped_to_int(given, coerce_factor = FALSE),
-    error = TRUE
+    "stbl",
+    "coerce",
+    "integer"
   )
 })
 
 test_that("to_int() errors informatively for bad factors (#4)", {
   given <- factor(letters)
-  expect_pkg_error_classes(to_int(given), "stbl", "incompatible_type")
-  expect_snapshot(
-    to_int(given),
-    error = TRUE
-  )
-  expect_snapshot(
-    wrapped_to_int(given),
-    error = TRUE
-  )
+  expect_pkg_error_snapshot(to_int(given), "stbl", "incompatible_type")
+  expect_pkg_error_snapshot(wrapped_to_int(given), "stbl", "incompatible_type")
 })
 
 test_that("to_int() works for lists (#2, #273)", {
@@ -219,37 +156,19 @@ test_that("to_int_scalar() allows length-1 ints through (#12)", {
 
 test_that("to_int_scalar() provides informative error messages (#12)", {
   given <- 1:10
-  expect_pkg_error_classes(to_int_scalar(given), "stbl", "non_scalar")
-  expect_snapshot(
-    to_int_scalar(given),
-    error = TRUE
-  )
-  expect_snapshot(
-    wrapped_to_int_scalar(given),
-    error = TRUE
-  )
+  expect_pkg_error_snapshot(to_int_scalar(given), "stbl", "non_scalar")
+  expect_pkg_error_snapshot(wrapped_to_int_scalar(given), "stbl", "non_scalar")
 })
 
 test_that("to_int_scalar() respects allow_null (#12, #189)", {
   given <- NULL
-  expect_pkg_error_classes(to_int_scalar(given), "stbl", "bad_null")
-  expect_snapshot(
-    to_int_scalar(given),
-    error = TRUE
-  )
-  expect_snapshot(
-    wrapped_to_int_scalar(given),
-    error = TRUE
-  )
+  expect_pkg_error_snapshot(to_int_scalar(given), "stbl", "bad_null")
+  expect_pkg_error_snapshot(wrapped_to_int_scalar(given), "stbl", "bad_null")
 })
 
 test_that("to_int_scalar respects allow_zero_length (#12, #43, #45, #189)", {
   given <- integer()
-  expect_pkg_error_classes(to_int_scalar(given), "stbl", "bad_empty")
-  expect_snapshot(
-    to_int_scalar(given),
-    error = TRUE
-  )
+  expect_pkg_error_snapshot(to_int_scalar(given), "stbl", "bad_empty")
 })
 
 test_that("to_integer() exists (#164)", {

--- a/tests/testthat/test-to_lgl.R
+++ b/tests/testthat/test-to_lgl.R
@@ -25,18 +25,15 @@ test_that("to_lgl() works for NULL (#21)", {
 
 test_that("to_lgl() respects allow_null (#21)", {
   given <- NULL
-  expect_pkg_error_classes(
+  expect_pkg_error_snapshot(
     to_lgl(given, allow_null = FALSE),
     "stbl",
     "bad_null"
   )
-  expect_snapshot(
-    to_lgl(given, allow_null = FALSE),
-    error = TRUE
-  )
-  expect_snapshot(
+  expect_pkg_error_snapshot(
     wrapped_to_lgl(given, allow_null = FALSE),
-    error = TRUE
+    "stbl",
+    "bad_null"
   )
 })
 
@@ -111,14 +108,11 @@ test_that("to_lgl works for characters (#21)", {
 })
 
 test_that("to_lgl() errors for bad characters (#21)", {
-  expect_pkg_error_classes(to_lgl(letters), "stbl", "incompatible_type")
-  expect_snapshot(
-    to_lgl(letters),
-    error = TRUE
-  )
-  expect_snapshot(
+  expect_pkg_error_snapshot(to_lgl(letters), "stbl", "incompatible_type")
+  expect_pkg_error_snapshot(
     wrapped_to_lgl(letters),
-    error = TRUE
+    "stbl",
+    "incompatible_type"
   )
 })
 
@@ -160,15 +154,8 @@ test_that("to_lgl works for factors (#21)", {
 
 test_that("to_lgl errors for bad factors (#21)", {
   given <- factor(letters)
-  expect_pkg_error_classes(to_lgl(given), "stbl", "incompatible_type")
-  expect_snapshot(
-    to_lgl(given),
-    error = TRUE
-  )
-  expect_snapshot(
-    wrapped_to_lgl(given),
-    error = TRUE
-  )
+  expect_pkg_error_snapshot(to_lgl(given), "stbl", "incompatible_type")
+  expect_pkg_error_snapshot(wrapped_to_lgl(given), "stbl", "incompatible_type")
 })
 
 test_that("to_lgl() works for lists (#21, #273)", {
@@ -198,15 +185,8 @@ test_that("to_lgl() errors for other types (#21, #273)", {
   )
 
   given <- mean
-  expect_pkg_error_classes(to_lgl(given), "stbl", "coerce", "logical")
-  expect_snapshot(
-    to_lgl(given),
-    error = TRUE
-  )
-  expect_snapshot(
-    wrapped_to_lgl(given),
-    error = TRUE
-  )
+  expect_pkg_error_snapshot(to_lgl(given), "stbl", "coerce", "logical")
+  expect_pkg_error_snapshot(wrapped_to_lgl(given), "stbl", "coerce", "logical")
 })
 
 test_that("to_lgl_scalar() allows length-1 lgls through (#32, #189)", {
@@ -219,41 +199,24 @@ test_that("to_lgl_scalar() allows length-1 lgls through (#32, #189)", {
 
 test_that("to_lgl_scalar() errors for non-scalars (#32)", {
   given <- c(TRUE, FALSE, TRUE)
-  expect_pkg_error_classes(to_lgl_scalar(given), "stbl", "non_scalar")
-  expect_snapshot(
-    to_lgl_scalar(given),
-    error = TRUE
-  )
-  expect_snapshot(
-    wrapped_to_lgl_scalar(given),
-    error = TRUE
-  )
+  expect_pkg_error_snapshot(to_lgl_scalar(given), "stbl", "non_scalar")
+  expect_pkg_error_snapshot(wrapped_to_lgl_scalar(given), "stbl", "non_scalar")
 })
 
 test_that("to_lgl_scalar() errors for bad characters (#32)", {
   given <- "a"
-  expect_pkg_error_classes(to_lgl_scalar(given), "stbl", "incompatible_type")
-  expect_snapshot(
-    to_lgl_scalar(given),
-    error = TRUE
-  )
-  expect_snapshot(
+  expect_pkg_error_snapshot(to_lgl_scalar(given), "stbl", "incompatible_type")
+  expect_pkg_error_snapshot(
     wrapped_to_lgl_scalar(given),
-    error = TRUE
+    "stbl",
+    "incompatible_type"
   )
 })
 
 test_that("to_lgl_scalar() respects allow_null (#32, #189)", {
   given <- NULL
-  expect_pkg_error_classes(to_lgl_scalar(given), "stbl", "bad_null")
-  expect_snapshot(
-    to_lgl_scalar(given),
-    error = TRUE
-  )
-  expect_snapshot(
-    wrapped_to_lgl_scalar(given),
-    error = TRUE
-  )
+  expect_pkg_error_snapshot(to_lgl_scalar(given), "stbl", "bad_null")
+  expect_pkg_error_snapshot(wrapped_to_lgl_scalar(given), "stbl", "bad_null")
 })
 
 test_that("to_logical() exists (#164)", {

--- a/tests/testthat/test-to_lst.R
+++ b/tests/testthat/test-to_lst.R
@@ -13,18 +13,15 @@ test_that("to_lst() works for NULL (#157)", {
 
 test_that("to_lst() respects allow_null (#157)", {
   given <- NULL
-  expect_pkg_error_classes(
+  expect_pkg_error_snapshot(
     to_lst(given, allow_null = FALSE),
     "stbl",
     "bad_null"
   )
-  expect_snapshot(
-    to_lst(given, allow_null = FALSE),
-    error = TRUE
-  )
-  expect_snapshot(
+  expect_pkg_error_snapshot(
     wrapped_to_lst(given, allow_null = FALSE),
-    error = TRUE
+    "stbl",
+    "bad_null"
   )
 })
 
@@ -59,15 +56,8 @@ test_that("to_lst() works for character vectors (#157)", {
 
 test_that("to_lst() errors by default for functions (#157)", {
   given <- function(x) x + 1
-  expect_pkg_error_classes(to_lst(given), "stbl", "bad_function")
-  expect_snapshot(
-    to_lst(given),
-    error = TRUE
-  )
-  expect_snapshot(
-    wrapped_to_lst(given),
-    error = TRUE
-  )
+  expect_pkg_error_snapshot(to_lst(given), "stbl", "bad_function")
+  expect_pkg_error_snapshot(wrapped_to_lst(given), "stbl", "bad_function")
 })
 
 test_that("to_lst() works for functions with coerce_function = TRUE (#157)", {
@@ -81,19 +71,17 @@ test_that("to_lst() works for functions with coerce_function = TRUE (#157)", {
 
 test_that("to_lst() errors informatively for primitives (#157)", {
   given <- is.na
-  expect_pkg_error_classes(
+  expect_pkg_error_snapshot(
     to_lst(given, coerce_function = TRUE),
     "stbl",
     "coerce",
     "list"
   )
-  expect_snapshot(
-    to_lst(given, coerce_function = TRUE),
-    error = TRUE
-  )
-  expect_snapshot(
+  expect_pkg_error_snapshot(
     wrapped_to_lst(given, coerce_function = TRUE),
-    error = TRUE
+    "stbl",
+    "coerce",
+    "list"
   )
 })
 

--- a/tests/testthat/test-to_null.R
+++ b/tests/testthat/test-to_null.R
@@ -4,18 +4,15 @@ test_that(".to_null() works on the happy path (#129)", {
 
 test_that(".to_null() errors when NULL isn't allowed (#129)", {
   given <- NULL
-  expect_pkg_error_classes(
+  expect_pkg_error_snapshot(
     .to_null(given, allow_null = FALSE),
     "stbl",
     "bad_null"
   )
-  expect_snapshot(
-    .to_null(given, allow_null = FALSE),
-    error = TRUE
-  )
-  expect_snapshot(
+  expect_pkg_error_snapshot(
     wrapped_to_null(given, allow_null = FALSE),
-    error = TRUE
+    "stbl",
+    "bad_null"
   )
 })
 
@@ -27,35 +24,24 @@ test_that(".to_null() coerces anything to NULL (#129)", {
 })
 
 test_that(".to_null() errors for bad allow_null (#129)", {
-  expect_pkg_error_classes(
+  expect_pkg_error_snapshot(
     .to_null(NULL, allow_null = NULL),
     "stbl",
     "bad_null"
   )
-  expect_snapshot(
-    .to_null(NULL, allow_null = NULL),
-    error = TRUE
-  )
 
-  expect_pkg_error_classes(
+  expect_pkg_error_snapshot(
     .to_null(NULL, allow_null = "fish"),
     "stbl",
     "incompatible_type"
   )
-  expect_snapshot(
-    .to_null(NULL, allow_null = "fish"),
-    error = TRUE
-  )
-  expect_snapshot(
+  expect_pkg_error_snapshot(
     wrapped_to_null(NULL, allow_null = "fish"),
-    error = TRUE
+    "stbl",
+    "incompatible_type"
   )
 })
 
 test_that(".to_null() errors informatively for missing value (#129)", {
-  expect_pkg_error_classes(.to_null(), "stbl", "must")
-  expect_snapshot(
-    .to_null(),
-    error = TRUE
-  )
+  expect_pkg_error_snapshot(.to_null(), "stbl", "must")
 })


### PR DESCRIPTION
## Summary

Closes #298.

Converts the remaining `expect_pkg_error_classes(EXPR, ...)` + `expect_snapshot(EXPR, error = TRUE)` pairs (and their `wrapped_*` counterparts) into single `expect_pkg_error_snapshot()` calls, following the pattern already used in `test-check.R` (#296) and `test-stabilize_df.R`.

Converted files:

- `test-aaa-conditions.R`
- `test-pkg_abort.R`
- `test-specify_cls.R`
- `test-to_null.R`
- `test-to_lst.R`
- `test-to_lgl.R`
- `test-to_int.R`
- `test-to_fct.R`
- `test-to_dbl.R` (also contained the pattern, though not listed in the issue)
- `test-to_df.R`
- `test-stabilize_present.R`
- `test-stabilize_lst.R`
- `test-stabilize_lgl.R`
- `test-stabilize_int.R`
- `test-stabilize_fct.R`
- `test-stabilize_dbl.R`
- `test-stabilize_chr.R`
- `test-stabilize_arg.R`

Cases where the two expectations tested different expressions (e.g. a `given[[1]]` snapshot alongside the vectorized one), or where `expect_pkg_error_classes()`/`expect_snapshot()` appeared without a matching partner (e.g. `rlib_error_dots_nonempty` checks, or standalone class checks), were left unchanged.

Snapshots were re-recorded with `testthat::snapshot_accept()` since the recorded code expression shape changes even though the message output is unchanged.

No `NEWS.md` bullet — internal test-only change.

## Testing

- `devtools::test(reporter = "check")`: 0 failures (1844 passing)
- `devtools::check(error_on = "warning")`: 0 errors, 0 warnings, 0 notes