### PR TITLE
Mirror expect_snapshot() output in expect_pkg_*_snapshot() (#301)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,7 @@
 
 ## Breaking changes
 
+* `expect_pkg_error_snapshot()`, `expect_pkg_message_snapshot()`, and `expect_pkg_warning_snapshot()` now produce snapshots that mirror `testthat::expect_snapshot()`, showing the bare expression under `Code` and the condition class alongside its message. Existing snapshots must be re-accepted (#301).
 * `stabilize_present()` is now named `assert_present()`, since it doesn't stabilize (coerce) its input; it only asserts that the input is not `NULL`. Calling `stabilize_present()` now throws a "deprecated"-classed error directing you to `assert_present()` (#299).
 
 ## Bug fixes

--- a/R/pkg_abort.R
+++ b/R/pkg_abort.R
@@ -200,36 +200,17 @@ expect_pkg_error_snapshot <- function(
   env = caller_env()
 ) {
   # nocov start
-  rlang::check_installed("testthat", "to snapshot-test package errors")
-  obj_expr <- .strip_covr_from_expr(rlang::enexpr(object))
-  error_class_components <- rlang::list2(...)
-  # Inject expect_pkg_error_classes into env if not already findable, so this
-  # works even when the caller's package doesn't attach stbl. Evaluating
-  # directly in env (rather than a child) ensures assignments inside object are
-  # visible to the caller after this function returns.
-  if (!exists("expect_pkg_error_classes", envir = env, inherits = TRUE)) {
-    env$expect_pkg_error_classes <- expect_pkg_error_classes
-    on.exit(rm("expect_pkg_error_classes", envir = env), add = TRUE)
-  }
-  # Build the call to expect_snapshot() at runtime with rlang::call2() so it
-  # carries no source-reference attributes. covr attaches counter calls to
-  # source references; a runtime-built expression has none, so the snapshot
-  # Code section stays stable across normal and coverage runs.
-  snap_call <- rlang::call2(
-    "expect_snapshot",
-    rlang::call2(
-      "(",
-      rlang::call2(
-        "expect_pkg_error_classes",
-        obj_expr,
-        package,
-        !!!error_class_components
-      )
-    ),
+  .expect_pkg_condition_snapshot(
+    obj_expr = .strip_covr_from_expr(rlang::enexpr(object)),
+    package = package,
+    class_components = rlang::list2(...),
+    expect_fn_name = "expect_pkg_error_classes",
+    expect_fn = expect_pkg_error_classes,
+    check_installed_msg = "to snapshot-test package errors",
+    error = TRUE,
     transform = transform,
     variant = variant,
-    .ns = "testthat"
+    env = env
   )
-  eval(snap_call, envir = env)
   # nocov end
 }

--- a/R/pkg_inform.R
+++ b/R/pkg_inform.R
@@ -149,6 +149,7 @@ expect_pkg_message_snapshot <- function(
     expect_fn_name = "expect_pkg_message_classes",
     expect_fn = expect_pkg_message_classes,
     check_installed_msg = "to snapshot-test package messages",
+    error = FALSE,
     transform = transform,
     variant = variant,
     env = env

--- a/R/pkg_warn.R
+++ b/R/pkg_warn.R
@@ -148,6 +148,7 @@ expect_pkg_warning_snapshot <- function(
     expect_fn_name = "expect_pkg_warning_classes",
     expect_fn = expect_pkg_warning_classes,
     check_installed_msg = "to snapshot-test package warnings",
+    error = FALSE,
     transform = transform,
     variant = variant,
     env = env

--- a/R/utils-conditions.R
+++ b/R/utils-conditions.R
@@ -42,6 +42,9 @@
 #' @param expect_fn (`function`) The function to inject if not already findable.
 #' @param check_installed_msg (`character(1)`) The `"to ..."` string passed to
 #'   [rlang::check_installed()].
+#' @param error (`logical(1)`) Passed to [testthat::expect_snapshot()]. Set to
+#'   `TRUE` when snapshotting an error, so the error is captured rather than
+#'   propagated.
 #' @inheritParams expect_pkg_warning_snapshot
 #' @returns The result of [testthat::expect_snapshot()], invisibly.
 #' @keywords internal
@@ -52,6 +55,7 @@
   expect_fn_name,
   expect_fn,
   check_installed_msg,
+  error,
   transform,
   variant,
   env
@@ -62,17 +66,21 @@
     env[[expect_fn_name]] <- expect_fn
     on.exit(rm(list = expect_fn_name, envir = env), add = TRUE)
   }
+  # Check the condition's class hierarchy first, then snapshot the bare
+  # expression so the snapshot mirrors testthat::expect_snapshot() output while
+  # still recording the class via cnd_class = TRUE (#301).
+  class_check_call <- rlang::call2(
+    expect_fn_name,
+    obj_expr,
+    package,
+    !!!class_components
+  )
+  eval(class_check_call, envir = env)
   snap_call <- rlang::call2(
     "expect_snapshot",
-    rlang::call2(
-      "(",
-      rlang::call2(
-        expect_fn_name,
-        obj_expr,
-        package,
-        !!!class_components
-      )
-    ),
+    obj_expr,
+    error = error,
+    cnd_class = TRUE,
     transform = transform,
     variant = variant,
     .ns = "testthat"

--- a/man/dot-expect_pkg_condition_snapshot.Rd
+++ b/man/dot-expect_pkg_condition_snapshot.Rd
@@ -11,6 +11,7 @@
   expect_fn_name,
   expect_fn,
   check_installed_msg,
+  error,
   transform,
   variant,
   env
@@ -31,6 +32,10 @@ to look up or inject into \code{env}.}
 
 \item{check_installed_msg}{(\code{character(1)}) The \code{"to ..."} string passed to
 \code{\link[rlang:check_installed]{rlang::check_installed()}}.}
+
+\item{error}{(\code{logical(1)}) Passed to \code{\link[testthat:expect_snapshot]{testthat::expect_snapshot()}}. Set to
+\code{TRUE} when snapshotting an error, so the error is captured rather than
+propagated.}
 
 \item{transform}{(\code{function} or \code{NULL}) Optional function to scrub volatile
 output (e.g. temp paths) before snapshot comparison. Passed through to

--- a/tests/testthat/_snaps/aaa-conditions.md
+++ b/tests/testthat/_snaps/aaa-conditions.md
@@ -1,10 +1,8 @@
 # .stbl_abort() throws the expected error (#95)
 
     Code
-      (expect_pkg_error_classes(.stbl_abort("A message.", "a_subclass"), "stbl",
-      "a_subclass"))
-    Output
-      <error/stbl-error-a_subclass>
+      .stbl_abort("A message.", "a_subclass")
+    Condition <stbl-error-a_subclass>
       Error:
       ! A message.
 
@@ -26,10 +24,8 @@
 # .stop_cant_coerce() throws the expected error (#95)
 
     Code
-      (expect_pkg_error_classes(.stop_cant_coerce("character", "integer", "my_arg",
-        rlang::current_env()), "stbl", "coerce", "integer"))
-    Output
-      <error/stbl-error-coerce-integer>
+      .stop_cant_coerce("character", "integer", "my_arg", rlang::current_env())
+    Condition <stbl-error-coerce-integer>
       Error:
       ! Can't coerce `my_arg` <character> to <integer>.
 
@@ -46,20 +42,16 @@
 # .stop_must() throws the expected error (#95)
 
     Code
-      (expect_pkg_error_classes(.stop_must("must be a foo.", "my_arg", rlang::current_env()),
-      "stbl", "must"))
-    Output
-      <error/stbl-error-must>
+      .stop_must("must be a foo.", "my_arg", rlang::current_env())
+    Condition <stbl-error-must>
       Error:
       ! `my_arg` must be a foo.
 
 # .stop_must() handles subclasses (#95)
 
     Code
-      (expect_pkg_error_classes(.stop_must("must be a foo.", "my_arg", rlang::current_env(),
-      subclass = "my_custom_class"), "stbl", "my_custom_class"))
-    Output
-      <error/stbl-error-my_custom_class>
+      .stop_must("must be a foo.", "my_arg", rlang::current_env(), subclass = "my_custom_class")
+    Condition <stbl-error-my_custom_class>
       Error:
       ! `my_arg` must be a foo.
 
@@ -76,21 +68,17 @@
 # .stop_null() throws the expected error (#95)
 
     Code
-      (expect_pkg_error_classes(.stop_null("my_arg", rlang::current_env()), "stbl",
-      "bad_null"))
-    Output
-      <error/stbl-error-bad_null>
+      .stop_null("my_arg", rlang::current_env())
+    Condition <stbl-error-bad_null>
       Error:
       ! `my_arg` must not be <NULL>.
 
 # .stop_incompatible() throws the expected error (#95)
 
     Code
-      (expect_pkg_error_classes(.stop_incompatible("character", integer(), c(FALSE,
-        TRUE, FALSE, TRUE), "some reason", "my_arg", rlang::current_env()), "stbl",
-      "incompatible_type"))
-    Output
-      <error/stbl-error-incompatible_type>
+      .stop_incompatible("character", integer(), c(FALSE, TRUE, FALSE, TRUE),
+      "some reason", "my_arg", rlang::current_env())
+    Condition <stbl-error-incompatible_type>
       Error:
       ! `my_arg` <character> must be coercible to <integer>
       x Can't convert some values due to some reason.
@@ -99,11 +87,9 @@
 # .stop_incompatible() passes dots (#95)
 
     Code
-      (expect_pkg_error_classes(.stop_incompatible("character", integer(), c(FALSE,
-        TRUE, FALSE, TRUE), "some reason", "my_arg", rlang::current_env(), .internal = TRUE),
-      "stbl", "incompatible_type"))
-    Output
-      <error/stbl-error-incompatible_type>
+      .stop_incompatible("character", integer(), c(FALSE, TRUE, FALSE, TRUE),
+      "some reason", "my_arg", rlang::current_env(), .internal = TRUE)
+    Condition <stbl-error-incompatible_type>
       Error:
       ! `my_arg` <character> must be coercible to <integer>
       x Can't convert some values due to some reason.

--- a/tests/testthat/_snaps/assert_present.md
+++ b/tests/testthat/_snaps/assert_present.md
@@ -1,9 +1,8 @@
 # assert_present() errors for NULL (#110, #299)
 
     Code
-      (expect_pkg_error_classes(assert_present(NULL), "stbl", "bad_null"))
-    Output
-      <error/stbl-error-bad_null>
+      assert_present(NULL)
+    Condition <stbl-error-bad_null>
       Error:
       ! `NULL` must not be <NULL>.
 

--- a/tests/testthat/_snaps/check.md
+++ b/tests/testthat/_snaps/check.md
@@ -1,10 +1,8 @@
 # .check_na() works (#95)
 
     Code
-      (expect_pkg_error_classes(.check_na(c(1, NA), allow_na = FALSE), "stbl",
-      "bad_na"))
-    Output
-      <error/stbl-error-bad_na>
+      .check_na(c(1, NA), allow_na = FALSE)
+    Condition <stbl-error-bad_na>
       Error:
       ! `c(1, NA)` must not contain NA values.
       * NA locations: 2
@@ -12,9 +10,8 @@
 # .check_size() works (#95)
 
     Code
-      (expect_pkg_error_classes(.check_size(1:5, 6, 10), "stbl", "size_too_small"))
-    Output
-      <error/stbl-error-size_too_small>
+      .check_size(1:5, 6, 10)
+    Condition <stbl-error-size_too_small>
       Error:
       ! `1:5` must have size >= 6.
       x 5 is too small.
@@ -22,9 +19,8 @@
 ---
 
     Code
-      (expect_pkg_error_classes(.check_size(1:5, 1, 4), "stbl", "size_too_large"))
-    Output
-      <error/stbl-error-size_too_large>
+      .check_size(1:5, 1, 4)
+    Condition <stbl-error-size_too_large>
       Error:
       ! `1:5` must have size <= 4.
       x 5 is too big.
@@ -32,9 +28,8 @@
 # .check_scalar() works (#95)
 
     Code
-      (expect_pkg_error_classes(.check_scalar(1:2), "stbl", "non_scalar"))
-    Output
-      <error/stbl-error-non_scalar>
+      .check_scalar(1:2)
+    Condition <stbl-error-non_scalar>
       Error:
       ! `1:2` must be a single <integer>.
       x `1:2` has 2 values.
@@ -42,10 +37,8 @@
 ---
 
     Code
-      (expect_pkg_error_classes(.check_scalar(NULL, allow_null = FALSE), "stbl",
-      "non_scalar"))
-    Output
-      <error/stbl-error-non_scalar>
+      .check_scalar(NULL, allow_null = FALSE)
+    Condition <stbl-error-non_scalar>
       Error:
       ! `NULL` must be a single <non-NULL>.
       x `NULL` has no values.
@@ -53,10 +46,8 @@
 ---
 
     Code
-      (expect_pkg_error_classes(.check_scalar(character(), allow_zero_length = FALSE),
-      "stbl", "bad_empty"))
-    Output
-      <error/stbl-error-bad_empty>
+      .check_scalar(character(), allow_zero_length = FALSE)
+    Condition <stbl-error-bad_empty>
       Error:
       ! `character()` must be a single <character (non-empty)>.
       x `character()` has no values.
@@ -64,9 +55,8 @@
 # .check_x_no_more_than_y() works (#95)
 
     Code
-      (expect_pkg_error_classes(.check_x_no_more_than_y(2, 1), "stbl", "size_x_vs_y"))
-    Output
-      <error/stbl-error-size_x_vs_y>
+      .check_x_no_more_than_y(2, 1)
+    Condition <stbl-error-size_x_vs_y>
       Error:
       ! `2` can't be larger than `1`.
       * `2` = 2
@@ -75,11 +65,9 @@
 # .check_cast_failures() works
 
     Code
-      (expect_pkg_error_classes(.check_cast_failures(failures = failures, x_class = "character",
-        to = logical(), due_to = "incompatible values", x_arg = "test_arg", call = rlang::current_env()),
-      "stbl", "incompatible_type"))
-    Output
-      <error/stbl-error-incompatible_type>
+      .check_cast_failures(failures = failures, x_class = "character", to = logical(),
+      due_to = "incompatible values", x_arg = "test_arg", call = rlang::current_env())
+    Condition <stbl-error-incompatible_type>
       Error:
       ! `test_arg` <character> must be coercible to <logical>
       x Can't convert some values due to incompatible values.
@@ -88,19 +76,16 @@
 # .check_all_named() works (#203)
 
     Code
-      (expect_pkg_error_classes(.check_all_named(list(1, 2)), "stbl", "bad_named"))
-    Output
-      <error/stbl-error-bad_named>
+      .check_all_named(list(1, 2))
+    Condition <stbl-error-bad_named>
       Error:
       ! `list(1, 2)` must have all elements named.
 
 # .check_not_jagged() works (#203)
 
     Code
-      (expect_pkg_error_classes(.check_not_jagged(list(a = 1:3, b = 1:2)), "stbl",
-      "jagged"))
-    Output
-      <error/stbl-error-jagged>
+      .check_not_jagged(list(a = 1:3, b = 1:2))
+    Condition <stbl-error-jagged>
       Error:
       ! Can't coerce `list(a = 1:3, b = 1:2)` <list> to <data.frame>.
       i All list elements must have length 3 or 1.

--- a/tests/testthat/_snaps/pkg_abort.md
+++ b/tests/testthat/_snaps/pkg_abort.md
@@ -19,10 +19,8 @@
 # pkg_abort() passes dots to cli_abort() (#136)
 
     Code
-      (expect_pkg_error_classes(wrapped_abort("A message.", "a_subclass", .internal = TRUE),
-      "wrapped", "a_subclass"))
-    Output
-      <error/wrapped-error-a_subclass>
+      wrapped_abort("A message.", "a_subclass", .internal = TRUE)
+    Condition <wrapped-error-a_subclass>
       Error in `wrapped_abort()`:
       ! A message.
       i This is an internal error.
@@ -35,33 +33,27 @@
       Error in `wrapped_abort()`:
       ! This message comes from a custom environment.
 
-# expect_pkg_error_snapshot() snapshots error class and message (#188)
+# expect_pkg_error_snapshot() snapshots error class and message (#188, #301)
 
     Code
-      (expect_pkg_error_classes(pkg_abort("stbl", "A snapshot error.",
-        "snapshot_subclass"), "stbl", "snapshot_subclass"))
-    Output
-      <error/stbl-error-snapshot_subclass>
+      pkg_abort("stbl", "A snapshot error.", "snapshot_subclass")
+    Condition <stbl-error-snapshot_subclass>
       Error:
       ! A snapshot error.
 
-# expect_pkg_error_snapshot() works with multiple class components (#188)
+# expect_pkg_error_snapshot() works with multiple class components (#188, #301)
 
     Code
-      (expect_pkg_error_classes(pkg_abort("stbl", "A nested error.", c("outer",
-        "inner")), "stbl", "outer", "inner"))
-    Output
-      <error/stbl-error-outer-inner>
+      pkg_abort("stbl", "A nested error.", c("outer", "inner"))
+    Condition <stbl-error-outer-inner>
       Error:
       ! A nested error.
 
-# expect_pkg_error_snapshot() works from an env without stbl attached (#188)
+# expect_pkg_error_snapshot() works from an env without stbl attached (#188, #301)
 
     Code
-      (expect_pkg_error_classes(pkg_abort("otherpkg", "Foreign env error.",
-        "foreign_subclass"), "otherpkg", "foreign_subclass"))
-    Output
-      <error/otherpkg-error-foreign_subclass>
+      pkg_abort("otherpkg", "Foreign env error.", "foreign_subclass")
+    Condition <otherpkg-error-foreign_subclass>
       Error:
       ! Foreign env error.
 

--- a/tests/testthat/_snaps/pkg_inform.md
+++ b/tests/testthat/_snaps/pkg_inform.md
@@ -21,44 +21,31 @@
     Message <wrapped-message-subclass>
       This message comes from a custom environment.
 
-# expect_pkg_message_snapshot() snapshots message class and message (#213)
+# expect_pkg_message_snapshot() snapshots message class and message (#213, #301)
 
     Code
-      (expect_pkg_message_classes(pkg_inform("stbl", "A snapshot message.",
-        "snapshot_subclass"), "stbl", "snapshot_subclass"))
-    Output
-      <message/stbl-message-snapshot_subclass>
-      Message:
+      pkg_inform("stbl", "A snapshot message.", "snapshot_subclass")
+    Message <stbl-message-snapshot_subclass>
       A snapshot message.
 
-# expect_pkg_message_snapshot() works with multiple class components (#213)
+# expect_pkg_message_snapshot() works with multiple class components (#213, #301)
 
     Code
-      (expect_pkg_message_classes(pkg_inform("stbl", "A nested message.", c("outer",
-        "inner")), "stbl", "outer", "inner"))
-    Output
-      <message/stbl-message-outer-inner>
-      Message:
+      pkg_inform("stbl", "A nested message.", c("outer", "inner"))
+    Message <stbl-message-outer-inner>
       A nested message.
 
-# expect_pkg_message_snapshot() allows object definition inside expression (#234)
+# expect_pkg_message_snapshot() allows object definition inside expression (#234, #301)
 
     Code
-      (expect_pkg_message_classes({
-        result <- informs_and_returns()
-      }, "stbl", "return_subclass"))
-    Output
-      <message/stbl-message-return_subclass>
-      Message in `informs_and_returns()`:
+      result <- informs_and_returns()
+    Message <stbl-message-return_subclass>
       A message with a return value.
 
-# expect_pkg_message_snapshot() works from an env without stbl attached (#213)
+# expect_pkg_message_snapshot() works from an env without stbl attached (#213, #301)
 
     Code
-      (expect_pkg_message_classes(pkg_inform("otherpkg", "Foreign env message.",
-        "foreign_subclass"), "otherpkg", "foreign_subclass"))
-    Output
-      <message/otherpkg-message-foreign_subclass>
-      Message:
+      pkg_inform("otherpkg", "Foreign env message.", "foreign_subclass")
+    Message <otherpkg-message-foreign_subclass>
       Foreign env message.
 

--- a/tests/testthat/_snaps/pkg_warn.md
+++ b/tests/testthat/_snaps/pkg_warn.md
@@ -24,44 +24,35 @@
       Warning in `wrapped_warn()`:
       This message comes from a custom environment.
 
-# expect_pkg_warning_snapshot() snapshots warning class and message (#213)
+# expect_pkg_warning_snapshot() snapshots warning class and message (#213, #301)
 
     Code
-      (expect_pkg_warning_classes(pkg_warn("stbl", "A snapshot warning.",
-        "snapshot_subclass"), "stbl", "snapshot_subclass"))
-    Output
-      <warning/stbl-warning-snapshot_subclass>
+      pkg_warn("stbl", "A snapshot warning.", "snapshot_subclass")
+    Condition <stbl-warning-snapshot_subclass>
       Warning:
       A snapshot warning.
 
-# expect_pkg_warning_snapshot() works with multiple class components (#213)
+# expect_pkg_warning_snapshot() works with multiple class components (#213, #301)
 
     Code
-      (expect_pkg_warning_classes(pkg_warn("stbl", "A nested warning.", c("outer",
-        "inner")), "stbl", "outer", "inner"))
-    Output
-      <warning/stbl-warning-outer-inner>
+      pkg_warn("stbl", "A nested warning.", c("outer", "inner"))
+    Condition <stbl-warning-outer-inner>
       Warning:
       A nested warning.
 
-# expect_pkg_warning_snapshot() allows object definition inside expression (#234)
+# expect_pkg_warning_snapshot() allows object definition inside expression (#234, #301)
 
     Code
-      (expect_pkg_warning_classes({
-        result <- warns_and_returns()
-      }, "stbl", "return_subclass"))
-    Output
-      <warning/stbl-warning-return_subclass>
+      result <- warns_and_returns()
+    Condition <stbl-warning-return_subclass>
       Warning in `warns_and_returns()`:
       A warning with a return value.
 
-# expect_pkg_warning_snapshot() works from an env without stbl attached (#213)
+# expect_pkg_warning_snapshot() works from an env without stbl attached (#213, #301)
 
     Code
-      (expect_pkg_warning_classes(pkg_warn("otherpkg", "Foreign env warning.",
-        "foreign_subclass"), "otherpkg", "foreign_subclass"))
-    Output
-      <warning/otherpkg-warning-foreign_subclass>
+      pkg_warn("otherpkg", "Foreign env warning.", "foreign_subclass")
+    Condition <otherpkg-warning-foreign_subclass>
       Warning:
       Foreign env warning.
 

--- a/tests/testthat/_snaps/specify_cls.md
+++ b/tests/testthat/_snaps/specify_cls.md
@@ -36,11 +36,8 @@
 # The function built via specify_cls errors informatively for duplicated args (#150, #153, #161)
 
     Code
-      (expect_pkg_error_classes({
-        no_null(NULL, allow_null = FALSE)
-      }, "stbl", "duplicate_args"))
-    Output
-      <error/stbl-error-duplicate_args>
+      no_null(NULL, allow_null = FALSE)
+    Condition <stbl-error-duplicate_args>
       Error in `no_null()`:
       ! Arguments passed via `...` cannot duplicate specification.
       i Duplicated arguments: `allow_null`

--- a/tests/testthat/_snaps/specify_df.md
+++ b/tests/testthat/_snaps/specify_df.md
@@ -1,20 +1,16 @@
 # specify_df() errors when required column is missing (#142)
 
     Code
-      (expect_pkg_error_classes(validator(data.frame(name = "Alice")), "stbl",
-      "missing_element"))
-    Output
-      <error/stbl-error-missing_element>
+      validator(data.frame(name = "Alice"))
+    Condition <stbl-error-missing_element>
       Error:
       ! `data.frame(name = "Alice")` must contain element "age".
 
 # specify_df() passes through .min_rows, .max_rows (#142)
 
     Code
-      (expect_pkg_error_classes(validator(data.frame(a = 1L)), "stbl", "too_few_rows")
-      )
-    Output
-      <error/stbl-error-too_few_rows>
+      validator(data.frame(a = 1L))
+    Condition <stbl-error-too_few_rows>
       Error:
       ! `data.frame(a = 1L)` must have at least 2 rows.
       x 1 is too few.
@@ -22,10 +18,8 @@
 # specify_df() passes through .col_names (#142)
 
     Code
-      (expect_pkg_error_classes(validator(data.frame(a = 1L)), "stbl", "missing_cols")
-      )
-    Output
-      <error/stbl-error-missing_cols>
+      validator(data.frame(a = 1L))
+    Condition <stbl-error-missing_cols>
       Error:
       ! `data.frame(a = 1L)` must contain column "b".
 

--- a/tests/testthat/_snaps/stabilize_any_of.md
+++ b/tests/testthat/_snaps/stabilize_any_of.md
@@ -1,10 +1,8 @@
 # stabilize_any_of() errors with a combined message when all functions fail (#215, #285)
 
     Code
-      (expect_pkg_error_classes(stabilize_any_of(NULL, specify_int(allow_null = FALSE),
-      specify_chr(allow_null = FALSE)), "stbl", "cant_stabilize_any_of"))
-    Output
-      <error/stbl-error-cant_stabilize_any_of>
+      stabilize_any_of(NULL, specify_int(allow_null = FALSE), specify_chr(allow_null = FALSE))
+    Condition <stbl-error-cant_stabilize_any_of>
       Error:
       ! `NULL` must match at least one of the provided stabilizers.
       x `NULL` must not be <NULL>.
@@ -13,11 +11,9 @@
 ---
 
     Code
-      (expect_pkg_error_classes(wrapped_stabilize_any_of(NULL, specify_int(
-        allow_null = FALSE), specify_chr(allow_null = FALSE)), "stbl",
-      "cant_stabilize_any_of"))
-    Output
-      <error/stbl-error-cant_stabilize_any_of>
+      wrapped_stabilize_any_of(NULL, specify_int(allow_null = FALSE), specify_chr(
+        allow_null = FALSE))
+    Condition <stbl-error-cant_stabilize_any_of>
       Error in `wrapped_stabilize_any_of()`:
       ! `val` must match at least one of the provided stabilizers.
       x `val` must not be <NULL>.
@@ -26,10 +22,8 @@
 # stabilize_any_of() includes Locations from incompatible_type errors (#215, #285)
 
     Code
-      (expect_pkg_error_classes(stabilize_any_of(x, stabilize_lgl, stabilize_int),
-      "stbl", "cant_stabilize_any_of"))
-    Output
-      <error/stbl-error-cant_stabilize_any_of>
+      stabilize_any_of(x, stabilize_lgl, stabilize_int)
+    Condition <stbl-error-cant_stabilize_any_of>
       Error:
       ! `x` must match at least one of the provided stabilizers.
       x `x` <character> must be coercible to <logical> (Locations: 1)
@@ -38,10 +32,8 @@
 ---
 
     Code
-      (expect_pkg_error_classes(wrapped_stabilize_any_of(x, stabilize_lgl,
-        stabilize_int), "stbl", "cant_stabilize_any_of"))
-    Output
-      <error/stbl-error-cant_stabilize_any_of>
+      wrapped_stabilize_any_of(x, stabilize_lgl, stabilize_int)
+    Condition <stbl-error-cant_stabilize_any_of>
       Error in `wrapped_stabilize_any_of()`:
       ! `val` must match at least one of the provided stabilizers.
       x `val` <character> must be coercible to <logical> (Locations: 1)
@@ -50,9 +42,8 @@
 # stabilize_any_of() errors when ... is empty (#215, #285)
 
     Code
-      (expect_pkg_error_classes(stabilize_any_of(1L), "stbl", "empty_specs"))
-    Output
-      <error/stbl-error-empty_specs>
+      stabilize_any_of(1L)
+    Condition <stbl-error-empty_specs>
       Error:
       ! At least one function must be provided via `...`.
       i Supply stabilizer functions, or prototypes for `to_any_of()`.
@@ -60,10 +51,8 @@
 # stabilize_any_of() errors when ... contains named elements (#215, #285)
 
     Code
-      (expect_pkg_error_classes(stabilize_any_of(1L, int = stabilize_int), "stbl",
-      "named_spec"))
-    Output
-      <error/stbl-error-named_spec>
+      stabilize_any_of(1L, int = stabilize_int)
+    Condition <stbl-error-named_spec>
       Error:
       ! All elements passed via `...` must be unnamed.
       i Functions are applied to `x` in sequence, not by name.

--- a/tests/testthat/_snaps/stabilize_arg.md
+++ b/tests/testthat/_snaps/stabilize_arg.md
@@ -21,30 +21,24 @@
 # stabilize_arg() rejects NULLs when asked (#11, #58, #99)
 
     Code
-      (expect_pkg_error_classes(stabilize_arg(given, allow_null = FALSE), "stbl",
-      "bad_null"))
-    Output
-      <error/stbl-error-bad_null>
+      stabilize_arg(given, allow_null = FALSE)
+    Condition <stbl-error-bad_null>
       Error:
       ! `given` must not be <NULL>.
 
 ---
 
     Code
-      (expect_pkg_error_classes(wrapped_stabilize_arg(given, allow_null = FALSE),
-      "stbl", "bad_null"))
-    Output
-      <error/stbl-error-bad_null>
+      wrapped_stabilize_arg(given, allow_null = FALSE)
+    Condition <stbl-error-bad_null>
       Error in `wrapped_stabilize_arg()`:
       ! `val` must not be <NULL>.
 
 # stabilize_arg() checks NAs (#11, #58, #99)
 
     Code
-      (expect_pkg_error_classes(stabilize_arg(given, allow_na = FALSE), "stbl",
-      "bad_na"))
-    Output
-      <error/stbl-error-bad_na>
+      stabilize_arg(given, allow_na = FALSE)
+    Condition <stbl-error-bad_na>
       Error:
       ! `given` must not contain NA values.
       * NA locations: 4 and 7
@@ -52,10 +46,8 @@
 ---
 
     Code
-      (expect_pkg_error_classes(wrapped_stabilize_arg(given, allow_na = FALSE),
-      "stbl", "bad_na"))
-    Output
-      <error/stbl-error-bad_na>
+      wrapped_stabilize_arg(given, allow_na = FALSE)
+    Condition <stbl-error-bad_na>
       Error in `wrapped_stabilize_arg()`:
       ! `val` must not contain NA values.
       * NA locations: 4 and 7
@@ -63,10 +55,8 @@
 # stabilize_arg() checks size args (#11, #58, #99)
 
     Code
-      (expect_pkg_error_classes(stabilize_arg(given, min_size = 2, max_size = 1),
-      "stbl", "size_x_vs_y"))
-    Output
-      <error/stbl-error-size_x_vs_y>
+      stabilize_arg(given, min_size = 2, max_size = 1)
+    Condition <stbl-error-size_x_vs_y>
       Error:
       ! `min_size` can't be larger than `max_size`.
       * `min_size` = 2
@@ -75,10 +65,8 @@
 ---
 
     Code
-      (expect_pkg_error_classes(wrapped_stabilize_arg(given, min_size = 2, max_size = 1),
-      "stbl", "size_x_vs_y"))
-    Output
-      <error/stbl-error-size_x_vs_y>
+      wrapped_stabilize_arg(given, min_size = 2, max_size = 1)
+    Condition <stbl-error-size_x_vs_y>
       Error in `wrapped_stabilize_arg()`:
       ! `min_size` can't be larger than `max_size`.
       * `min_size` = 2
@@ -87,10 +75,8 @@
 # stabilize_arg() checks min_size (#11, #58, #99)
 
     Code
-      (expect_pkg_error_classes(stabilize_arg(given, min_size = 11), "stbl",
-      "size_too_small"))
-    Output
-      <error/stbl-error-size_too_small>
+      stabilize_arg(given, min_size = 11)
+    Condition <stbl-error-size_too_small>
       Error:
       ! `given` must have size >= 11.
       x 3 is too small.
@@ -98,10 +84,8 @@
 ---
 
     Code
-      (expect_pkg_error_classes(wrapped_stabilize_arg(given, min_size = 11), "stbl",
-      "size_too_small"))
-    Output
-      <error/stbl-error-size_too_small>
+      wrapped_stabilize_arg(given, min_size = 11)
+    Condition <stbl-error-size_too_small>
       Error in `wrapped_stabilize_arg()`:
       ! `val` must have size >= 11.
       x 3 is too small.
@@ -109,10 +93,8 @@
 # stabilize_arg() checks max_size (#11, #58)
 
     Code
-      (expect_pkg_error_classes(stabilize_arg(given, max_size = 2), "stbl",
-      "size_too_large"))
-    Output
-      <error/stbl-error-size_too_large>
+      stabilize_arg(given, max_size = 2)
+    Condition <stbl-error-size_too_large>
       Error:
       ! `given` must have size <= 2.
       x 3 is too big.
@@ -120,10 +102,8 @@
 ---
 
     Code
-      (expect_pkg_error_classes(wrapped_stabilize_arg(given, max_size = 2), "stbl",
-      "size_too_large"))
-    Output
-      <error/stbl-error-size_too_large>
+      wrapped_stabilize_arg(given, max_size = 2)
+    Condition <stbl-error-size_too_large>
       Error in `wrapped_stabilize_arg()`:
       ! `val` must have size <= 2.
       x 3 is too big.
@@ -131,9 +111,8 @@
 # stabilize_arg_scalar() errors for non-scalars (#12, #58)
 
     Code
-      (expect_pkg_error_classes(stabilize_arg_scalar(given), "stbl", "non_scalar"))
-    Output
-      <error/stbl-error-non_scalar>
+      stabilize_arg_scalar(given)
+    Condition <stbl-error-non_scalar>
       Error:
       ! `given` must be a single <integer>.
       x `given` has 10 values.
@@ -141,10 +120,8 @@
 ---
 
     Code
-      (expect_pkg_error_classes(wrapped_stabilize_arg_scalar(given), "stbl",
-      "non_scalar"))
-    Output
-      <error/stbl-error-non_scalar>
+      wrapped_stabilize_arg_scalar(given)
+    Condition <stbl-error-non_scalar>
       Error in `wrapped_stabilize_arg_scalar()`:
       ! `val` must be a single <integer>.
       x `val` has 10 values.
@@ -152,10 +129,8 @@
 # stabilize_arg_scalar() respects allow_null (#12, #58)
 
     Code
-      (expect_pkg_error_classes(stabilize_arg_scalar(given, allow_null = FALSE),
-      "stbl", "non_scalar"))
-    Output
-      <error/stbl-error-non_scalar>
+      stabilize_arg_scalar(given, allow_null = FALSE)
+    Condition <stbl-error-non_scalar>
       Error:
       ! `given` must be a single <non-NULL>.
       x `given` has no values.
@@ -163,10 +138,8 @@
 ---
 
     Code
-      (expect_pkg_error_classes(wrapped_stabilize_arg_scalar(given, allow_null = FALSE),
-      "stbl", "non_scalar"))
-    Output
-      <error/stbl-error-non_scalar>
+      wrapped_stabilize_arg_scalar(given, allow_null = FALSE)
+    Condition <stbl-error-non_scalar>
       Error in `wrapped_stabilize_arg_scalar()`:
       ! `val` must be a single <non-NULL>.
       x `val` has no values.
@@ -174,10 +147,8 @@
 # stabilize_arg_scalar() errors on weird internal arg values (#12, #58)
 
     Code
-      (expect_pkg_error_classes(stabilize_arg_scalar(given, allow_null = c(TRUE,
-        FALSE)), "stbl", "non_scalar"))
-    Output
-      <error/stbl-error-non_scalar>
+      stabilize_arg_scalar(given, allow_null = c(TRUE, FALSE))
+    Condition <stbl-error-non_scalar>
       Error:
       ! `allow_null` must be a single <logical>.
       x `allow_null` has 2 values.

--- a/tests/testthat/_snaps/stabilize_chr.md
+++ b/tests/testthat/_snaps/stabilize_chr.md
@@ -1,10 +1,8 @@
 # stabilize_chr() errors for bad regex matches (#27, #52)
 
     Code
-      (expect_pkg_error_classes(stabilize_chr(given, regex = pattern), "stbl", "must")
-      )
-    Output
-      <error/stbl-error-must>
+      stabilize_chr(given, regex = pattern)
+    Condition <stbl-error-must>
       Error:
       ! `given` must match the regex pattern "^\\d{5}(?:[-\\s]\\d{4})?$"
       x Some values fail the check.
@@ -14,10 +12,8 @@
 ---
 
     Code
-      (expect_pkg_error_classes(wrapped_stabilize_chr(given, regex = pattern), "stbl",
-      "must"))
-    Output
-      <error/stbl-error-must>
+      wrapped_stabilize_chr(given, regex = pattern)
+    Condition <stbl-error-must>
       Error in `wrapped_stabilize_chr()`:
       ! `val` must match the regex pattern "^\\d{5}(?:[-\\s]\\d{4})?$"
       x Some values fail the check.
@@ -34,10 +30,8 @@
 ---
 
     Code
-      (expect_pkg_error_classes(stabilize_chr(c("example.com", "not a url"), regex = url_regex),
-      "stbl", "must"))
-    Output
-      <error/stbl-error-must>
+      stabilize_chr(c("example.com", "not a url"), regex = url_regex)
+    Condition <stbl-error-must>
       Error:
       ! `c("example.com", "not a url")` must match the regex pattern "^(?:(?:(?:https?|ftp):)?\\/\\/)?(?:\\S+(?::\\S*)?@)?(?:(?!(?:10|127)(?:\\.\\d{1,3}){3})(?!(?:169\\.254|192\\.168)(?:\\.\\d{1,3}){2})(?!172\\.(?:1[6-9]|2\\d|3[0-1])(?:\\.\\d{1,3}){2})(?:[1-9]\\d?|1\\d\\d|2[01]\\d|22[0-3])(?:\\.(?:1?\\d{1,2}|2[0-4]\\d|25[0-5])){2}(?:\\.(?:[1-9]\\d?|1\\d\\d|2[0-4]\\d|25[0-4]))|(?:(?:[a-z0-9\\u00a1-\\uffff][a-z0-9\\u00a1-\\uffff_-]{0,62})?[a-z0-9\\u00a1-\\uffff]\\.)+(?:[a-z\\u00a1-\\uffff]{2,}\\.?))(?::\\d{2,5})?(?:[/?#]\\S*)?$"
       x Some values fail the check.
@@ -47,10 +41,8 @@
 # stabilize_chr() allows for customized error messages (#52)
 
     Code
-      (expect_pkg_error_classes(stabilize_chr(c("not a url", "example.com"), regex = c(
-        `must be a url.` = url_regex)), "stbl", "must"))
-    Output
-      <error/stbl-error-must>
+      stabilize_chr(c("not a url", "example.com"), regex = c(`must be a url.` = url_regex))
+    Condition <stbl-error-must>
       Error:
       ! `c("not a url", "example.com")` must be a url.
       x Some values fail the check.
@@ -60,10 +52,8 @@
 # stabilize_chr() works with regex that contains braces (#52)
 
     Code
-      (expect_pkg_error_classes(stabilize_chr(c("b", "aa"), regex = "a{1,3}"), "stbl",
-      "must"))
-    Output
-      <error/stbl-error-must>
+      stabilize_chr(c("b", "aa"), regex = "a{1,3}")
+    Condition <stbl-error-must>
       Error:
       ! `c("b", "aa")` must match the regex pattern "a{1,3}"
       x Some values fail the check.
@@ -73,9 +63,8 @@
 # stabilize_chr() accepts negated regex args (#85)
 
     Code
-      (expect_pkg_error_classes(stabilize_chr(given, regex = regex), "stbl", "must"))
-    Output
-      <error/stbl-error-must>
+      stabilize_chr(given, regex = regex)
+    Condition <stbl-error-must>
       Error:
       ! `given` must not match the regex pattern "c"
       x Some values fail the check.
@@ -85,9 +74,8 @@
 # stabilize_chr() accepts multiple regex rules (#86, #85)
 
     Code
-      (expect_pkg_error_classes(stabilize_chr(given, regex = rules), "stbl", "must"))
-    Output
-      <error/stbl-error-must>
+      stabilize_chr(given, regex = rules)
+    Condition <stbl-error-must>
       Error:
       ! `given` must match the regex pattern "a"
       x Some values fail the check.
@@ -101,10 +89,8 @@
 # stabilize_chr() works with stringr::fixed() (#87)
 
     Code
-      (expect_pkg_error_classes(stabilize_chr(c("a.b", "acb"), regex = stringr::fixed(
-        "a.b")), "stbl", "must"))
-    Output
-      <error/stbl-error-must>
+      stabilize_chr(c("a.b", "acb"), regex = stringr::fixed("a.b"))
+    Condition <stbl-error-must>
       Error:
       ! `c("a.b", "acb")` must match the regex pattern "a.b"
       x Some values fail the check.
@@ -114,10 +100,8 @@
 # stabilize_chr() works with stringr::coll() (#87)
 
     Code
-      (expect_pkg_error_classes(stabilize_chr(c("a", "A"), regex = stringr::coll("a")),
-      "stbl", "must"))
-    Output
-      <error/stbl-error-must>
+      stabilize_chr(c("a", "A"), regex = stringr::coll("a"))
+    Condition <stbl-error-must>
       Error:
       ! `c("a", "A")` must match the regex pattern "a"
       x Some values fail the check.
@@ -127,10 +111,8 @@
 # stabilize_chr() works with stringr::regex() (#87)
 
     Code
-      (expect_pkg_error_classes(stabilize_chr(c("A", "B"), regex = stringr::regex("a",
-        ignore_case = TRUE)), "stbl", "must"))
-    Output
-      <error/stbl-error-must>
+      stabilize_chr(c("A", "B"), regex = stringr::regex("a", ignore_case = TRUE))
+    Condition <stbl-error-must>
       Error:
       ! `c("A", "B")` must match the regex pattern "a"
       x Some values fail the check.
@@ -140,28 +122,24 @@
 # stabilize_chr_scalar() respects allow_null (#22, #189)
 
     Code
-      (expect_pkg_error_classes(stabilize_chr_scalar(given), "stbl", "bad_null"))
-    Output
-      <error/stbl-error-bad_null>
+      stabilize_chr_scalar(given)
+    Condition <stbl-error-bad_null>
       Error:
       ! `given` must not be <NULL>.
 
 ---
 
     Code
-      (expect_pkg_error_classes(wrapped_stabilize_chr_scalar(given), "stbl",
-      "bad_null"))
-    Output
-      <error/stbl-error-bad_null>
+      wrapped_stabilize_chr_scalar(given)
+    Condition <stbl-error-bad_null>
       Error in `wrapped_stabilize_chr_scalar()`:
       ! `val` must not be <NULL>.
 
 # stabilize_chr_scalar() errors for non-scalars (#22)
 
     Code
-      (expect_pkg_error_classes(stabilize_chr_scalar(given), "stbl", "non_scalar"))
-    Output
-      <error/stbl-error-non_scalar>
+      stabilize_chr_scalar(given)
+    Condition <stbl-error-non_scalar>
       Error:
       ! `given` must be a single <character>.
       x `given` has 26 values.
@@ -169,10 +147,8 @@
 ---
 
     Code
-      (expect_pkg_error_classes(wrapped_stabilize_chr_scalar(given), "stbl",
-      "non_scalar"))
-    Output
-      <error/stbl-error-non_scalar>
+      wrapped_stabilize_chr_scalar(given)
+    Condition <stbl-error-non_scalar>
       Error in `wrapped_stabilize_chr_scalar()`:
       ! `val` must be a single <character>.
       x `val` has 26 values.
@@ -180,10 +156,8 @@
 # stabilize_chr_scalar() works with regex that contains braces (#52)
 
     Code
-      (expect_pkg_error_classes(stabilize_chr_scalar("b", regex = "a{1,3}"), "stbl",
-      "must"))
-    Output
-      <error/stbl-error-must>
+      stabilize_chr_scalar("b", regex = "a{1,3}")
+    Condition <stbl-error-must>
       Error:
       ! `"b"` must match the regex pattern "a{1,3}"
       x "b" fails the check.

--- a/tests/testthat/_snaps/stabilize_dbl.md
+++ b/tests/testthat/_snaps/stabilize_dbl.md
@@ -1,10 +1,8 @@
 # stabilize_dbl() checks min_value (#23, #176)
 
     Code
-      (expect_pkg_error_classes(stabilize_dbl(given, min_value = 11.1), "stbl",
-      "outside_range"))
-    Output
-      <error/stbl-error-outside_range>
+      stabilize_dbl(given, min_value = 11.1)
+    Condition <stbl-error-outside_range>
       Error:
       ! `given` must be >= 11.1.
       i Some values are too low.
@@ -23,10 +21,8 @@
 ---
 
     Code
-      (expect_pkg_error_classes(wrapped_stabilize_dbl(given, min_value = 11.1),
-      "stbl", "outside_range"))
-    Output
-      <error/stbl-error-outside_range>
+      wrapped_stabilize_dbl(given, min_value = 11.1)
+    Condition <stbl-error-outside_range>
       Error in `wrapped_stabilize_dbl()`:
       ! `val` must be >= 11.1.
       i Some values are too low.
@@ -36,10 +32,8 @@
 # stabilize_dbl() checks max_value (#23, #176)
 
     Code
-      (expect_pkg_error_classes(stabilize_dbl(given, max_value = 4.1), "stbl",
-      "outside_range"))
-    Output
-      <error/stbl-error-outside_range>
+      stabilize_dbl(given, max_value = 4.1)
+    Condition <stbl-error-outside_range>
       Error:
       ! `given` must be <= 4.1.
       i Some values are too high.
@@ -49,10 +43,8 @@
 ---
 
     Code
-      (expect_pkg_error_classes(wrapped_stabilize_dbl(given, max_value = 4.1), "stbl",
-      "outside_range"))
-    Output
-      <error/stbl-error-outside_range>
+      wrapped_stabilize_dbl(given, max_value = 4.1)
+    Condition <stbl-error-outside_range>
       Error in `wrapped_stabilize_dbl()`:
       ! `val` must be <= 4.1.
       i Some values are too high.
@@ -62,28 +54,24 @@
 # stabilize_dbl_scalar() respects allow_null (#23, #189)
 
     Code
-      (expect_pkg_error_classes(stabilize_dbl_scalar(given), "stbl", "bad_null"))
-    Output
-      <error/stbl-error-bad_null>
+      stabilize_dbl_scalar(given)
+    Condition <stbl-error-bad_null>
       Error:
       ! `given` must not be <NULL>.
 
 ---
 
     Code
-      (expect_pkg_error_classes(wrapped_stabilize_dbl_scalar(given), "stbl",
-      "bad_null"))
-    Output
-      <error/stbl-error-bad_null>
+      wrapped_stabilize_dbl_scalar(given)
+    Condition <stbl-error-bad_null>
       Error in `wrapped_stabilize_dbl_scalar()`:
       ! `val` must not be <NULL>.
 
 # stabilize_dbl_scalar() errors on non-scalars (#23)
 
     Code
-      (expect_pkg_error_classes(stabilize_dbl_scalar(given), "stbl", "non_scalar"))
-    Output
-      <error/stbl-error-non_scalar>
+      stabilize_dbl_scalar(given)
+    Condition <stbl-error-non_scalar>
       Error:
       ! `given` must be a single <numeric>.
       x `given` has 10 values.
@@ -91,10 +79,8 @@
 ---
 
     Code
-      (expect_pkg_error_classes(wrapped_stabilize_dbl_scalar(given), "stbl",
-      "non_scalar"))
-    Output
-      <error/stbl-error-non_scalar>
+      wrapped_stabilize_dbl_scalar(given)
+    Condition <stbl-error-non_scalar>
       Error in `wrapped_stabilize_dbl_scalar()`:
       ! `val` must be a single <numeric>.
       x `val` has 10 values.

--- a/tests/testthat/_snaps/stabilize_df.md
+++ b/tests/testthat/_snaps/stabilize_df.md
@@ -1,60 +1,48 @@
 # stabilize_df() respects .allow_null (#142)
 
     Code
-      (expect_pkg_error_classes(stabilize_df(NULL, .allow_null = FALSE), "stbl",
-      "bad_null"))
-    Output
-      <error/stbl-error-bad_null>
+      stabilize_df(NULL, .allow_null = FALSE)
+    Condition <stbl-error-bad_null>
       Error:
       ! `NULL` must not be <NULL>.
 
 ---
 
     Code
-      (expect_pkg_error_classes(wrapped_stabilize_df(NULL, .allow_null = FALSE),
-      "stbl", "bad_null"))
-    Output
-      <error/stbl-error-bad_null>
+      wrapped_stabilize_df(NULL, .allow_null = FALSE)
+    Condition <stbl-error-bad_null>
       Error in `wrapped_stabilize_df()`:
       ! `val` must not be <NULL>.
 
 # stabilize_df() errors for non-coercible input (#142)
 
     Code
-      (expect_pkg_error_classes(stabilize_df("not a data frame"), "stbl", "coerce",
-      "data.frame"))
-    Output
-      <error/stbl-error-coerce-data.frame>
+      stabilize_df("not a data frame")
+    Condition <stbl-error-coerce-data.frame>
       Error:
       ! Can't coerce `"not a data frame"` <character> to <data.frame>.
 
 ---
 
     Code
-      (expect_pkg_error_classes(wrapped_stabilize_df("not a data frame"), "stbl",
-      "coerce", "data.frame"))
-    Output
-      <error/stbl-error-coerce-data.frame>
+      wrapped_stabilize_df("not a data frame")
+    Condition <stbl-error-coerce-data.frame>
       Error in `wrapped_stabilize_df()`:
       ! Can't coerce `val` <character> to <data.frame>.
 
 # stabilize_df() errors when required column is missing (#142)
 
     Code
-      (expect_pkg_error_classes(stabilize_df(data.frame(foo = "a"), name = specify_chr_scalar()),
-      "stbl", "missing_element"))
-    Output
-      <error/stbl-error-missing_element>
+      stabilize_df(data.frame(foo = "a"), name = specify_chr_scalar())
+    Condition <stbl-error-missing_element>
       Error:
       ! `data.frame(foo = "a")` must contain element "name".
 
 # stabilize_df() errors informatively when column fails validation (#142)
 
     Code
-      (expect_pkg_error_classes(stabilize_df(data.frame(count = "not-an-int"), count = specify_int_scalar()),
-      "stbl", "incompatible_type"))
-    Output
-      <error/stbl-error-incompatible_type>
+      stabilize_df(data.frame(count = "not-an-int"), count = specify_int_scalar())
+    Condition <stbl-error-incompatible_type>
       Error:
       ! `data.frame(count = "not-an-int")[["count"]]` <character> must be coercible to <integer>
       x Can't convert some values due to incompatible values.
@@ -63,10 +51,8 @@
 # stabilize_df() errors on extra columns by default (#142)
 
     Code
-      (expect_pkg_error_classes(stabilize_df(data.frame(a = 1L, b = 2L), a = specify_int_scalar()),
-      "stbl", "bad_named"))
-    Output
-      <error/stbl-error-bad_named>
+      stabilize_df(data.frame(a = 1L, b = 2L), a = specify_int_scalar())
+    Condition <stbl-error-bad_named>
       Error:
       ! `data.frame(a = 1L, b = 2L)` must not contain extra named elements.
       x Extra element: "b"
@@ -74,10 +60,9 @@
 # stabilize_df() validates extra columns with .extra_cols (#142)
 
     Code
-      (expect_pkg_error_classes(stabilize_df(data.frame(a = 1L, b = "not-int"), a = specify_int_scalar(),
-      .extra_cols = specify_int_scalar()), "stbl", "incompatible_type"))
-    Output
-      <error/stbl-error-incompatible_type>
+      stabilize_df(data.frame(a = 1L, b = "not-int"), a = specify_int_scalar(),
+      .extra_cols = specify_int_scalar())
+    Condition <stbl-error-incompatible_type>
       Error:
       ! `data.frame(a = 1L, b = "not-int")[["b"]]` <character> must be coercible to <integer>
       x Can't convert some values due to incompatible values.
@@ -86,10 +71,8 @@
 # stabilize_df() enforces .min_rows (snapshot) (#142)
 
     Code
-      (expect_pkg_error_classes(stabilize_df(mtcars[0, ], .min_rows = 1, .extra_cols = assert_present),
-      "stbl", "too_few_rows"))
-    Output
-      <error/stbl-error-too_few_rows>
+      stabilize_df(mtcars[0, ], .min_rows = 1, .extra_cols = assert_present)
+    Condition <stbl-error-too_few_rows>
       Error:
       ! `mtcars[0, ]` must have at least 1 row.
       x 0 is too few.
@@ -97,10 +80,8 @@
 # stabilize_df() enforces .max_rows (snapshot) (#142)
 
     Code
-      (expect_pkg_error_classes(stabilize_df(mtcars, .max_rows = 5, .extra_cols = assert_present),
-      "stbl", "too_many_rows"))
-    Output
-      <error/stbl-error-too_many_rows>
+      stabilize_df(mtcars, .max_rows = 5, .extra_cols = assert_present)
+    Condition <stbl-error-too_many_rows>
       Error:
       ! `mtcars` must have at most 5 rows.
       x 32 is too many.
@@ -108,20 +89,16 @@
 # stabilize_df() enforces .col_names (snapshot) (#142)
 
     Code
-      (expect_pkg_error_classes(stabilize_df(data.frame(a = 1L), .col_names = c("a",
-        "b"), .extra_cols = assert_present), "stbl", "missing_cols"))
-    Output
-      <error/stbl-error-missing_cols>
+      stabilize_df(data.frame(a = 1L), .col_names = c("a", "b"), .extra_cols = assert_present)
+    Condition <stbl-error-missing_cols>
       Error:
       ! `data.frame(a = 1L)` must contain column "b".
 
 # stabilize_df() with unnamed specs errors informatively (#142)
 
     Code
-      (expect_pkg_error_classes(stabilize_df(data.frame(a = 1L), specify_int_scalar()),
-      "stbl", "unnamed_spec"))
-    Output
-      <error/stbl-error-unnamed_spec>
+      stabilize_df(data.frame(a = 1L), specify_int_scalar())
+    Condition <stbl-error-unnamed_spec>
       Error:
       ! All elements passed via `...` must be named.
       i Each name corresponds to a required element in the list.

--- a/tests/testthat/_snaps/stabilize_fct.md
+++ b/tests/testthat/_snaps/stabilize_fct.md
@@ -1,10 +1,8 @@
 # stabilize_fct() throws errors for bad levels (#62, #67)
 
     Code
-      (expect_pkg_error_classes(stabilize_fct(letters[1:5], levels = c("a", "c"),
-      to_na = "b"), "stbl", "fct_levels"))
-    Output
-      <error/stbl-error-fct_levels>
+      stabilize_fct(letters[1:5], levels = c("a", "c"), to_na = "b")
+    Condition <stbl-error-fct_levels>
       Error:
       ! Each value of `letters[1:5]` must be in the expected levels.
       i Allowed levels: "a" and "c".
@@ -14,10 +12,8 @@
 ---
 
     Code
-      (expect_pkg_error_classes(wrapped_stabilize_fct(letters[1:5], levels = c("a",
-        "c"), to_na = "b"), "stbl", "fct_levels"))
-    Output
-      <error/stbl-error-fct_levels>
+      wrapped_stabilize_fct(letters[1:5], levels = c("a", "c"), to_na = "b")
+    Condition <stbl-error-fct_levels>
       Error in `wrapped_stabilize_fct()`:
       ! Each value of `val` must be in the expected levels.
       i Allowed levels: "a" and "c".
@@ -27,28 +23,24 @@
 # stabilize_fct_scalar() respects allow_null (#62, #189)
 
     Code
-      (expect_pkg_error_classes(stabilize_fct_scalar(given), "stbl", "bad_null"))
-    Output
-      <error/stbl-error-bad_null>
+      stabilize_fct_scalar(given)
+    Condition <stbl-error-bad_null>
       Error:
       ! `given` must not be <NULL>.
 
 ---
 
     Code
-      (expect_pkg_error_classes(wrapped_stabilize_fct_scalar(given), "stbl",
-      "bad_null"))
-    Output
-      <error/stbl-error-bad_null>
+      wrapped_stabilize_fct_scalar(given)
+    Condition <stbl-error-bad_null>
       Error in `wrapped_stabilize_fct_scalar()`:
       ! `val` must not be <NULL>.
 
 # stabilize_fct_scalar() errors for non-scalars (#62)
 
     Code
-      (expect_pkg_error_classes(stabilize_fct_scalar(given), "stbl", "non_scalar"))
-    Output
-      <error/stbl-error-non_scalar>
+      stabilize_fct_scalar(given)
+    Condition <stbl-error-non_scalar>
       Error:
       ! `given` must be a single <factor>.
       x `given` has 26 values.
@@ -56,10 +48,8 @@
 ---
 
     Code
-      (expect_pkg_error_classes(wrapped_stabilize_fct_scalar(given), "stbl",
-      "non_scalar"))
-    Output
-      <error/stbl-error-non_scalar>
+      wrapped_stabilize_fct_scalar(given)
+    Condition <stbl-error-non_scalar>
       Error in `wrapped_stabilize_fct_scalar()`:
       ! `val` must be a single <factor>.
       x `val` has 26 values.

--- a/tests/testthat/_snaps/stabilize_int.md
+++ b/tests/testthat/_snaps/stabilize_int.md
@@ -1,10 +1,8 @@
 # stabilize_int() checks min_value (#2, #6, #176)
 
     Code
-      (expect_pkg_error_classes(stabilize_int(given, min_value = 11), "stbl",
-      "outside_range"))
-    Output
-      <error/stbl-error-outside_range>
+      stabilize_int(given, min_value = 11)
+    Condition <stbl-error-outside_range>
       Error:
       ! `given` must be >= 11.
       i Some values are too low.
@@ -14,10 +12,8 @@
 ---
 
     Code
-      (expect_pkg_error_classes(wrapped_stabilize_int(given, min_value = 11), "stbl",
-      "outside_range"))
-    Output
-      <error/stbl-error-outside_range>
+      wrapped_stabilize_int(given, min_value = 11)
+    Condition <stbl-error-outside_range>
       Error in `wrapped_stabilize_int()`:
       ! `val` must be >= 11.
       i Some values are too low.
@@ -27,10 +23,8 @@
 # stabilize_int() checks max_value (#5, #176)
 
     Code
-      (expect_pkg_error_classes(stabilize_int(given, max_value = 4), "stbl",
-      "outside_range"))
-    Output
-      <error/stbl-error-outside_range>
+      stabilize_int(given, max_value = 4)
+    Condition <stbl-error-outside_range>
       Error:
       ! `given` must be <= 4.
       i Some values are too high.
@@ -40,10 +34,8 @@
 ---
 
     Code
-      (expect_pkg_error_classes(wrapped_stabilize_int(given, max_value = 4), "stbl",
-      "outside_range"))
-    Output
-      <error/stbl-error-outside_range>
+      wrapped_stabilize_int(given, max_value = 4)
+    Condition <stbl-error-outside_range>
       Error in `wrapped_stabilize_int()`:
       ! `val` must be <= 4.
       i Some values are too high.
@@ -53,28 +45,24 @@
 # stabilize_int_scalar() respects allow_null (#12, #189)
 
     Code
-      (expect_pkg_error_classes(stabilize_int_scalar(given), "stbl", "bad_null"))
-    Output
-      <error/stbl-error-bad_null>
+      stabilize_int_scalar(given)
+    Condition <stbl-error-bad_null>
       Error:
       ! `given` must not be <NULL>.
 
 ---
 
     Code
-      (expect_pkg_error_classes(wrapped_stabilize_int_scalar(given), "stbl",
-      "bad_null"))
-    Output
-      <error/stbl-error-bad_null>
+      wrapped_stabilize_int_scalar(given)
+    Condition <stbl-error-bad_null>
       Error in `wrapped_stabilize_int_scalar()`:
       ! `val` must not be <NULL>.
 
 # stabilize_int_scalar() errors on non-scalars (#12)
 
     Code
-      (expect_pkg_error_classes(stabilize_int_scalar(given), "stbl", "non_scalar"))
-    Output
-      <error/stbl-error-non_scalar>
+      stabilize_int_scalar(given)
+    Condition <stbl-error-non_scalar>
       Error:
       ! `given` must be a single <integer>.
       x `given` has 10 values.
@@ -82,10 +70,8 @@
 ---
 
     Code
-      (expect_pkg_error_classes(wrapped_stabilize_int_scalar(given), "stbl",
-      "non_scalar"))
-    Output
-      <error/stbl-error-non_scalar>
+      wrapped_stabilize_int_scalar(given)
+    Condition <stbl-error-non_scalar>
       Error in `wrapped_stabilize_int_scalar()`:
       ! `val` must be a single <integer>.
       x `val` has 10 values.

--- a/tests/testthat/_snaps/stabilize_lgl.md
+++ b/tests/testthat/_snaps/stabilize_lgl.md
@@ -1,10 +1,8 @@
 # stabilize_lgl() checks NAs (#28)
 
     Code
-      (expect_pkg_error_classes(stabilize_lgl(given, allow_na = FALSE), "stbl",
-      "bad_na"))
-    Output
-      <error/stbl-error-bad_na>
+      stabilize_lgl(given, allow_na = FALSE)
+    Condition <stbl-error-bad_na>
       Error:
       ! `given` must not contain NA values.
       * NA locations: 2
@@ -12,10 +10,8 @@
 ---
 
     Code
-      (expect_pkg_error_classes(wrapped_stabilize_lgl(given, allow_na = FALSE),
-      "stbl", "bad_na"))
-    Output
-      <error/stbl-error-bad_na>
+      wrapped_stabilize_lgl(given, allow_na = FALSE)
+    Condition <stbl-error-bad_na>
       Error in `wrapped_stabilize_lgl()`:
       ! `val` must not contain NA values.
       * NA locations: 2
@@ -23,10 +19,8 @@
 # stabilize_lgl() checks min_size (#28)
 
     Code
-      (expect_pkg_error_classes(stabilize_lgl(given, min_size = 5), "stbl",
-      "size_too_small"))
-    Output
-      <error/stbl-error-size_too_small>
+      stabilize_lgl(given, min_size = 5)
+    Condition <stbl-error-size_too_small>
       Error:
       ! `given` must have size >= 5.
       x 4 is too small.
@@ -34,10 +28,8 @@
 ---
 
     Code
-      (expect_pkg_error_classes(wrapped_stabilize_lgl(given, min_size = 5), "stbl",
-      "size_too_small"))
-    Output
-      <error/stbl-error-size_too_small>
+      wrapped_stabilize_lgl(given, min_size = 5)
+    Condition <stbl-error-size_too_small>
       Error in `wrapped_stabilize_lgl()`:
       ! `val` must have size >= 5.
       x 4 is too small.
@@ -45,10 +37,8 @@
 # stabilize_lgl() checks max_size (#28)
 
     Code
-      (expect_pkg_error_classes(stabilize_lgl(given, max_size = 3), "stbl",
-      "size_too_large"))
-    Output
-      <error/stbl-error-size_too_large>
+      stabilize_lgl(given, max_size = 3)
+    Condition <stbl-error-size_too_large>
       Error:
       ! `given` must have size <= 3.
       x 4 is too big.
@@ -56,10 +46,8 @@
 ---
 
     Code
-      (expect_pkg_error_classes(wrapped_stabilize_lgl(given, max_size = 3), "stbl",
-      "size_too_large"))
-    Output
-      <error/stbl-error-size_too_large>
+      wrapped_stabilize_lgl(given, max_size = 3)
+    Condition <stbl-error-size_too_large>
       Error in `wrapped_stabilize_lgl()`:
       ! `val` must have size <= 3.
       x 4 is too big.
@@ -67,28 +55,24 @@
 # stabilize_lgl_scalar() respects allow_null (#28, #189)
 
     Code
-      (expect_pkg_error_classes(stabilize_lgl_scalar(given), "stbl", "bad_null"))
-    Output
-      <error/stbl-error-bad_null>
+      stabilize_lgl_scalar(given)
+    Condition <stbl-error-bad_null>
       Error:
       ! `given` must not be <NULL>.
 
 ---
 
     Code
-      (expect_pkg_error_classes(wrapped_stabilize_lgl_scalar(given), "stbl",
-      "bad_null"))
-    Output
-      <error/stbl-error-bad_null>
+      wrapped_stabilize_lgl_scalar(given)
+    Condition <stbl-error-bad_null>
       Error in `wrapped_stabilize_lgl_scalar()`:
       ! `val` must not be <NULL>.
 
 # stabilize_lgl_scalar() errors on non-scalars (#28)
 
     Code
-      (expect_pkg_error_classes(stabilize_lgl_scalar(given), "stbl", "non_scalar"))
-    Output
-      <error/stbl-error-non_scalar>
+      stabilize_lgl_scalar(given)
+    Condition <stbl-error-non_scalar>
       Error:
       ! `given` must be a single <logical>.
       x `given` has 3 values.
@@ -96,10 +80,8 @@
 ---
 
     Code
-      (expect_pkg_error_classes(wrapped_stabilize_lgl_scalar(given), "stbl",
-      "non_scalar"))
-    Output
-      <error/stbl-error-non_scalar>
+      wrapped_stabilize_lgl_scalar(given)
+    Condition <stbl-error-non_scalar>
       Error in `wrapped_stabilize_lgl_scalar()`:
       ! `val` must be a single <logical>.
       x `val` has 3 values.

--- a/tests/testthat/_snaps/stabilize_lst.md
+++ b/tests/testthat/_snaps/stabilize_lst.md
@@ -1,50 +1,40 @@
 # stabilize_lst() respects .allow_null (#110)
 
     Code
-      (expect_pkg_error_classes(stabilize_lst(NULL, .allow_null = FALSE), "stbl",
-      "bad_null"))
-    Output
-      <error/stbl-error-bad_null>
+      stabilize_lst(NULL, .allow_null = FALSE)
+    Condition <stbl-error-bad_null>
       Error:
       ! `NULL` must not be <NULL>.
 
 ---
 
     Code
-      (expect_pkg_error_classes(wrapped_stabilize_lst(NULL, .allow_null = FALSE),
-      "stbl", "bad_null"))
-    Output
-      <error/stbl-error-bad_null>
+      wrapped_stabilize_lst(NULL, .allow_null = FALSE)
+    Condition <stbl-error-bad_null>
       Error in `wrapped_stabilize_lst()`:
       ! `val` must not be <NULL>.
 
 # stabilize_lst() errors when required named element is missing (#110)
 
     Code
-      (expect_pkg_error_classes(stabilize_lst(list(foo = "a"), name = specify_chr_scalar()),
-      "stbl", "missing_element"))
-    Output
-      <error/stbl-error-missing_element>
+      stabilize_lst(list(foo = "a"), name = specify_chr_scalar())
+    Condition <stbl-error-missing_element>
       Error:
       ! `list(foo = "a")` must contain element "name".
 
 ---
 
     Code
-      (expect_pkg_error_classes(wrapped_stabilize_lst(list(foo = "a"), name = specify_chr_scalar()),
-      "stbl", "missing_element"))
-    Output
-      <error/stbl-error-missing_element>
+      wrapped_stabilize_lst(list(foo = "a"), name = specify_chr_scalar())
+    Condition <stbl-error-missing_element>
       Error in `wrapped_stabilize_lst()`:
       ! `val` must contain element "name".
 
 # stabilize_lst() errors informatively when element fails validation (#110)
 
     Code
-      (expect_pkg_error_classes(stabilize_lst(list(count = "not-an-int"), count = specify_int_scalar()),
-      "stbl", "incompatible_type"))
-    Output
-      <error/stbl-error-incompatible_type>
+      stabilize_lst(list(count = "not-an-int"), count = specify_int_scalar())
+    Condition <stbl-error-incompatible_type>
       Error:
       ! `list(count = "not-an-int")[["count"]]` <character> must be coercible to <integer>
       x Can't convert some values due to incompatible values.
@@ -53,10 +43,8 @@
 # stabilize_lst() errors on extra named elements by default (#110)
 
     Code
-      (expect_pkg_error_classes(stabilize_lst(list(a = 1L, b = 2L)), "stbl",
-      "bad_named"))
-    Output
-      <error/stbl-error-bad_named>
+      stabilize_lst(list(a = 1L, b = 2L))
+    Condition <stbl-error-bad_named>
       Error:
       ! `list(a = 1L, b = 2L)` must not contain extra named elements.
       x Extra elements: "a" and "b"
@@ -64,10 +52,8 @@
 ---
 
     Code
-      (expect_pkg_error_classes(wrapped_stabilize_lst(list(a = 1L, b = 2L)), "stbl",
-      "bad_named"))
-    Output
-      <error/stbl-error-bad_named>
+      wrapped_stabilize_lst(list(a = 1L, b = 2L))
+    Condition <stbl-error-bad_named>
       Error in `wrapped_stabilize_lst()`:
       ! `val` must not contain extra named elements.
       x Extra elements: "a" and "b"
@@ -75,9 +61,8 @@
 # stabilize_lst() errors on unnamed elements by default (#110)
 
     Code
-      (expect_pkg_error_classes(stabilize_lst(list(1L, 2L)), "stbl", "bad_unnamed"))
-    Output
-      <error/stbl-error-bad_unnamed>
+      stabilize_lst(list(1L, 2L))
+    Condition <stbl-error-bad_unnamed>
       Error:
       ! `list(1L, 2L)` must not contain unnamed elements.
       x Unnamed positions: 1 and 2
@@ -85,10 +70,8 @@
 ---
 
     Code
-      (expect_pkg_error_classes(wrapped_stabilize_lst(list(1L, 2L)), "stbl",
-      "bad_unnamed"))
-    Output
-      <error/stbl-error-bad_unnamed>
+      wrapped_stabilize_lst(list(1L, 2L))
+    Condition <stbl-error-bad_unnamed>
       Error in `wrapped_stabilize_lst()`:
       ! `val` must not contain unnamed elements.
       x Unnamed positions: 1 and 2
@@ -96,10 +79,8 @@
 # stabilize_lst() enforces .min_size (#110)
 
     Code
-      (expect_pkg_error_classes(stabilize_lst(list(a = 1L), .named = specify_int_scalar(),
-      .min_size = 2), "stbl", "size_too_small"))
-    Output
-      <error/stbl-error-size_too_small>
+      stabilize_lst(list(a = 1L), .named = specify_int_scalar(), .min_size = 2)
+    Condition <stbl-error-size_too_small>
       Error:
       ! `list(a = 1L)` must have size >= 2.
       x 1 is too small.
@@ -107,20 +88,16 @@
 # stabilize_lst() validates nested lists (#110)
 
     Code
-      (expect_pkg_error_classes(stabilize_lst(list(aes = list(x = mtcars, y = "hp")),
-      aes = spec_aes), "stbl", "coerce", "character"))
-    Output
-      <error/stbl-error-coerce-character>
+      stabilize_lst(list(aes = list(x = mtcars, y = "hp")), aes = spec_aes)
+    Condition <stbl-error-coerce-character>
       Error:
       ! Can't coerce `list(aes = list(x = mtcars, y = "hp"))[["aes"]][["x"]]` <data.frame> to <character>.
 
 # .check_duplicate_names(): errors on duplicate names by default (#110)
 
     Code
-      (expect_pkg_error_classes(stabilize_lst(list(a = 1L, a = 2L), .named = specify_int_scalar()),
-      "stbl", "duplicate_names"))
-    Output
-      <error/stbl-error-duplicate_names>
+      stabilize_lst(list(a = 1L, a = 2L), .named = specify_int_scalar())
+    Condition <stbl-error-duplicate_names>
       Error:
       ! `list(a = 1L, a = 2L)` must not contain duplicate names.
       x Duplicate name: "a"
@@ -128,10 +105,8 @@
 ---
 
     Code
-      (expect_pkg_error_classes(wrapped_stabilize_lst(list(a = 1L, a = 2L), .named = specify_int_scalar()),
-      "stbl", "duplicate_names"))
-    Output
-      <error/stbl-error-duplicate_names>
+      wrapped_stabilize_lst(list(a = 1L, a = 2L), .named = specify_int_scalar())
+    Condition <stbl-error-duplicate_names>
       Error in `wrapped_stabilize_lst()`:
       ! `val` must not contain duplicate names.
       x Duplicate name: "a"

--- a/tests/testthat/_snaps/stabilize_present.md
+++ b/tests/testthat/_snaps/stabilize_present.md
@@ -1,9 +1,8 @@
 # stabilize_present() is deprecated in favor of assert_present() (#299)
 
     Code
-      (expect_pkg_error_classes(stabilize_present("hello"), "stbl", "deprecated"))
-    Output
-      <error/stbl-error-deprecated>
+      stabilize_present("hello")
+    Condition <stbl-error-deprecated>
       Error:
       ! `stabilize_present()` was renamed to `assert_present()`.
       i Please call `assert_present()` instead.

--- a/tests/testthat/_snaps/to_any_of.md
+++ b/tests/testthat/_snaps/to_any_of.md
@@ -1,10 +1,8 @@
 # to_any_of() errors with a combined message when all prototypes fail (#215, #285)
 
     Code
-      (expect_pkg_error_classes(to_any_of(new.env(), integer(), character()), "stbl",
-      "cant_stabilize_any_of"))
-    Output
-      <error/stbl-error-cant_stabilize_any_of>
+      to_any_of(new.env(), integer(), character())
+    Condition <stbl-error-cant_stabilize_any_of>
       Error:
       ! `new.env()` must match at least one of the provided stabilizers.
       x `new.env()` must be a vector, not an environment.
@@ -13,10 +11,8 @@
 ---
 
     Code
-      (expect_pkg_error_classes(wrapped_to_any_of(new.env(), integer(), character()),
-      "stbl", "cant_stabilize_any_of"))
-    Output
-      <error/stbl-error-cant_stabilize_any_of>
+      wrapped_to_any_of(new.env(), integer(), character())
+    Condition <stbl-error-cant_stabilize_any_of>
       Error in `wrapped_to_any_of()`:
       ! `val` must match at least one of the provided stabilizers.
       x `val` must be a vector, not an environment.
@@ -25,9 +21,8 @@
 # to_any_of() errors when ... is empty (#215, #285)
 
     Code
-      (expect_pkg_error_classes(to_any_of(1L), "stbl", "empty_specs"))
-    Output
-      <error/stbl-error-empty_specs>
+      to_any_of(1L)
+    Condition <stbl-error-empty_specs>
       Error:
       ! At least one function must be provided via `...`.
       i Supply stabilizer functions, or prototypes for `to_any_of()`.

--- a/tests/testthat/_snaps/to_chr.md
+++ b/tests/testthat/_snaps/to_chr.md
@@ -1,29 +1,24 @@
 # to_chr() respects allow_null (#22)
 
     Code
-      (expect_pkg_error_classes(to_chr(given, allow_null = FALSE), "stbl", "bad_null")
-      )
-    Output
-      <error/stbl-error-bad_null>
+      to_chr(given, allow_null = FALSE)
+    Condition <stbl-error-bad_null>
       Error:
       ! `given` must not be <NULL>.
 
 ---
 
     Code
-      (expect_pkg_error_classes(wrapped_to_chr(given, allow_null = FALSE), "stbl",
-      "bad_null"))
-    Output
-      <error/stbl-error-bad_null>
+      wrapped_to_chr(given, allow_null = FALSE)
+    Condition <stbl-error-bad_null>
       Error in `wrapped_to_chr()`:
       ! `val` must not be <NULL>.
 
 # to_chr() errors for anonymous functions (#251)
 
     Code
-      (expect_pkg_error_classes(to_chr(function(x) x), "stbl", "coerce", "character"))
-    Output
-      <error/stbl-error-coerce-character>
+      to_chr(function(x) x)
+    Condition <stbl-error-coerce-character>
       Error:
       ! Can't coerce `function(x) x` <function> to <character>.
       i Anonymous functions can't be converted to a string name.
@@ -31,9 +26,8 @@
 # to_chr() fails gracefully for weird cases (#22, #273)
 
     Code
-      (expect_pkg_error_classes(to_chr(given), "stbl", "incompatible_type"))
-    Output
-      <error/stbl-error-incompatible_type>
+      to_chr(given)
+    Condition <stbl-error-incompatible_type>
       Error:
       ! `given` <list> must be coercible to <character>
       x Can't convert some values due to incompatible element types.
@@ -42,9 +36,8 @@
 ---
 
     Code
-      (expect_pkg_error_classes(wrapped_to_chr(given), "stbl", "incompatible_type"))
-    Output
-      <error/stbl-error-incompatible_type>
+      wrapped_to_chr(given)
+    Condition <stbl-error-incompatible_type>
       Error in `wrapped_to_chr()`:
       ! `val` <list> must be coercible to <character>
       x Can't convert some values due to incompatible element types.
@@ -53,9 +46,8 @@
 ---
 
     Code
-      (expect_pkg_error_classes(to_chr(given), "stbl", "incompatible_type"))
-    Output
-      <error/stbl-error-incompatible_type>
+      to_chr(given)
+    Condition <stbl-error-incompatible_type>
       Error:
       ! `given` <list> must be coercible to <character>
       x Can't convert some values due to incompatible element types.
@@ -64,9 +56,8 @@
 ---
 
     Code
-      (expect_pkg_error_classes(wrapped_to_chr(given), "stbl", "incompatible_type"))
-    Output
-      <error/stbl-error-incompatible_type>
+      wrapped_to_chr(given)
+    Condition <stbl-error-incompatible_type>
       Error in `wrapped_to_chr()`:
       ! `val` <list> must be coercible to <character>
       x Can't convert some values due to incompatible element types.
@@ -75,27 +66,24 @@
 ---
 
     Code
-      (expect_pkg_error_classes(to_chr(given), "stbl", "coerce", "character"))
-    Output
-      <error/stbl-error-coerce-character>
+      to_chr(given)
+    Condition <stbl-error-coerce-character>
       Error:
       ! Can't coerce `given` <data.frame> to <character>.
 
 ---
 
     Code
-      (expect_pkg_error_classes(wrapped_to_chr(given), "stbl", "coerce", "character"))
-    Output
-      <error/stbl-error-coerce-character>
+      wrapped_to_chr(given)
+    Condition <stbl-error-coerce-character>
       Error in `wrapped_to_chr()`:
       ! Can't coerce `val` <data.frame> to <character>.
 
 ---
 
     Code
-      (expect_pkg_error_classes(to_chr(given), "stbl", "incompatible_type"))
-    Output
-      <error/stbl-error-incompatible_type>
+      to_chr(given)
+    Condition <stbl-error-incompatible_type>
       Error:
       ! `given` <list> must be coercible to <character>
       x Can't convert some values due to incompatible element types.
@@ -104,9 +92,8 @@
 ---
 
     Code
-      (expect_pkg_error_classes(wrapped_to_chr(given), "stbl", "incompatible_type"))
-    Output
-      <error/stbl-error-incompatible_type>
+      wrapped_to_chr(given)
+    Condition <stbl-error-incompatible_type>
       Error in `wrapped_to_chr()`:
       ! `val` <list> must be coercible to <character>
       x Can't convert some values due to incompatible element types.
@@ -115,9 +102,8 @@
 # to_chr_scalar() errors for non-scalars (#22)
 
     Code
-      (expect_pkg_error_classes(to_chr_scalar(given), "stbl", "non_scalar"))
-    Output
-      <error/stbl-error-non_scalar>
+      to_chr_scalar(given)
+    Condition <stbl-error-non_scalar>
       Error:
       ! `given` must be a single <character>.
       x `given` has 26 values.
@@ -125,9 +111,8 @@
 ---
 
     Code
-      (expect_pkg_error_classes(wrapped_to_chr_scalar(given), "stbl", "non_scalar"))
-    Output
-      <error/stbl-error-non_scalar>
+      wrapped_to_chr_scalar(given)
+    Condition <stbl-error-non_scalar>
       Error in `wrapped_to_chr_scalar()`:
       ! `val` must be a single <character>.
       x `val` has 26 values.
@@ -135,9 +120,8 @@
 # to_chr_scalar() errors for uncoerceable types (#22, #273)
 
     Code
-      (expect_pkg_error_classes(to_chr_scalar(given), "stbl", "incompatible_type"))
-    Output
-      <error/stbl-error-incompatible_type>
+      to_chr_scalar(given)
+    Condition <stbl-error-incompatible_type>
       Error:
       ! `given` <list> must be coercible to <character>
       x Can't convert some values due to incompatible element types.
@@ -146,10 +130,8 @@
 ---
 
     Code
-      (expect_pkg_error_classes(wrapped_to_chr_scalar(given), "stbl",
-      "incompatible_type"))
-    Output
-      <error/stbl-error-incompatible_type>
+      wrapped_to_chr_scalar(given)
+    Condition <stbl-error-incompatible_type>
       Error in `wrapped_to_chr_scalar()`:
       ! `val` <list> must be coercible to <character>
       x Can't convert some values due to incompatible element types.
@@ -158,27 +140,24 @@
 # to_chr_scalar() respects allow_null (#22, #189)
 
     Code
-      (expect_pkg_error_classes(to_chr_scalar(given), "stbl", "bad_null"))
-    Output
-      <error/stbl-error-bad_null>
+      to_chr_scalar(given)
+    Condition <stbl-error-bad_null>
       Error:
       ! `given` must not be <NULL>.
 
 ---
 
     Code
-      (expect_pkg_error_classes(wrapped_to_chr_scalar(given), "stbl", "bad_null"))
-    Output
-      <error/stbl-error-bad_null>
+      wrapped_to_chr_scalar(given)
+    Condition <stbl-error-bad_null>
       Error in `wrapped_to_chr_scalar()`:
       ! `val` must not be <NULL>.
 
 # to_chr_scalar respects allow_zero_length (#22, #43, #45, #189)
 
     Code
-      (expect_pkg_error_classes(to_chr_scalar(given), "stbl", "bad_empty"))
-    Output
-      <error/stbl-error-bad_empty>
+      to_chr_scalar(given)
+    Condition <stbl-error-bad_empty>
       Error:
       ! `given` must be a single <character (non-empty)>.
       x `given` has no values.
@@ -186,18 +165,16 @@
 # to_chr() errors for types that can't be coerced (#noissue)
 
     Code
-      (expect_pkg_error_classes(to_chr(given), "stbl", "coerce", "character"))
-    Output
-      <error/stbl-error-coerce-character>
+      to_chr(given)
+    Condition <stbl-error-coerce-character>
       Error:
       ! Can't coerce `given` <environment> to <character>.
 
 ---
 
     Code
-      (expect_pkg_error_classes(wrapped_to_chr(given), "stbl", "coerce", "character"))
-    Output
-      <error/stbl-error-coerce-character>
+      wrapped_to_chr(given)
+    Condition <stbl-error-coerce-character>
       Error in `wrapped_to_chr()`:
       ! Can't coerce `val` <environment> to <character>.
 

--- a/tests/testthat/_snaps/to_dbl.md
+++ b/tests/testthat/_snaps/to_dbl.md
@@ -1,49 +1,40 @@
 # to_dbl() respects allow_null (#23)
 
     Code
-      (expect_pkg_error_classes(to_dbl(given, allow_null = FALSE), "stbl", "bad_null")
-      )
-    Output
-      <error/stbl-error-bad_null>
+      to_dbl(given, allow_null = FALSE)
+    Condition <stbl-error-bad_null>
       Error:
       ! `given` must not be <NULL>.
 
 ---
 
     Code
-      (expect_pkg_error_classes(wrapped_to_dbl(given, allow_null = FALSE), "stbl",
-      "bad_null"))
-    Output
-      <error/stbl-error-bad_null>
+      wrapped_to_dbl(given, allow_null = FALSE)
+    Condition <stbl-error-bad_null>
       Error in `wrapped_to_dbl()`:
       ! `val` must not be <NULL>.
 
 # to_dbl() respects coerce_character (#23)
 
     Code
-      (expect_pkg_error_classes(to_dbl(given, coerce_character = FALSE), "stbl",
-      "coerce", "double"))
-    Output
-      <error/stbl-error-coerce-double>
+      to_dbl(given, coerce_character = FALSE)
+    Condition <stbl-error-coerce-double>
       Error:
       ! Can't coerce `given` <character> to <double>.
 
 ---
 
     Code
-      (expect_pkg_error_classes(wrapped_to_dbl(given, coerce_character = FALSE),
-      "stbl", "coerce", "double"))
-    Output
-      <error/stbl-error-coerce-double>
+      wrapped_to_dbl(given, coerce_character = FALSE)
+    Condition <stbl-error-coerce-double>
       Error in `wrapped_to_dbl()`:
       ! Can't coerce `val` <character> to <double>.
 
 # to_dbl() errors informatively for bad chrs (#23)
 
     Code
-      (expect_pkg_error_classes(to_dbl(given), "stbl", "incompatible_type"))
-    Output
-      <error/stbl-error-incompatible_type>
+      to_dbl(given)
+    Condition <stbl-error-incompatible_type>
       Error:
       ! `given` <character> must be coercible to <double>
       x Can't convert some values due to incompatible values.
@@ -52,9 +43,8 @@
 ---
 
     Code
-      (expect_pkg_error_classes(wrapped_to_dbl(given), "stbl", "incompatible_type"))
-    Output
-      <error/stbl-error-incompatible_type>
+      wrapped_to_dbl(given)
+    Condition <stbl-error-incompatible_type>
       Error in `wrapped_to_dbl()`:
       ! `val` <character> must be coercible to <double>
       x Can't convert some values due to incompatible values.
@@ -63,9 +53,8 @@
 # to_dbl() errors informatively for bad complexes (#23)
 
     Code
-      (expect_pkg_error_classes(to_dbl(given), "stbl", "incompatible_type"))
-    Output
-      <error/stbl-error-incompatible_type>
+      to_dbl(given)
+    Condition <stbl-error-incompatible_type>
       Error:
       ! `given` <complex> must be coercible to <double>
       x Can't convert some values due to non-zero complex components.
@@ -74,9 +63,8 @@
 ---
 
     Code
-      (expect_pkg_error_classes(wrapped_to_dbl(given), "stbl", "incompatible_type"))
-    Output
-      <error/stbl-error-incompatible_type>
+      wrapped_to_dbl(given)
+    Condition <stbl-error-incompatible_type>
       Error in `wrapped_to_dbl()`:
       ! `val` <complex> must be coercible to <double>
       x Can't convert some values due to non-zero complex components.
@@ -85,29 +73,24 @@
 # to_dbl() respects coerce_factor (#23)
 
     Code
-      (expect_pkg_error_classes(to_dbl(given, coerce_factor = FALSE), "stbl",
-      "coerce", "double"))
-    Output
-      <error/stbl-error-coerce-double>
+      to_dbl(given, coerce_factor = FALSE)
+    Condition <stbl-error-coerce-double>
       Error:
       ! Can't coerce `given` <factor> to <double>.
 
 ---
 
     Code
-      (expect_pkg_error_classes(wrapped_to_dbl(given, coerce_factor = FALSE), "stbl",
-      "coerce", "double"))
-    Output
-      <error/stbl-error-coerce-double>
+      wrapped_to_dbl(given, coerce_factor = FALSE)
+    Condition <stbl-error-coerce-double>
       Error in `wrapped_to_dbl()`:
       ! Can't coerce `val` <factor> to <double>.
 
 # to_dbl() errors informatively for bad factors (#23)
 
     Code
-      (expect_pkg_error_classes(to_dbl(given), "stbl", "incompatible_type"))
-    Output
-      <error/stbl-error-incompatible_type>
+      to_dbl(given)
+    Condition <stbl-error-incompatible_type>
       Error:
       ! `given` <factor> must be coercible to <double>
       x Can't convert some values due to incompatible values.
@@ -116,9 +99,8 @@
 ---
 
     Code
-      (expect_pkg_error_classes(wrapped_to_dbl(given), "stbl", "incompatible_type"))
-    Output
-      <error/stbl-error-incompatible_type>
+      wrapped_to_dbl(given)
+    Condition <stbl-error-incompatible_type>
       Error in `wrapped_to_dbl()`:
       ! `val` <factor> must be coercible to <double>
       x Can't convert some values due to incompatible values.
@@ -127,9 +109,8 @@
 # to_dbl() works for lists (#128, #273)
 
     Code
-      (expect_pkg_error_classes(to_dbl(list(1.1, 1:5)), "stbl", "incompatible_type"))
-    Output
-      <error/stbl-error-incompatible_type>
+      to_dbl(list(1.1, 1:5))
+    Condition <stbl-error-incompatible_type>
       Error:
       ! `list(1.1, 1:5)` <list> must be coercible to <double>
       x Can't convert some values due to incompatible element types.
@@ -138,9 +119,8 @@
 # to_dbl_scalar() provides informative error messages (#23)
 
     Code
-      (expect_pkg_error_classes(to_dbl_scalar(given), "stbl", "non_scalar"))
-    Output
-      <error/stbl-error-non_scalar>
+      to_dbl_scalar(given)
+    Condition <stbl-error-non_scalar>
       Error:
       ! `given` must be a single <numeric>.
       x `given` has 2 values.
@@ -148,9 +128,8 @@
 ---
 
     Code
-      (expect_pkg_error_classes(wrapped_to_dbl_scalar(given), "stbl", "non_scalar"))
-    Output
-      <error/stbl-error-non_scalar>
+      wrapped_to_dbl_scalar(given)
+    Condition <stbl-error-non_scalar>
       Error in `wrapped_to_dbl_scalar()`:
       ! `val` must be a single <numeric>.
       x `val` has 2 values.
@@ -158,27 +137,24 @@
 # to_dbl_scalar() respects allow_null (#23, #189)
 
     Code
-      (expect_pkg_error_classes(to_dbl_scalar(given), "stbl", "bad_null"))
-    Output
-      <error/stbl-error-bad_null>
+      to_dbl_scalar(given)
+    Condition <stbl-error-bad_null>
       Error:
       ! `given` must not be <NULL>.
 
 ---
 
     Code
-      (expect_pkg_error_classes(wrapped_to_dbl_scalar(given), "stbl", "bad_null"))
-    Output
-      <error/stbl-error-bad_null>
+      wrapped_to_dbl_scalar(given)
+    Condition <stbl-error-bad_null>
       Error in `wrapped_to_dbl_scalar()`:
       ! `val` must not be <NULL>.
 
 # to_dbl_scalar respects allow_zero_length (#23, #43, #45, #189)
 
     Code
-      (expect_pkg_error_classes(to_dbl_scalar(given), "stbl", "bad_empty"))
-    Output
-      <error/stbl-error-bad_empty>
+      to_dbl_scalar(given)
+    Condition <stbl-error-bad_empty>
       Error:
       ! `given` must be a single <numeric (non-empty)>.
       x `given` has no values.

--- a/tests/testthat/_snaps/to_df.md
+++ b/tests/testthat/_snaps/to_df.md
@@ -1,19 +1,16 @@
 # to_df() respects allow_null (#201)
 
     Code
-      (expect_pkg_error_classes(to_df(NULL, allow_null = FALSE), "stbl", "bad_null"))
-    Output
-      <error/stbl-error-bad_null>
+      to_df(NULL, allow_null = FALSE)
+    Condition <stbl-error-bad_null>
       Error:
       ! `NULL` must not be <NULL>.
 
 ---
 
     Code
-      (expect_pkg_error_classes(wrapped_to_df(NULL, allow_null = FALSE), "stbl",
-      "bad_null"))
-    Output
-      <error/stbl-error-bad_null>
+      wrapped_to_df(NULL, allow_null = FALSE)
+    Condition <stbl-error-bad_null>
       Error in `wrapped_to_df()`:
       ! `val` must not be <NULL>.
 
@@ -40,9 +37,8 @@
 # to_df() errors for a list with incompatible column lengths (#201)
 
     Code
-      (expect_pkg_error_classes(to_df(list(a = 1:3, b = 1:2)), "stbl", "jagged"))
-    Output
-      <error/stbl-error-jagged>
+      to_df(list(a = 1:3, b = 1:2))
+    Condition <stbl-error-jagged>
       Error:
       ! Can't coerce `list(a = 1:3, b = 1:2)` <list> to <data.frame>.
       i All list elements must have length 3 or 1.
@@ -51,10 +47,8 @@
 ---
 
     Code
-      (expect_pkg_error_classes(wrapped_to_df(list(a = 1:3, b = 1:2)), "stbl",
-      "jagged"))
-    Output
-      <error/stbl-error-jagged>
+      wrapped_to_df(list(a = 1:3, b = 1:2))
+    Condition <stbl-error-jagged>
       Error in `wrapped_to_df()`:
       ! Can't coerce `val` <list> to <data.frame>.
       i All list elements must have length 3 or 1.
@@ -63,29 +57,24 @@
 # to_df() errors for an unnamed list (#203)
 
     Code
-      (expect_pkg_error_classes(to_df(list(1, 2)), "stbl", "bad_named"))
-    Output
-      <error/stbl-error-bad_named>
+      to_df(list(1, 2))
+    Condition <stbl-error-bad_named>
       Error:
       ! `list(1, 2)` must have all elements named.
 
 # to_df() errors for non-coercible types (#201)
 
     Code
-      (expect_pkg_error_classes(to_df("not a data frame"), "stbl", "coerce",
-      "data.frame"))
-    Output
-      <error/stbl-error-coerce-data.frame>
+      to_df("not a data frame")
+    Condition <stbl-error-coerce-data.frame>
       Error:
       ! Can't coerce `"not a data frame"` <character> to <data.frame>.
 
 # to_df.default() errors for non-coercible types (#201)
 
     Code
-      (expect_pkg_error_classes(to_df(as.Date("2024-01-01")), "stbl", "coerce",
-      "data.frame"))
-    Output
-      <error/stbl-error-coerce-data.frame>
+      to_df(as.Date("2024-01-01"))
+    Condition <stbl-error-coerce-data.frame>
       Error:
       ! Can't coerce `as.Date("2024-01-01")` <Date> to <data.frame>.
 

--- a/tests/testthat/_snaps/to_fct.md
+++ b/tests/testthat/_snaps/to_fct.md
@@ -1,10 +1,8 @@
 # to_fct() throws errors for bad levels (#62, #67, #177)
 
     Code
-      (expect_pkg_error_classes(to_fct(letters[1:5], levels = c("a", "c"), to_na = "b"),
-      "stbl", "fct_levels"))
-    Output
-      <error/stbl-error-fct_levels>
+      to_fct(letters[1:5], levels = c("a", "c"), to_na = "b")
+    Condition <stbl-error-fct_levels>
       Error:
       ! Each value of `letters[1:5]` must be in the expected levels.
       i Allowed levels: "a" and "c".
@@ -14,10 +12,8 @@
 ---
 
     Code
-      (expect_pkg_error_classes(wrapped_to_fct(letters[1:5], levels = c("a", "c"),
-      to_na = "b"), "stbl", "fct_levels"))
-    Output
-      <error/stbl-error-fct_levels>
+      wrapped_to_fct(letters[1:5], levels = c("a", "c"), to_na = "b")
+    Condition <stbl-error-fct_levels>
       Error in `wrapped_to_fct()`:
       ! Each value of `val` must be in the expected levels.
       i Allowed levels: "a" and "c".
@@ -27,29 +23,24 @@
 # to_fct() respects allow_null (#62)
 
     Code
-      (expect_pkg_error_classes(to_fct(given, allow_null = FALSE), "stbl", "bad_null")
-      )
-    Output
-      <error/stbl-error-bad_null>
+      to_fct(given, allow_null = FALSE)
+    Condition <stbl-error-bad_null>
       Error:
       ! `given` must not be <NULL>.
 
 ---
 
     Code
-      (expect_pkg_error_classes(wrapped_to_fct(given, allow_null = FALSE), "stbl",
-      "bad_null"))
-    Output
-      <error/stbl-error-bad_null>
+      wrapped_to_fct(given, allow_null = FALSE)
+    Condition <stbl-error-bad_null>
       Error in `wrapped_to_fct()`:
       ! `val` must not be <NULL>.
 
 # to_fct() works for lists (#64, #273)
 
     Code
-      (expect_pkg_error_classes(to_fct(list("a", 1:5)), "stbl", "incompatible_type"))
-    Output
-      <error/stbl-error-incompatible_type>
+      to_fct(list("a", 1:5))
+    Condition <stbl-error-incompatible_type>
       Error:
       ! `list("a", 1:5)` <list> must be coercible to <factor>
       x Can't convert some values due to incompatible element types.
@@ -58,45 +49,40 @@
 # to_fct() errors for things that can't be coerced (#62, #273)
 
     Code
-      (expect_pkg_error_classes(to_fct(given), "stbl", "coerce", "factor"))
-    Output
-      <error/stbl-error-coerce-factor>
+      to_fct(given)
+    Condition <stbl-error-coerce-factor>
       Error:
       ! Can't coerce `given` <function> to <factor>.
 
 ---
 
     Code
-      (expect_pkg_error_classes(wrapped_to_fct(given), "stbl", "coerce", "factor"))
-    Output
-      <error/stbl-error-coerce-factor>
+      wrapped_to_fct(given)
+    Condition <stbl-error-coerce-factor>
       Error in `wrapped_to_fct()`:
       ! Can't coerce `val` <function> to <factor>.
 
 ---
 
     Code
-      (expect_pkg_error_classes(to_fct(given), "stbl", "coerce", "factor"))
-    Output
-      <error/stbl-error-coerce-factor>
+      to_fct(given)
+    Condition <stbl-error-coerce-factor>
       Error:
       ! Can't coerce `given` <data.frame> to <factor>.
 
 ---
 
     Code
-      (expect_pkg_error_classes(wrapped_to_fct(given), "stbl", "coerce", "factor"))
-    Output
-      <error/stbl-error-coerce-factor>
+      wrapped_to_fct(given)
+    Condition <stbl-error-coerce-factor>
       Error in `wrapped_to_fct()`:
       ! Can't coerce `val` <data.frame> to <factor>.
 
 ---
 
     Code
-      (expect_pkg_error_classes(to_fct(given), "stbl", "incompatible_type"))
-    Output
-      <error/stbl-error-incompatible_type>
+      to_fct(given)
+    Condition <stbl-error-incompatible_type>
       Error:
       ! `given` <list> must be coercible to <factor>
       x Can't convert some values due to incompatible element types.
@@ -105,9 +91,8 @@
 ---
 
     Code
-      (expect_pkg_error_classes(wrapped_to_fct(given), "stbl", "incompatible_type"))
-    Output
-      <error/stbl-error-incompatible_type>
+      wrapped_to_fct(given)
+    Condition <stbl-error-incompatible_type>
       Error in `wrapped_to_fct()`:
       ! `val` <list> must be coercible to <factor>
       x Can't convert some values due to incompatible element types.
@@ -116,9 +101,8 @@
 # to_fct_scalar() provides informative error messages (#62)
 
     Code
-      (expect_pkg_error_classes(to_fct_scalar(given), "stbl", "non_scalar"))
-    Output
-      <error/stbl-error-non_scalar>
+      to_fct_scalar(given)
+    Condition <stbl-error-non_scalar>
       Error:
       ! `given` must be a single <factor>.
       x `given` has 26 values.
@@ -126,9 +110,8 @@
 ---
 
     Code
-      (expect_pkg_error_classes(wrapped_to_fct_scalar(given), "stbl", "non_scalar"))
-    Output
-      <error/stbl-error-non_scalar>
+      wrapped_to_fct_scalar(given)
+    Condition <stbl-error-non_scalar>
       Error in `wrapped_to_fct_scalar()`:
       ! `val` must be a single <factor>.
       x `val` has 26 values.
@@ -136,9 +119,8 @@
 # to_fct_scalar respects allow_zero_length (#62, #43, #45, #189)
 
     Code
-      (expect_pkg_error_classes(to_fct_scalar(given), "stbl", "bad_empty"))
-    Output
-      <error/stbl-error-bad_empty>
+      to_fct_scalar(given)
+    Condition <stbl-error-bad_empty>
       Error:
       ! `given` must be a single <factor (non-empty)>.
       x `given` has no values.
@@ -146,10 +128,8 @@
 # to_fct() errors for ints with unexpected levels (#241)
 
     Code
-      (expect_pkg_error_classes(to_fct(given, levels = c("1", "2")), "stbl",
-      "fct_levels"))
-    Output
-      <error/stbl-error-fct_levels>
+      to_fct(given, levels = c("1", "2"))
+    Condition <stbl-error-fct_levels>
       Error:
       ! Each value of `<chr>` must be in the expected levels.
       i Allowed levels: "1" and "2".
@@ -158,10 +138,8 @@
 ---
 
     Code
-      (expect_pkg_error_classes(wrapped_to_fct(given, levels = c("1", "2")), "stbl",
-      "fct_levels"))
-    Output
-      <error/stbl-error-fct_levels>
+      wrapped_to_fct(given, levels = c("1", "2"))
+    Condition <stbl-error-fct_levels>
       Error in `wrapped_to_fct()`:
       ! Each value of `<chr>` must be in the expected levels.
       i Allowed levels: "1" and "2".

--- a/tests/testthat/_snaps/to_fn.md
+++ b/tests/testthat/_snaps/to_fn.md
@@ -1,78 +1,64 @@
 # to_fn() respects allow_null for NULL input (#250)
 
     Code
-      (expect_pkg_error_classes(to_fn(NULL, allow_null = FALSE), "stbl", "bad_null"))
-    Output
-      <error/stbl-error-bad_null>
+      to_fn(NULL, allow_null = FALSE)
+    Condition <stbl-error-bad_null>
       Error:
       ! `NULL` must not be <NULL>.
 
 ---
 
     Code
-      (expect_pkg_error_classes(wrapped_to_fn(NULL, allow_null = FALSE), "stbl",
-      "bad_null"))
-    Output
-      <error/stbl-error-bad_null>
+      wrapped_to_fn(NULL, allow_null = FALSE)
+    Condition <stbl-error-bad_null>
       Error in `wrapped_to_fn()`:
       ! `val` must not be <NULL>.
 
 # to_fn() fails cleanly for weird ':' use in character names (#250)
 
     Code
-      (expect_pkg_error_classes(to_fn("base:mean"), "stbl", "invalid_function_name"))
-    Output
-      <error/stbl-error-invalid_function_name>
+      to_fn("base:mean")
+    Condition <stbl-error-invalid_function_name>
       Error:
       ! `"base:mean"` must be a valid function name.
 
 ---
 
     Code
-      (expect_pkg_error_classes(to_fn("base::mean::thing"), "stbl",
-      "invalid_function_name"))
-    Output
-      <error/stbl-error-invalid_function_name>
+      to_fn("base::mean::thing")
+    Condition <stbl-error-invalid_function_name>
       Error:
       ! `"base::mean::thing"` must be a valid function name.
 
 ---
 
     Code
-      (expect_pkg_error_classes(to_fn("base::mean:thing"), "stbl",
-      "invalid_function_name"))
-    Output
-      <error/stbl-error-invalid_function_name>
+      to_fn("base::mean:thing")
+    Condition <stbl-error-invalid_function_name>
       Error:
       ! `"base::mean:thing"` must be a valid function name.
 
 ---
 
     Code
-      (expect_pkg_error_classes(to_fn("base:mean:thing"), "stbl",
-      "invalid_function_name"))
-    Output
-      <error/stbl-error-invalid_function_name>
+      to_fn("base:mean:thing")
+    Condition <stbl-error-invalid_function_name>
       Error:
       ! `"base:mean:thing"` must be a valid function name.
 
 ---
 
     Code
-      (expect_pkg_error_classes(to_fn("base:mean::thing"), "stbl",
-      "invalid_function_name"))
-    Output
-      <error/stbl-error-invalid_function_name>
+      to_fn("base:mean::thing")
+    Condition <stbl-error-invalid_function_name>
       Error:
       ! `"base:mean::thing"` must be a valid function name.
 
 # to_fn() errors informatively for unknown character names (#250)
 
     Code
-      (expect_pkg_error_classes(to_fn("not_a_real_function_xyz"), "stbl",
-      "unknown_function"))
-    Output
-      <error/stbl-error-unknown_function>
+      to_fn("not_a_real_function_xyz")
+    Condition <stbl-error-unknown_function>
       Error:
       ! `"not_a_real_function_xyz"` must be the name of a known function.
       x Can't find function `not_a_real_function_xyz()`.
@@ -80,10 +66,8 @@
 ---
 
     Code
-      (expect_pkg_error_classes(wrapped_to_fn("not_a_real_function_xyz"), "stbl",
-      "unknown_function"))
-    Output
-      <error/stbl-error-unknown_function>
+      wrapped_to_fn("not_a_real_function_xyz")
+    Condition <stbl-error-unknown_function>
       Error in `wrapped_to_fn()`:
       ! `val` must be the name of a known function.
       x Can't find function `not_a_real_function_xyz()`.
@@ -91,9 +75,8 @@
 # to_fn() errors for length > 1 character input (#250)
 
     Code
-      (expect_pkg_error_classes(to_fn(c("mean", "sum")), "stbl", "non_scalar"))
-    Output
-      <error/stbl-error-non_scalar>
+      to_fn(c("mean", "sum"))
+    Condition <stbl-error-non_scalar>
       Error:
       ! `c("mean", "sum")` must be a single function name.
       x `c("mean", "sum")` has 2 values.
@@ -101,10 +84,8 @@
 ---
 
     Code
-      (expect_pkg_error_classes(wrapped_to_fn(c("mean", "sum")), "stbl", "non_scalar")
-      )
-    Output
-      <error/stbl-error-non_scalar>
+      wrapped_to_fn(c("mean", "sum"))
+    Condition <stbl-error-non_scalar>
       Error in `wrapped_to_fn()`:
       ! `val` must be a single function name.
       x `val` has 2 values.
@@ -112,20 +93,16 @@
 # to_fn() respects allow_null for length-0 character input (#250)
 
     Code
-      (expect_pkg_error_classes(to_fn(character(), allow_null = FALSE), "stbl",
-      "bad_null"))
-    Output
-      <error/stbl-error-bad_null>
+      to_fn(character(), allow_null = FALSE)
+    Condition <stbl-error-bad_null>
       Error:
       ! `character()` must not be <NULL>.
 
 # to_fn() errors informatively for bad namespaced names (#250)
 
     Code
-      (expect_pkg_error_classes(to_fn("nonexistent_pkg::mean"), "stbl",
-      "unknown_function"))
-    Output
-      <error/stbl-error-unknown_function>
+      to_fn("nonexistent_pkg::mean")
+    Condition <stbl-error-unknown_function>
       Error:
       ! `"nonexistent_pkg::mean"` must be the name of a known function.
       x Can't find function `nonexistent_pkg::mean()`.
@@ -133,9 +110,8 @@
 # to_fn() errors informatively for non-coercible types (#250)
 
     Code
-      (expect_pkg_error_classes(to_fn(1L), "stbl", "coerce", "function"))
-    Output
-      <error/stbl-error-coerce-function>
+      to_fn(1L)
+    Condition <stbl-error-coerce-function>
       Error:
       ! Can't coerce `1L` <integer> to <function>.
 

--- a/tests/testthat/_snaps/to_int.md
+++ b/tests/testthat/_snaps/to_int.md
@@ -1,29 +1,24 @@
 # to_int() respects allow_null (#2)
 
     Code
-      (expect_pkg_error_classes(to_int(given, allow_null = FALSE), "stbl", "bad_null")
-      )
-    Output
-      <error/stbl-error-bad_null>
+      to_int(given, allow_null = FALSE)
+    Condition <stbl-error-bad_null>
       Error:
       ! `given` must not be <NULL>.
 
 ---
 
     Code
-      (expect_pkg_error_classes(wrapped_to_int(given, allow_null = FALSE), "stbl",
-      "bad_null"))
-    Output
-      <error/stbl-error-bad_null>
+      wrapped_to_int(given, allow_null = FALSE)
+    Condition <stbl-error-bad_null>
       Error in `wrapped_to_int()`:
       ! `val` must not be <NULL>.
 
 # to_int() errors for dbls that would lose precision (#2, #217)
 
     Code
-      (expect_pkg_error_classes(to_int(given), "stbl", "incompatible_type"))
-    Output
-      <error/stbl-error-incompatible_type>
+      to_int(given)
+    Condition <stbl-error-incompatible_type>
       Error:
       ! `given` <double> must be coercible to <integer>
       x Can't convert some values due to loss of precision.
@@ -32,9 +27,8 @@
 ---
 
     Code
-      (expect_pkg_error_classes(wrapped_to_int(given), "stbl", "incompatible_type"))
-    Output
-      <error/stbl-error-incompatible_type>
+      wrapped_to_int(given)
+    Condition <stbl-error-incompatible_type>
       Error in `wrapped_to_int()`:
       ! `val` <double> must be coercible to <integer>
       x Can't convert some values due to loss of precision.
@@ -43,9 +37,8 @@
 ---
 
     Code
-      (expect_pkg_error_classes(to_int(given), "stbl", "incompatible_type"))
-    Output
-      <error/stbl-error-incompatible_type>
+      to_int(given)
+    Condition <stbl-error-incompatible_type>
       Error:
       ! `given` <double> must be coercible to <integer>
       x Can't convert some values due to loss of precision.
@@ -54,9 +47,8 @@
 ---
 
     Code
-      (expect_pkg_error_classes(wrapped_to_int(given), "stbl", "incompatible_type"))
-    Output
-      <error/stbl-error-incompatible_type>
+      wrapped_to_int(given)
+    Condition <stbl-error-incompatible_type>
       Error in `wrapped_to_int()`:
       ! `val` <double> must be coercible to <integer>
       x Can't convert some values due to loss of precision.
@@ -65,29 +57,24 @@
 # to_int() respects coerce_character (#14)
 
     Code
-      (expect_pkg_error_classes(to_int(given, coerce_character = FALSE), "stbl",
-      "coerce", "integer"))
-    Output
-      <error/stbl-error-coerce-integer>
+      to_int(given, coerce_character = FALSE)
+    Condition <stbl-error-coerce-integer>
       Error:
       ! Can't coerce `given` <character> to <integer>.
 
 ---
 
     Code
-      (expect_pkg_error_classes(wrapped_to_int(given, coerce_character = FALSE),
-      "stbl", "coerce", "integer"))
-    Output
-      <error/stbl-error-coerce-integer>
+      wrapped_to_int(given, coerce_character = FALSE)
+    Condition <stbl-error-coerce-integer>
       Error in `wrapped_to_int()`:
       ! Can't coerce `val` <character> to <integer>.
 
 # to_int() errors informatively for bad chrs (#2)
 
     Code
-      (expect_pkg_error_classes(to_int(given), "stbl", "incompatible_type"))
-    Output
-      <error/stbl-error-incompatible_type>
+      to_int(given)
+    Condition <stbl-error-incompatible_type>
       Error:
       ! `given` <character> must be coercible to <integer>
       x Can't convert some values due to loss of precision.
@@ -96,9 +83,8 @@
 ---
 
     Code
-      (expect_pkg_error_classes(wrapped_to_int(given), "stbl", "incompatible_type"))
-    Output
-      <error/stbl-error-incompatible_type>
+      wrapped_to_int(given)
+    Condition <stbl-error-incompatible_type>
       Error in `wrapped_to_int()`:
       ! `val` <character> must be coercible to <integer>
       x Can't convert some values due to loss of precision.
@@ -107,9 +93,8 @@
 ---
 
     Code
-      (expect_pkg_error_classes(to_int(given), "stbl", "incompatible_type"))
-    Output
-      <error/stbl-error-incompatible_type>
+      to_int(given)
+    Condition <stbl-error-incompatible_type>
       Error:
       ! `given` <character> must be coercible to <integer>
       x Can't convert some values due to incompatible values.
@@ -118,9 +103,8 @@
 ---
 
     Code
-      (expect_pkg_error_classes(wrapped_to_int(given), "stbl", "incompatible_type"))
-    Output
-      <error/stbl-error-incompatible_type>
+      wrapped_to_int(given)
+    Condition <stbl-error-incompatible_type>
       Error in `wrapped_to_int()`:
       ! `val` <character> must be coercible to <integer>
       x Can't convert some values due to incompatible values.
@@ -129,9 +113,8 @@
 # to_int() errors informatively for bad complexes (#2)
 
     Code
-      (expect_pkg_error_classes(to_int(given), "stbl", "incompatible_type"))
-    Output
-      <error/stbl-error-incompatible_type>
+      to_int(given)
+    Condition <stbl-error-incompatible_type>
       Error:
       ! `given` <complex> must be coercible to <integer>
       x Can't convert some values due to non-zero complex components.
@@ -140,9 +123,8 @@
 ---
 
     Code
-      (expect_pkg_error_classes(wrapped_to_int(given), "stbl", "incompatible_type"))
-    Output
-      <error/stbl-error-incompatible_type>
+      wrapped_to_int(given)
+    Condition <stbl-error-incompatible_type>
       Error in `wrapped_to_int()`:
       ! `val` <complex> must be coercible to <integer>
       x Can't convert some values due to non-zero complex components.
@@ -151,9 +133,8 @@
 # to_int() errors for complexes that would lose precision (#noissue)
 
     Code
-      (expect_pkg_error_classes(to_int(given), "stbl", "incompatible_type"))
-    Output
-      <error/stbl-error-incompatible_type>
+      to_int(given)
+    Condition <stbl-error-incompatible_type>
       Error:
       ! `given` <complex> must be coercible to <integer>
       x Can't convert some values due to loss of precision.
@@ -162,9 +143,8 @@
 ---
 
     Code
-      (expect_pkg_error_classes(wrapped_to_int(given), "stbl", "incompatible_type"))
-    Output
-      <error/stbl-error-incompatible_type>
+      wrapped_to_int(given)
+    Condition <stbl-error-incompatible_type>
       Error in `wrapped_to_int()`:
       ! `val` <complex> must be coercible to <integer>
       x Can't convert some values due to loss of precision.
@@ -173,9 +153,8 @@
 ---
 
     Code
-      (expect_pkg_error_classes(to_int(given), "stbl", "incompatible_type"))
-    Output
-      <error/stbl-error-incompatible_type>
+      to_int(given)
+    Condition <stbl-error-incompatible_type>
       Error:
       ! `given` <complex> must be coercible to <integer>
       x Can't convert some values due to loss of precision.
@@ -184,9 +163,8 @@
 ---
 
     Code
-      (expect_pkg_error_classes(wrapped_to_int(given), "stbl", "incompatible_type"))
-    Output
-      <error/stbl-error-incompatible_type>
+      wrapped_to_int(given)
+    Condition <stbl-error-incompatible_type>
       Error in `wrapped_to_int()`:
       ! `val` <complex> must be coercible to <integer>
       x Can't convert some values due to loss of precision.
@@ -195,29 +173,24 @@
 # to_int() respects coerce_factor (#14)
 
     Code
-      (expect_pkg_error_classes(to_int(given, coerce_factor = FALSE), "stbl",
-      "coerce", "integer"))
-    Output
-      <error/stbl-error-coerce-integer>
+      to_int(given, coerce_factor = FALSE)
+    Condition <stbl-error-coerce-integer>
       Error:
       ! Can't coerce `given` <factor> to <integer>.
 
 ---
 
     Code
-      (expect_pkg_error_classes(wrapped_to_int(given, coerce_factor = FALSE), "stbl",
-      "coerce", "integer"))
-    Output
-      <error/stbl-error-coerce-integer>
+      wrapped_to_int(given, coerce_factor = FALSE)
+    Condition <stbl-error-coerce-integer>
       Error in `wrapped_to_int()`:
       ! Can't coerce `val` <factor> to <integer>.
 
 # to_int() errors informatively for bad factors (#4)
 
     Code
-      (expect_pkg_error_classes(to_int(given), "stbl", "incompatible_type"))
-    Output
-      <error/stbl-error-incompatible_type>
+      to_int(given)
+    Condition <stbl-error-incompatible_type>
       Error:
       ! `given` <factor> must be coercible to <integer>
       x Can't convert some values due to incompatible values.
@@ -226,9 +199,8 @@
 ---
 
     Code
-      (expect_pkg_error_classes(wrapped_to_int(given), "stbl", "incompatible_type"))
-    Output
-      <error/stbl-error-incompatible_type>
+      wrapped_to_int(given)
+    Condition <stbl-error-incompatible_type>
       Error in `wrapped_to_int()`:
       ! `val` <factor> must be coercible to <integer>
       x Can't convert some values due to incompatible values.
@@ -237,9 +209,8 @@
 # to_int() works for lists (#2, #273)
 
     Code
-      (expect_pkg_error_classes(to_int(list(1L, 1:5)), "stbl", "incompatible_type"))
-    Output
-      <error/stbl-error-incompatible_type>
+      to_int(list(1L, 1:5))
+    Condition <stbl-error-incompatible_type>
       Error:
       ! `list(1L, 1:5)` <list> must be coercible to <integer>
       x Can't convert some values due to incompatible element types.
@@ -248,9 +219,8 @@
 # to_int_scalar() provides informative error messages (#12)
 
     Code
-      (expect_pkg_error_classes(to_int_scalar(given), "stbl", "non_scalar"))
-    Output
-      <error/stbl-error-non_scalar>
+      to_int_scalar(given)
+    Condition <stbl-error-non_scalar>
       Error:
       ! `given` must be a single <integer>.
       x `given` has 10 values.
@@ -258,9 +228,8 @@
 ---
 
     Code
-      (expect_pkg_error_classes(wrapped_to_int_scalar(given), "stbl", "non_scalar"))
-    Output
-      <error/stbl-error-non_scalar>
+      wrapped_to_int_scalar(given)
+    Condition <stbl-error-non_scalar>
       Error in `wrapped_to_int_scalar()`:
       ! `val` must be a single <integer>.
       x `val` has 10 values.
@@ -268,27 +237,24 @@
 # to_int_scalar() respects allow_null (#12, #189)
 
     Code
-      (expect_pkg_error_classes(to_int_scalar(given), "stbl", "bad_null"))
-    Output
-      <error/stbl-error-bad_null>
+      to_int_scalar(given)
+    Condition <stbl-error-bad_null>
       Error:
       ! `given` must not be <NULL>.
 
 ---
 
     Code
-      (expect_pkg_error_classes(wrapped_to_int_scalar(given), "stbl", "bad_null"))
-    Output
-      <error/stbl-error-bad_null>
+      wrapped_to_int_scalar(given)
+    Condition <stbl-error-bad_null>
       Error in `wrapped_to_int_scalar()`:
       ! `val` must not be <NULL>.
 
 # to_int_scalar respects allow_zero_length (#12, #43, #45, #189)
 
     Code
-      (expect_pkg_error_classes(to_int_scalar(given), "stbl", "bad_empty"))
-    Output
-      <error/stbl-error-bad_empty>
+      to_int_scalar(given)
+    Condition <stbl-error-bad_empty>
       Error:
       ! `given` must be a single <integer (non-empty)>.
       x `given` has no values.

--- a/tests/testthat/_snaps/to_lgl.md
+++ b/tests/testthat/_snaps/to_lgl.md
@@ -1,29 +1,24 @@
 # to_lgl() respects allow_null (#21)
 
     Code
-      (expect_pkg_error_classes(to_lgl(given, allow_null = FALSE), "stbl", "bad_null")
-      )
-    Output
-      <error/stbl-error-bad_null>
+      to_lgl(given, allow_null = FALSE)
+    Condition <stbl-error-bad_null>
       Error:
       ! `given` must not be <NULL>.
 
 ---
 
     Code
-      (expect_pkg_error_classes(wrapped_to_lgl(given, allow_null = FALSE), "stbl",
-      "bad_null"))
-    Output
-      <error/stbl-error-bad_null>
+      wrapped_to_lgl(given, allow_null = FALSE)
+    Condition <stbl-error-bad_null>
       Error in `wrapped_to_lgl()`:
       ! `val` must not be <NULL>.
 
 # to_lgl() errors for bad characters (#21)
 
     Code
-      (expect_pkg_error_classes(to_lgl(letters), "stbl", "incompatible_type"))
-    Output
-      <error/stbl-error-incompatible_type>
+      to_lgl(letters)
+    Condition <stbl-error-incompatible_type>
       Error:
       ! `letters` <character> must be coercible to <logical>
       x Can't convert some values due to incompatible values.
@@ -32,9 +27,8 @@
 ---
 
     Code
-      (expect_pkg_error_classes(wrapped_to_lgl(letters), "stbl", "incompatible_type"))
-    Output
-      <error/stbl-error-incompatible_type>
+      wrapped_to_lgl(letters)
+    Condition <stbl-error-incompatible_type>
       Error in `wrapped_to_lgl()`:
       ! `val` <character> must be coercible to <logical>
       x Can't convert some values due to incompatible values.
@@ -43,9 +37,8 @@
 # to_lgl errors for bad factors (#21)
 
     Code
-      (expect_pkg_error_classes(to_lgl(given), "stbl", "incompatible_type"))
-    Output
-      <error/stbl-error-incompatible_type>
+      to_lgl(given)
+    Condition <stbl-error-incompatible_type>
       Error:
       ! `given` <factor> must be coercible to <logical>
       x Can't convert some values due to incompatible values.
@@ -54,9 +47,8 @@
 ---
 
     Code
-      (expect_pkg_error_classes(wrapped_to_lgl(given), "stbl", "incompatible_type"))
-    Output
-      <error/stbl-error-incompatible_type>
+      wrapped_to_lgl(given)
+    Condition <stbl-error-incompatible_type>
       Error in `wrapped_to_lgl()`:
       ! `val` <factor> must be coercible to <logical>
       x Can't convert some values due to incompatible values.
@@ -65,9 +57,8 @@
 # to_lgl() works for lists (#21, #273)
 
     Code
-      (expect_pkg_error_classes(to_lgl(list(TRUE, 1:5)), "stbl", "incompatible_type"))
-    Output
-      <error/stbl-error-incompatible_type>
+      to_lgl(list(TRUE, 1:5))
+    Condition <stbl-error-incompatible_type>
       Error:
       ! `list(TRUE, 1:5)` <list> must be coercible to <logical>
       x Can't convert some values due to incompatible element types.
@@ -76,9 +67,8 @@
 # to_lgl() errors for other types (#21, #273)
 
     Code
-      (expect_pkg_error_classes(to_lgl(given), "stbl", "incompatible_type"))
-    Output
-      <error/stbl-error-incompatible_type>
+      to_lgl(given)
+    Condition <stbl-error-incompatible_type>
       Error:
       ! `given` <list> must be coercible to <logical>
       x Can't convert some values due to incompatible element types.
@@ -87,9 +77,8 @@
 ---
 
     Code
-      (expect_pkg_error_classes(wrapped_to_lgl(given), "stbl", "incompatible_type"))
-    Output
-      <error/stbl-error-incompatible_type>
+      wrapped_to_lgl(given)
+    Condition <stbl-error-incompatible_type>
       Error in `wrapped_to_lgl()`:
       ! `val` <list> must be coercible to <logical>
       x Can't convert some values due to incompatible element types.
@@ -98,27 +87,24 @@
 ---
 
     Code
-      (expect_pkg_error_classes(to_lgl(given), "stbl", "coerce", "logical"))
-    Output
-      <error/stbl-error-coerce-logical>
+      to_lgl(given)
+    Condition <stbl-error-coerce-logical>
       Error:
       ! Can't coerce `given` <function> to <logical>.
 
 ---
 
     Code
-      (expect_pkg_error_classes(wrapped_to_lgl(given), "stbl", "coerce", "logical"))
-    Output
-      <error/stbl-error-coerce-logical>
+      wrapped_to_lgl(given)
+    Condition <stbl-error-coerce-logical>
       Error in `wrapped_to_lgl()`:
       ! Can't coerce `val` <function> to <logical>.
 
 # to_lgl_scalar() errors for non-scalars (#32)
 
     Code
-      (expect_pkg_error_classes(to_lgl_scalar(given), "stbl", "non_scalar"))
-    Output
-      <error/stbl-error-non_scalar>
+      to_lgl_scalar(given)
+    Condition <stbl-error-non_scalar>
       Error:
       ! `given` must be a single <logical>.
       x `given` has 3 values.
@@ -126,9 +112,8 @@
 ---
 
     Code
-      (expect_pkg_error_classes(wrapped_to_lgl_scalar(given), "stbl", "non_scalar"))
-    Output
-      <error/stbl-error-non_scalar>
+      wrapped_to_lgl_scalar(given)
+    Condition <stbl-error-non_scalar>
       Error in `wrapped_to_lgl_scalar()`:
       ! `val` must be a single <logical>.
       x `val` has 3 values.
@@ -136,9 +121,8 @@
 # to_lgl_scalar() errors for bad characters (#32)
 
     Code
-      (expect_pkg_error_classes(to_lgl_scalar(given), "stbl", "incompatible_type"))
-    Output
-      <error/stbl-error-incompatible_type>
+      to_lgl_scalar(given)
+    Condition <stbl-error-incompatible_type>
       Error:
       ! `given` <character> must be coercible to <logical>
       x Can't convert some values due to incompatible values.
@@ -147,10 +131,8 @@
 ---
 
     Code
-      (expect_pkg_error_classes(wrapped_to_lgl_scalar(given), "stbl",
-      "incompatible_type"))
-    Output
-      <error/stbl-error-incompatible_type>
+      wrapped_to_lgl_scalar(given)
+    Condition <stbl-error-incompatible_type>
       Error in `wrapped_to_lgl_scalar()`:
       ! `val` <character> must be coercible to <logical>
       x Can't convert some values due to incompatible values.
@@ -159,18 +141,16 @@
 # to_lgl_scalar() respects allow_null (#32, #189)
 
     Code
-      (expect_pkg_error_classes(to_lgl_scalar(given), "stbl", "bad_null"))
-    Output
-      <error/stbl-error-bad_null>
+      to_lgl_scalar(given)
+    Condition <stbl-error-bad_null>
       Error:
       ! `given` must not be <NULL>.
 
 ---
 
     Code
-      (expect_pkg_error_classes(wrapped_to_lgl_scalar(given), "stbl", "bad_null"))
-    Output
-      <error/stbl-error-bad_null>
+      wrapped_to_lgl_scalar(given)
+    Condition <stbl-error-bad_null>
       Error in `wrapped_to_lgl_scalar()`:
       ! `val` must not be <NULL>.
 

--- a/tests/testthat/_snaps/to_lst.md
+++ b/tests/testthat/_snaps/to_lst.md
@@ -1,20 +1,16 @@
 # to_lst() respects allow_null (#157)
 
     Code
-      (expect_pkg_error_classes(to_lst(given, allow_null = FALSE), "stbl", "bad_null")
-      )
-    Output
-      <error/stbl-error-bad_null>
+      to_lst(given, allow_null = FALSE)
+    Condition <stbl-error-bad_null>
       Error:
       ! `given` must not be <NULL>.
 
 ---
 
     Code
-      (expect_pkg_error_classes(wrapped_to_lst(given, allow_null = FALSE), "stbl",
-      "bad_null"))
-    Output
-      <error/stbl-error-bad_null>
+      wrapped_to_lst(given, allow_null = FALSE)
+    Condition <stbl-error-bad_null>
       Error in `wrapped_to_lst()`:
       ! `val` must not be <NULL>.
 
@@ -41,38 +37,32 @@
 # to_lst() errors by default for functions (#157)
 
     Code
-      (expect_pkg_error_classes(to_lst(given), "stbl", "bad_function"))
-    Output
-      <error/stbl-error-bad_function>
+      to_lst(given)
+    Condition <stbl-error-bad_function>
       Error:
       ! `given` must not be a <function>.
 
 ---
 
     Code
-      (expect_pkg_error_classes(wrapped_to_lst(given), "stbl", "bad_function"))
-    Output
-      <error/stbl-error-bad_function>
+      wrapped_to_lst(given)
+    Condition <stbl-error-bad_function>
       Error in `wrapped_to_lst()`:
       ! `val` must not be a <function>.
 
 # to_lst() errors informatively for primitives (#157)
 
     Code
-      (expect_pkg_error_classes(to_lst(given, coerce_function = TRUE), "stbl",
-      "coerce", "list"))
-    Output
-      <error/stbl-error-coerce-list>
+      to_lst(given, coerce_function = TRUE)
+    Condition <stbl-error-coerce-list>
       Error:
       ! Can't coerce `given` <primitive function> to <list>.
 
 ---
 
     Code
-      (expect_pkg_error_classes(wrapped_to_lst(given, coerce_function = TRUE), "stbl",
-      "coerce", "list"))
-    Output
-      <error/stbl-error-coerce-list>
+      wrapped_to_lst(given, coerce_function = TRUE)
+    Condition <stbl-error-coerce-list>
       Error in `wrapped_to_lst()`:
       ! Can't coerce `val` <primitive function> to <list>.
 

--- a/tests/testthat/_snaps/to_null.md
+++ b/tests/testthat/_snaps/to_null.md
@@ -1,40 +1,32 @@
 # .to_null() errors when NULL isn't allowed (#129)
 
     Code
-      (expect_pkg_error_classes(.to_null(given, allow_null = FALSE), "stbl",
-      "bad_null"))
-    Output
-      <error/stbl-error-bad_null>
+      .to_null(given, allow_null = FALSE)
+    Condition <stbl-error-bad_null>
       Error:
       ! `given` must not be <NULL>.
 
 ---
 
     Code
-      (expect_pkg_error_classes(wrapped_to_null(given, allow_null = FALSE), "stbl",
-      "bad_null"))
-    Output
-      <error/stbl-error-bad_null>
+      wrapped_to_null(given, allow_null = FALSE)
+    Condition <stbl-error-bad_null>
       Error in `wrapped_to_null()`:
       ! `val` must not be <NULL>.
 
 # .to_null() errors for bad allow_null (#129)
 
     Code
-      (expect_pkg_error_classes(.to_null(NULL, allow_null = NULL), "stbl", "bad_null")
-      )
-    Output
-      <error/stbl-error-bad_null>
+      .to_null(NULL, allow_null = NULL)
+    Condition <stbl-error-bad_null>
       Error:
       ! `allow_null` must not be <NULL>.
 
 ---
 
     Code
-      (expect_pkg_error_classes(.to_null(NULL, allow_null = "fish"), "stbl",
-      "incompatible_type"))
-    Output
-      <error/stbl-error-incompatible_type>
+      .to_null(NULL, allow_null = "fish")
+    Condition <stbl-error-incompatible_type>
       Error:
       ! `allow_null` <character> must be coercible to <logical>
       x Can't convert some values due to incompatible values.
@@ -43,10 +35,8 @@
 ---
 
     Code
-      (expect_pkg_error_classes(wrapped_to_null(NULL, allow_null = "fish"), "stbl",
-      "incompatible_type"))
-    Output
-      <error/stbl-error-incompatible_type>
+      wrapped_to_null(NULL, allow_null = "fish")
+    Condition <stbl-error-incompatible_type>
       Error in `wrapped_to_null()`:
       ! `allow_null` <character> must be coercible to <logical>
       x Can't convert some values due to incompatible values.
@@ -55,9 +45,8 @@
 # .to_null() errors informatively for missing value (#129)
 
     Code
-      (expect_pkg_error_classes(.to_null(), "stbl", "must"))
-    Output
-      <error/stbl-error-must>
+      .to_null()
+    Condition <stbl-error-must>
       Error:
       ! `unknown arg` must not be missing.
 

--- a/tests/testthat/test-pkg_abort.R
+++ b/tests/testthat/test-pkg_abort.R
@@ -179,7 +179,7 @@ test_that(".strip_covr_from_expr() removes covr counter wrappers (#253)", {
   )
 })
 
-test_that("expect_pkg_error_snapshot() snapshots error class and message (#188)", {
+test_that("expect_pkg_error_snapshot() snapshots error class and message (#188, #301)", {
   expect_pkg_error_snapshot(
     pkg_abort("stbl", "A snapshot error.", "snapshot_subclass"),
     "stbl",
@@ -187,7 +187,7 @@ test_that("expect_pkg_error_snapshot() snapshots error class and message (#188)"
   )
 })
 
-test_that("expect_pkg_error_snapshot() works with multiple class components (#188)", {
+test_that("expect_pkg_error_snapshot() works with multiple class components (#188, #301)", {
   expect_pkg_error_snapshot(
     pkg_abort("stbl", "A nested error.", c("outer", "inner")),
     "stbl",
@@ -196,7 +196,7 @@ test_that("expect_pkg_error_snapshot() works with multiple class components (#18
   )
 })
 
-test_that("expect_pkg_error_snapshot() works from an env without stbl attached (#188)", {
+test_that("expect_pkg_error_snapshot() works from an env without stbl attached (#188, #301)", {
   # Simulate calling from another package where expect_pkg_error_classes
   # isn't directly available in the caller's environment.
   foreign_env <- new.env(parent = baseenv())

--- a/tests/testthat/test-pkg_inform.R
+++ b/tests/testthat/test-pkg_inform.R
@@ -91,7 +91,7 @@ test_that("expect_pkg_message_classes() tests expressions for classes (#213)", {
   )
 })
 
-test_that("expect_pkg_message_snapshot() snapshots message class and message (#213)", {
+test_that("expect_pkg_message_snapshot() snapshots message class and message (#213, #301)", {
   expect_pkg_message_snapshot(
     pkg_inform("stbl", "A snapshot message.", "snapshot_subclass"),
     "stbl",
@@ -99,7 +99,7 @@ test_that("expect_pkg_message_snapshot() snapshots message class and message (#2
   )
 })
 
-test_that("expect_pkg_message_snapshot() works with multiple class components (#213)", {
+test_that("expect_pkg_message_snapshot() works with multiple class components (#213, #301)", {
   expect_pkg_message_snapshot(
     pkg_inform("stbl", "A nested message.", c("outer", "inner")),
     "stbl",
@@ -108,7 +108,7 @@ test_that("expect_pkg_message_snapshot() works with multiple class components (#
   )
 })
 
-test_that("expect_pkg_message_snapshot() allows object definition inside expression (#234)", {
+test_that("expect_pkg_message_snapshot() allows object definition inside expression (#234, #301)", {
   informs_and_returns <- function() {
     pkg_inform("stbl", "A message with a return value.", "return_subclass")
     "the return value"
@@ -123,7 +123,7 @@ test_that("expect_pkg_message_snapshot() allows object definition inside express
   expect_equal(result, "the return value")
 })
 
-test_that("expect_pkg_message_snapshot() works from an env without stbl attached (#213)", {
+test_that("expect_pkg_message_snapshot() works from an env without stbl attached (#213, #301)", {
   foreign_env <- new.env(parent = baseenv())
   foreign_env$pkg_inform <- pkg_inform
   foreign_env$expect_pkg_message_snapshot <- expect_pkg_message_snapshot

--- a/tests/testthat/test-pkg_warn.R
+++ b/tests/testthat/test-pkg_warn.R
@@ -101,7 +101,7 @@ test_that("expect_pkg_warning_classes() tests expressions for classes (#213)", {
   )
 })
 
-test_that("expect_pkg_warning_snapshot() snapshots warning class and message (#213)", {
+test_that("expect_pkg_warning_snapshot() snapshots warning class and message (#213, #301)", {
   expect_pkg_warning_snapshot(
     pkg_warn("stbl", "A snapshot warning.", "snapshot_subclass"),
     "stbl",
@@ -109,7 +109,7 @@ test_that("expect_pkg_warning_snapshot() snapshots warning class and message (#2
   )
 })
 
-test_that("expect_pkg_warning_snapshot() works with multiple class components (#213)", {
+test_that("expect_pkg_warning_snapshot() works with multiple class components (#213, #301)", {
   expect_pkg_warning_snapshot(
     pkg_warn("stbl", "A nested warning.", c("outer", "inner")),
     "stbl",
@@ -118,7 +118,7 @@ test_that("expect_pkg_warning_snapshot() works with multiple class components (#
   )
 })
 
-test_that("expect_pkg_warning_snapshot() allows object definition inside expression (#234)", {
+test_that("expect_pkg_warning_snapshot() allows object definition inside expression (#234, #301)", {
   warns_and_returns <- function() {
     pkg_warn("stbl", "A warning with a return value.", "return_subclass")
     "the return value"
@@ -133,7 +133,7 @@ test_that("expect_pkg_warning_snapshot() allows object definition inside express
   expect_equal(result, "the return value")
 })
 
-test_that("expect_pkg_warning_snapshot() works from an env without stbl attached (#213)", {
+test_that("expect_pkg_warning_snapshot() works from an env without stbl attached (#213, #301)", {
   foreign_env <- new.env(parent = baseenv())
   foreign_env$pkg_warn <- pkg_warn
   foreign_env$expect_pkg_warning_snapshot <- expect_pkg_warning_snapshot


### PR DESCRIPTION
Closes #301

## Summary

`expect_pkg_error_snapshot()`, `expect_pkg_message_snapshot()`, and `expect_pkg_warning_snapshot()` now produce snapshots that mirror `testthat::expect_snapshot()` output: the bare expression appears under `Code`, and the condition class is recorded alongside its message via `cnd_class = TRUE` (rather than wrapping the expression in `expect_pkg_*_classes()`).

## Approach

- `.expect_pkg_condition_snapshot()` now runs the class-hierarchy check (`expect_pkg_*_classes()`) first, then calls `testthat::expect_snapshot()` on the bare expression with `cnd_class = TRUE` and a parameterized `error` argument.
- `expect_pkg_error_snapshot()` was refactored to use the shared helper (`error = TRUE`); the warning and message wrappers pass `error = FALSE`.
- No unexported testthat internals are used.

## Breaking change

Every snapshot produced by these helpers changes format, so all affected snapshots were re-accepted. Downstream users will need to re-accept their snapshots.

## Testing

- `devtools::test()` — 1847 passing.
- `devtools::check(error_on = "warning")` — 0 errors, 0 warnings, 0 notes.