### PR TITLE
Attach locations field to element-wise conditions

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,10 @@
 * `expect_pkg_error_snapshot()`, `expect_pkg_message_snapshot()`, and `expect_pkg_warning_snapshot()` now produce snapshots that mirror `testthat::expect_snapshot()`, showing the bare expression under `Code` and the condition class alongside its message. Existing snapshots must be re-accepted (#301).
 * `stabilize_present()` is now named `assert_present()`, since it doesn't stabilize (coerce) its input; it only asserts that the input is not `NULL`. Calling `stabilize_present()` now throws a "deprecated"-classed error directing you to `assert_present()` (#299).
 
+## New features
+
+* Errors raised for element-wise failures now carry an integer `locations` element on the condition object, giving the positions in the input that failed the check. Handlers can read these positions directly via `cnd$locations` instead of parsing the error message (#274).
+
 ## Bug fixes
 
 * `to_chr()`, `to_dbl()`, `to_fct()`, `to_int()`, and `to_lgl()` now throw an "incompatible type" error (with failing element locations) instead of a generic "can't coerce" error when a list contains elements that can't be converted (#273).

--- a/NEWS.md
+++ b/NEWS.md
@@ -7,7 +7,7 @@
 
 ## New features
 
-* Errors raised for element-wise failures now carry an integer `locations` element on the condition object, giving the positions in the input that failed the check. Handlers can read these positions directly via `cnd$locations` instead of parsing the error message (#274).
+* Errors raised for element-wise failures now carry an integer `locations` element on the condition object, giving the positions in the input that failed the check. Handlers can read these positions via `cnd$locations` (#274).
 
 ## Bug fixes
 

--- a/R/aaa-conditions.R
+++ b/R/aaa-conditions.R
@@ -216,6 +216,7 @@ rlang::caller_env
     subclass = "incompatible_type",
     message_env = rlang::current_env(),
     parent = parent,
+    locations = locations,
     ...
   )
 }

--- a/R/check.R
+++ b/R/check.R
@@ -24,7 +24,8 @@
       additional_msg = c("*" = "NA locations: {locations}"),
       call = call,
       subclass = "bad_na",
-      message_env = rlang::current_env()
+      message_env = rlang::current_env(),
+      locations = locations
     )
   }
   return(invisible(NULL))
@@ -232,6 +233,7 @@
   }
   max_len <- max(non_one)
   short_mask <- lens < max_len & lens > 1L
+  locations <- unname(which(short_mask))
   short_nms <- names(x)[short_mask]
   short_lens <- lens[short_mask]
   short_pairs <- paste(paste0(short_nms, " = ", short_lens), collapse = ", ")
@@ -246,6 +248,7 @@
     ),
     subclass = "jagged",
     call = call,
-    message_env = rlang::current_env()
+    message_env = rlang::current_env(),
+    locations = locations
   )
 }

--- a/R/stabilize_chr.R
+++ b/R/stabilize_chr.R
@@ -184,7 +184,7 @@ stabilise_character_scalar <- stabilize_chr_scalar
 
   rules <- if (is.list(regex)) regex else list(regex)
 
-  error_msgs <- lapply(
+  rule_failures <- lapply(
     X = rules,
     FUN = .apply_regex_rule,
     x = x,
@@ -192,14 +192,18 @@ stabilise_character_scalar <- stabilize_chr_scalar
     call = call
   )
 
-  error_msgs <- unlist(error_msgs)
+  error_msgs <- unlist(lapply(rule_failures, `[[`, "message"))
 
   if (length(error_msgs)) {
+    locations <- sort(unique(unlist(
+      lapply(rule_failures, `[[`, "locations")
+    )))
     .stbl_abort(
       message = error_msgs,
       subclass = "must",
       call = call,
-      message_env = rlang::current_env()
+      message_env = rlang::current_env(),
+      locations = locations
     )
   }
 
@@ -211,8 +215,8 @@ stabilise_character_scalar <- stabilize_chr_scalar
 #' @param rule `(length-1 character)` A regex rule (possibly with a `name` and
 #'   `negate` attribute).
 #' @inheritParams .shared-params
-#' @returns A character vector of error messages if the rule fails, otherwise
-#'   `NULL`.
+#' @returns A list with a `message` character vector and integer `locations` of
+#'   the failing elements if the rule fails, otherwise `NULL`.
 #' @keywords internal
 .apply_regex_rule <- function(rule, x, x_arg, call) {
   rule <- to_chr_scalar(rule, call = call)
@@ -229,7 +233,10 @@ stabilise_character_scalar <- stabilize_chr_scalar
   )
   additional_msg <- .describe_failure_chr(x, success, negate)
 
-  c(main_msg, additional_msg)
+  list(
+    message = c(main_msg, additional_msg),
+    locations = which(!success)
+  )
 }
 
 #' Detect a regex pattern in a character vector

--- a/R/stabilize_dbl.R
+++ b/R/stabilize_dbl.R
@@ -189,11 +189,13 @@ stabilise_double_scalar <- stabilize_dbl_scalar
     target_value = max_value,
     x_arg = x_arg
   )
+  locations <- sort(unique(c(min_failure_locations, max_failure_locations)))
   .stbl_abort(
     c(min_msg, max_msg),
     subclass = "outside_range",
     call = call,
-    message_env = rlang::current_env()
+    message_env = rlang::current_env(),
+    locations = locations
   )
 }
 

--- a/R/to_fct.R
+++ b/R/to_fct.R
@@ -181,6 +181,7 @@ to_fct.default <- function(
 #' @inherit .shared-return-conditions return
 #' @keywords internal
 .stop_bad_levels <- function(x, bad_casts, levels, to_na, x_arg, call) {
+  locations <- which(bad_casts)
   bad_values <- unique(x[bad_casts])
   msg <- c(
     "Each value of {.arg {x_arg}} must be in the expected levels.",
@@ -200,7 +201,8 @@ to_fct.default <- function(
     message = msg,
     subclass = "fct_levels",
     call = call,
-    message_env = rlang::current_env()
+    message_env = rlang::current_env(),
+    locations = locations
   )
 }
 

--- a/man/dot-apply_regex_rule.Rd
+++ b/man/dot-apply_regex_rule.Rd
@@ -21,8 +21,8 @@ in unexported functions.}
 source of error messages.}
 }
 \value{
-A character vector of error messages if the rule fails, otherwise
-\code{NULL}.
+A list with a \code{message} character vector and integer \code{locations} of
+the failing elements if the rule fails, otherwise \code{NULL}.
 }
 \description{
 Apply a single regex rule to a character vector

--- a/tests/testthat/test-check.R
+++ b/tests/testthat/test-check.R
@@ -9,6 +9,11 @@ test_that(".check_na() works (#95)", {
   )
 })
 
+test_that(".check_na() attaches failing locations (#274)", {
+  cnd <- rlang::catch_cnd(.check_na(c(1, NA, 3, NA), allow_na = FALSE))
+  expect_identical(cnd$locations, c(2L, 4L))
+})
+
 test_that(".check_size() works (#95)", {
   expect_null(.check_size(1:5, NULL, NULL))
   expect_null(.check_size(1:5, 1, 10))
@@ -86,6 +91,20 @@ test_that(".check_cast_failures() works", {
   )
 })
 
+test_that(".check_cast_failures() attaches failing locations (#274)", {
+  cnd <- rlang::catch_cnd(
+    .check_cast_failures(
+      failures = c(FALSE, TRUE, FALSE, TRUE),
+      x_class = "character",
+      to = logical(),
+      due_to = "incompatible values",
+      x_arg = "test_arg",
+      call = rlang::current_env()
+    )
+  )
+  expect_identical(cnd$locations, c(2L, 4L))
+})
+
 test_that(".check_all_named() works (#203)", {
   expect_null(.check_all_named(list(a = 1, b = 2)))
   expect_pkg_error_snapshot(.check_all_named(list(1, 2)), "stbl", "bad_named")
@@ -100,4 +119,18 @@ test_that(".check_not_jagged() works (#203)", {
     "stbl",
     "jagged"
   )
+})
+
+test_that(".check_not_jagged() attaches failing locations (#274)", {
+  cnd <- rlang::catch_cnd(
+    .check_not_jagged(list(a = 1:3, b = 1:3, c = 1:2))
+  )
+  expect_identical(cnd$locations, 3L)
+})
+
+test_that("object-level checks do not attach locations (#274)", {
+  expect_null(rlang::catch_cnd(.check_size(1:5, 6, 10))$locations)
+  expect_null(rlang::catch_cnd(.check_scalar(1:2))$locations)
+  expect_null(rlang::catch_cnd(.check_all_named(list(1, 2)))$locations)
+  expect_null(rlang::catch_cnd(.check_x_no_more_than_y(2, 1))$locations)
 })

--- a/tests/testthat/test-stabilize_chr.R
+++ b/tests/testthat/test-stabilize_chr.R
@@ -223,3 +223,10 @@ test_that("stabilize_character_scalar() exists (#164)", {
 test_that("stabilise_character_scalar() exists (#167)", {
   expect_no_error(stabilise_character_scalar(TRUE))
 })
+
+test_that("stabilize_chr() attaches regex failure locations (#274)", {
+  cnd <- rlang::catch_cnd(
+    stabilize_chr(c("hide", "find", "find", "hide"), regex = "hide")
+  )
+  expect_identical(cnd$locations, c(2L, 3L))
+})

--- a/tests/testthat/test-stabilize_dbl.R
+++ b/tests/testthat/test-stabilize_dbl.R
@@ -83,3 +83,8 @@ test_that("stabilize_double_scalar() exists (#164)", {
 test_that("stabilise_double_scalar() exists (#167)", {
   expect_no_error(stabilise_double_scalar(TRUE))
 })
+
+test_that("stabilize_dbl() attaches value failure locations (#274)", {
+  cnd <- rlang::catch_cnd(stabilize_dbl(c(1, 5, 2, 8), max_value = 4))
+  expect_identical(cnd$locations, c(2L, 4L))
+})

--- a/tests/testthat/test-stabilize_int.R
+++ b/tests/testthat/test-stabilize_int.R
@@ -79,3 +79,8 @@ test_that("stabilize_integer_scalar() exists (#164)", {
 test_that("stabilise_integer_scalar() exists (#167)", {
   expect_no_error(stabilise_integer_scalar(TRUE))
 })
+
+test_that("stabilize_int() attaches value failure locations (#274)", {
+  cnd <- rlang::catch_cnd(stabilize_int(c(1L, 5L, 2L, 8L), min_value = 3))
+  expect_identical(cnd$locations, c(1L, 3L))
+})

--- a/tests/testthat/test-to_fct.R
+++ b/tests/testthat/test-to_fct.R
@@ -155,3 +155,8 @@ test_that("to_fct() sorts integer levels numerically not lexicographically (#241
   result <- to_fct(given)
   expect_identical(levels(result), c("1", "2", "10"))
 })
+
+test_that("to_fct() attaches bad-level locations (#274)", {
+  cnd <- rlang::catch_cnd(to_fct(c("a", "b", "c", "d"), levels = c("a", "b")))
+  expect_identical(cnd$locations, c(3L, 4L))
+})


### PR DESCRIPTION
Closes #274

Element-wise validation failures now attach a machine-readable integer `locations` element to the condition object, giving the positions in `x` that failed. Handlers can read `cnd$locations` instead of parsing the message string.

## In scope (locations attached)
- `.stop_incompatible()` — covers `.check_cast_failures()`, `.check_chr_to_int_failures()`, `.check_dbl_to_int_failures()`, `.check_cpx_to_int_failures()`
- `.check_na()`
- `.check_value_chr()` (regex / value rules; locations unioned across rules)
- `.check_value_dbl()` (min/max value; locations unioned across min and max)
- `.check_not_jagged()`
- `.stop_bad_levels()`

## Out of scope (object-level failures, no locations)
`.check_size()`, `.check_scalar()`, `.check_all_named()`, `.check_x_no_more_than_y()` — a test asserts these do **not** carry a `locations` element.

Existing messages continue to render the same location information for users. New tests (tagged `#274`) assert the presence and correctness of `locations` for one representative failure per in-scope check.