### PR TITLE
docs: refer to "objects" not "arguments"

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,11 +2,11 @@
 
 ## Repository overview
 
-**stbl** — Stabilize Function Arguments
+**stbl** — Stabilize Objects
 
 A set of consistent, opinionated functions to quickly check
-    function arguments, coerce them to the desired configuration, or
-    deliver informative error messages when that is not possible.
+    objects, coerce them to the desired configuration, or deliver
+    informative error messages when that is not possible.
 
 https://stbl.wrangle.zone/, https://github.com/wranglezone/stbl
 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,12 +1,12 @@
 Package: stbl
-Title: Stabilize Function Arguments
+Title: Stabilize Objects
 Version: 0.4.0.9000
 Authors@R:
     person("Jon", "Harmon", , "jonthegeek@gmail.com", role = c("aut", "cre", "cph"),
            comment = c(ORCID = "0000-0003-4781-4346"))
 Description: A set of consistent, opinionated functions to quickly check
-    function arguments, coerce them to the desired configuration, or
-    deliver informative error messages when that is not possible.
+    objects, coerce them to the desired configuration, or deliver
+    informative error messages when that is not possible.
 License: MIT + file LICENSE
 URL: https://stbl.wrangle.zone/, https://github.com/wranglezone/stbl
 BugReports: https://github.com/wranglezone/stbl/issues

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -26,11 +26,11 @@ Suggests:
     testthat (>= 3.3.0)
 VignetteBuilder:
     knitr
+Config/Needs/website: quarto
+Config/roxygen2/version: 8.0.0
 Config/testthat/edition: 3
 Config/testthat/parallel: true
-Config/Needs/website: quarto
 Encoding: UTF-8
 Language: en-US
 NeedsCompilation: yes
 Roxygen: list(markdown = TRUE)
-Config/roxygen2/version: 8.0.0

--- a/R/aaa-conditions.R
+++ b/R/aaa-conditions.R
@@ -170,7 +170,7 @@ rlang::caller_env
   .glue2("{.arg [x_arg]} [msg]")
 }
 
-#' Abort because an argument must not be NULL
+#' Abort because an object must not be NULL
 #'
 #' @inheritParams .stbl_abort
 #' @inheritParams .shared-params

--- a/R/aaa-shared_params.R
+++ b/R/aaa-shared_params.R
@@ -82,12 +82,12 @@
 #' @param to_na `(character)` Values to convert to `NA`.
 #' @param to_type_obj An empty object of the target type (e.g., `integer()`).
 #' @param unique (`logical(1)`) Should all elements in `x` be distinct?
-#' @param x The argument to stabilize.
-#' @param x_arg (`character(1)`) The name of the argument being stabilized
+#' @param x The object to stabilize.
+#' @param x_arg (`character(1)`) The name of the object being stabilized
 #'   to use in error messages. The automatic value will work in most cases, or
 #'   pass it through from higher-level functions to make error messages clearer
 #'   in unexported functions.
-#' @param x_class (`character(1)`) The class name of the argument being
+#' @param x_class (`character(1)`) The class name of the object being
 #'   stabilized to use in error messages. Use this if you remove a special class
 #'   from the object before checking its coercion, but want the error message to
 #'   match the original class.

--- a/R/aaa-shared_params.R
+++ b/R/aaa-shared_params.R
@@ -12,8 +12,7 @@
 #'   type). `NULL` (default) skips the check. `NA` values in `x` are permitted
 #'   independently of `allowed_values`, subject to `allow_na`.
 #' @param allow_null (`logical(1)`) Is NULL an acceptable value?
-#' @param allow_zero_length (`logical(1)`) Are zero-length vectors
-#'   acceptable?
+#' @param allow_zero_length (`logical(1)`) Are zero-length vectors acceptable?
 #' @param are_cls_ish_fn The `are_*_ish` function to apply to each element.
 #' @param call `(environment)` The execution environment to mention as the
 #'   source of error messages.
@@ -22,15 +21,15 @@
 #'   after coercion.
 #' @param check_cls_value_fn_args `(list)` A list of additional arguments to
 #'   pass to `check_cls_value_fn()`.
-#' @param coerce_character (`logical(1)`) Should character vectors such as
-#'   "1" and "2.0" be considered numeric-ish?
-#' @param coerce_factor (`logical(1)`) Should factors with values such as
-#'   "1" and "2.0" be considered numeric-ish? Note that this package uses the
+#' @param coerce_character (`logical(1)`) Should character vectors such as "1"
+#'   and "2.0" be considered numeric-ish?
+#' @param coerce_factor (`logical(1)`) Should factors with values such as "1"
+#'   and "2.0" be considered numeric-ish? Note that this package uses the
 #'   character value from the factor, while [as.integer()] and [as.double()] use
 #'   the integer index of the factor.
 #' @param coerce_function (`logical(1)`) Should functions be coerced?
-#' @param depth (`integer(1)`) Current recursion depth. Do not manually
-#'   set this parameter.
+#' @param depth (`integer(1)`) Current recursion depth. Do not manually set this
+#'   parameter.
 #' @param due_to (`character(1)`) A string describing the reason for the
 #'   failure.
 #' @param failures `(logical)` A logical vector indicating which elements
@@ -38,26 +37,25 @@
 #' @param is_rlang_cls_scalar `(function)` An `is_scalar_*()` function from
 #'   rlang, used for a fast path if `x` is already the right type.
 #' @param levels `(character)` The desired factor levels. For factors, a
-#'   vector's `levels` play the same role that `allowed_values` plays for
-#'   other types: they restrict `x` to a fixed set of permitted values.
+#'   vector's `levels` play the same role that `allowed_values` plays for other
+#'   types: they restrict `x` to a fixed set of permitted values.
 #' @param max_characters (`integer(1)`) Maximum number of characters allowed in
 #'   each element.
-#' @param max_levels (`numeric(1)`) Maximum number of distinct non-`NA`
-#'   values allowed across the whole vector after applying `to_na`.
-#' @param max_size (`integer(1)`) The maximum size of the object. Object
-#'   size will be tested using [vctrs::vec_size()].
-#' @param max_value (`numeric(1)`) The highest allowed value for `x`. If
-#'   `NULL` (default) values are not checked.
+#' @param max_levels (`numeric(1)`) Maximum number of distinct non-`NA` values
+#'   allowed across the whole vector after applying `to_na`.
+#' @param max_size (`integer(1)`) The maximum size of the object. Object size
+#'   will be tested using [vctrs::vec_size()].
+#' @param max_value (`numeric(1)`) The highest allowed value for `x`. If `NULL`
+#'   (default) values are not checked.
 #' @param message_env (`environment`) The execution environment to use to
 #'   evaluate variables in error messages.
 #' @param min_characters (`integer(1)`) Minimum number of characters allowed in
 #'   each element.
-#' @param min_size (`integer(1)`) The minimum size of the object. Object
-#'   size will be tested using [vctrs::vec_size()].
-#' @param min_value (`numeric(1)`) The lowest allowed value for `x`. If
-#'   `NULL` (default) values are not checked.
-#' @param package (`character(1)`) The name of the package to use in
-#'   classes.
+#' @param min_size (`integer(1)`) The minimum size of the object. Object size
+#'   will be tested using [vctrs::vec_size()].
+#' @param min_value (`numeric(1)`) The lowest allowed value for `x`. If `NULL`
+#'   (default) values are not checked.
+#' @param package (`character(1)`) The name of the package to use in classes.
 #' @param parent A parent condition, as you might create during a
 #'   [rlang::try_fetch()]. See [rlang::abort()] for additional information.
 #' @param regex `(character, list, or stringr_pattern)` One or more optional
@@ -83,14 +81,14 @@
 #' @param to_type_obj An empty object of the target type (e.g., `integer()`).
 #' @param unique (`logical(1)`) Should all elements in `x` be distinct?
 #' @param x The object to stabilize.
-#' @param x_arg (`character(1)`) The name of the object being stabilized
-#'   to use in error messages. The automatic value will work in most cases, or
-#'   pass it through from higher-level functions to make error messages clearer
-#'   in unexported functions.
-#' @param x_class (`character(1)`) The class name of the object being
-#'   stabilized to use in error messages. Use this if you remove a special class
-#'   from the object before checking its coercion, but want the error message to
-#'   match the original class.
+#' @param x_arg (`character(1)`) The name of the object being stabilized to use
+#'   in error messages. The automatic value will work in most cases, or pass it
+#'   through from higher-level functions to make error messages clearer in
+#'   unexported functions.
+#' @param x_class (`character(1)`) The class name of the object being stabilized
+#'   to use in error messages. Use this if you remove a special class from the
+#'   object before checking its coercion, but want the error message to match
+#'   the original class.
 #'
 #' @name .shared-params
 #' @keywords internal

--- a/R/check.R
+++ b/R/check.R
@@ -196,7 +196,8 @@
 #' Check that one value is not greater than another
 #'
 #' @param y The value to compare against.
-#' @param y_arg (`character(1)`) The name of the `y` argument.
+#' @param y_arg (`character(1)`) The name of the `y` value to use in error
+#'   messages.
 #' @inheritParams .shared-params-check
 #' @inheritParams .shared-params
 #' @inherit .shared-return-conditions return

--- a/R/regex.R
+++ b/R/regex.R
@@ -1,6 +1,6 @@
 #' Create a regex matching rule
 #'
-#' Attach a standardized error message to a `regex` argument. By default, the
+#' Attach a standardized error message to a `regex` pattern. By default, the
 #' message will be "must match the regex pattern \{regex\}". If the input
 #' `regex` has a `negate` attribute set to `TRUE` (set automatically by
 #' `regex_must_not_match()`), the message will instead be "must not match...".

--- a/R/stabilize_arg.R
+++ b/R/stabilize_arg.R
@@ -1,10 +1,10 @@
-#' Ensure an argument meets expectations
+#' Ensure an object meets expectations
 #'
 #' @description
 #' `stabilize_arg()` is used by other functions such as [stabilize_int()]. Use
 #' `stabilize_arg()` if the type-specific functions will not work for your use
 #' case, but you would still like to check things like size or whether the
-#' argument is NULL.
+#' object is NULL.
 #'
 #' `stabilize_arg_scalar()` is optimized to check for length-1 vectors.
 #'

--- a/R/stabilize_df.R
+++ b/R/stabilize_df.R
@@ -1,4 +1,4 @@
-#' Ensure a data frame argument meets expectations
+#' Ensure a data frame meets expectations
 #'
 #' `stabilize_df()` validates the structure and contents of a data frame. It can
 #' check that specific named columns are present and valid, that extra columns

--- a/R/stabilize_lst.R
+++ b/R/stabilize_lst.R
@@ -1,4 +1,4 @@
-#' Ensure a list argument meets expectations
+#' Ensure a list meets expectations
 #'
 #' `stabilize_lst()` validates the structure and contents of a list. It can
 #' check that specific named elements are present and valid, that extra named

--- a/R/to_chr.R
+++ b/R/to_chr.R
@@ -69,7 +69,7 @@ to_character <- to_chr
 #' Internal S3 implementation of to_chr
 #'
 #' @inheritParams .shared-params
-#' @returns The argument coerced to character.
+#' @returns The object coerced to character.
 #' @keywords internal
 .to_chr_impl <- function(
   x,

--- a/R/to_df.R
+++ b/R/to_df.R
@@ -1,13 +1,13 @@
-#' Ensure a data frame argument meets expectations
+#' Ensure a data frame meets expectations
 #'
-#' `to_df()` checks whether an argument can be coerced to a data frame,
+#' `to_df()` checks whether an object can be coerced to a data frame,
 #' returning it silently if so. Otherwise an informative error message is
 #' signaled. `to_data_frame()` is a synonym of `to_df()`.
 #'
 #' @param ... Arguments passed to [base::as.data.frame()] or other methods.
 #' @inheritParams .shared-params
 #'
-#' @returns The argument as a data frame.
+#' @returns The object as a data frame.
 #' @family data frame functions
 #' @export
 #'

--- a/R/to_lst.R
+++ b/R/to_lst.R
@@ -1,6 +1,6 @@
-#' Ensure a list argument meets expectations
+#' Ensure a list meets expectations
 #'
-#' `to_lst()` checks whether an argument can be coerced to a list without losing
+#' `to_lst()` checks whether an object can be coerced to a list without losing
 #' information, returning it silently if so. Otherwise an informative error
 #' message is signaled. `to_list()` is a synonym of `to_lst()`.
 #'
@@ -17,7 +17,7 @@
 #' @param ... Arguments passed to [base::as.list()] or other methods.
 #' @inheritParams .shared-params
 #'
-#' @returns The argument as a list.
+#' @returns The object as a list.
 #' @family list functions
 #' @export
 to_lst <- function(
@@ -91,7 +91,7 @@ to_lst.function <- function(
   }
 }
 
-#' Abort because an argument must not be a function
+#' Abort because an object must not be a function
 #'
 #' @inheritParams .stbl_abort
 #' @inheritParams .shared-params

--- a/R/to_null.R
+++ b/R/to_null.R
@@ -1,4 +1,4 @@
-#' Ensure an argument is NULL
+#' Ensure an object is NULL
 #'
 #' @inheritParams .shared-params
 #' @returns `NULL` or an error.

--- a/README.Rmd
+++ b/README.Rmd
@@ -23,7 +23,7 @@ knitr::opts_chunk$set(
 <!-- badges: end -->
 
 R is flexible about classes.
-Variables are not declared with explicit classes, and arguments of the "wrong" class don't cause errors until they explicitly fail at some point in the call stack.
+Variables are not declared with explicit classes, and objects of the "wrong" class don't cause errors until they explicitly fail at some point in the call stack.
 It would be helpful to keep that flexibility from a user standpoint, but to error informatively and quickly if the inputs will not work for a computation.
 The purpose of stbl is to allow programmers to specify what they want, and to then see if what the user supplied can work for that purpose.
 
@@ -51,14 +51,14 @@ pak::pak("wranglezone/stbl")
 
 ## Usage
 
-The primary use-case for stbl is to stabilize function arguments. 
-The goal is to make sure arguments will work the way you expect them to work, and to give meaningful error messages when they won't.
+The primary use-case for stbl is to stabilize objects, such as function arguments. 
+The goal is to make sure objects will work the way you expect them to work, and to give meaningful error messages when they won't.
 
 For example, perhaps you would like to protect against the case where data is not properly translated from character to integer when it's loaded by a user.
 
 ### Without stbl:
 
-Without the argument-stabilizers provided in stbl, error messages can be cryptic, and errors trigger when you might not want them to.
+Without the stabilizers provided in stbl, error messages can be cryptic, and errors trigger when you might not want them to.
 
 ```{r no-stbl, error = TRUE}
 my_old_fun <- function(my_arg_name) {
@@ -69,7 +69,7 @@ my_old_fun("1")
 
 ### With stbl:
 
-stbl helps to ensure that arguments are what you expect them to be.
+stbl helps to ensure that objects are what you expect them to be.
 
 ```{r with-stbl-ok}
 my_fun <- function(my_arg_name) {

--- a/README.md
+++ b/README.md
@@ -15,12 +15,12 @@ coverage](https://codecov.io/gh/wranglezone/stbl/branch/main/graph/badge.svg)](h
 <!-- badges: end -->
 
 R is flexible about classes. Variables are not declared with explicit
-classes, and arguments of the “wrong” class don’t cause errors until
-they explicitly fail at some point in the call stack. It would be
-helpful to keep that flexibility from a user standpoint, but to error
-informatively and quickly if the inputs will not work for a computation.
-The purpose of stbl is to allow programmers to specify what they want,
-and to then see if what the user supplied can work for that purpose.
+classes, and objects of the “wrong” class don’t cause errors until they
+explicitly fail at some point in the call stack. It would be helpful to
+keep that flexibility from a user standpoint, but to error informatively
+and quickly if the inputs will not work for a computation. The purpose
+of stbl is to allow programmers to specify what they want, and to then
+see if what the user supplied can work for that purpose.
 
 This approach aligns with [Postel’s
 Law](https://en.wikipedia.org/wiki/Robustness_principle):
@@ -55,9 +55,9 @@ pak::pak("wranglezone/stbl")
 
 ## Usage
 
-The primary use-case for stbl is to stabilize function arguments. The
-goal is to make sure arguments will work the way you expect them to
-work, and to give meaningful error messages when they won’t.
+The primary use-case for stbl is to stabilize objects, such as function
+arguments. The goal is to make sure objects will work the way you expect
+them to work, and to give meaningful error messages when they won’t.
 
 For example, perhaps you would like to protect against the case where
 data is not properly translated from character to integer when it’s
@@ -65,8 +65,8 @@ loaded by a user.
 
 ### Without stbl:
 
-Without the argument-stabilizers provided in stbl, error messages can be
-cryptic, and errors trigger when you might not want them to.
+Without the stabilizers provided in stbl, error messages can be cryptic,
+and errors trigger when you might not want them to.
 
 ``` r
 my_old_fun <- function(my_arg_name) {
@@ -79,7 +79,7 @@ my_old_fun("1")
 
 ### With stbl:
 
-stbl helps to ensure that arguments are what you expect them to be.
+stbl helps to ensure that objects are what you expect them to be.
 
 ``` r
 my_fun <- function(my_arg_name) {

--- a/man/are_chr_ish.Rd
+++ b/man/are_chr_ish.Rd
@@ -23,8 +23,8 @@ is_character_ish(x, ...)
 
 \item{...}{Arguments passed to methods.}
 
-\item{depth}{(\code{integer(1)}) Current recursion depth. Do not manually
-set this parameter.}
+\item{depth}{(\code{integer(1)}) Current recursion depth. Do not manually set this
+parameter.}
 }
 \value{
 \code{are_chr_ish()} returns a logical vector with the same length as the

--- a/man/are_dbl_ish.Rd
+++ b/man/are_dbl_ish.Rd
@@ -29,16 +29,16 @@ is_double_ish(x, ...)
 
 \item{...}{Arguments passed to methods.}
 
-\item{coerce_character}{(\code{logical(1)}) Should character vectors such as
-"1" and "2.0" be considered numeric-ish?}
+\item{coerce_character}{(\code{logical(1)}) Should character vectors such as "1"
+and "2.0" be considered numeric-ish?}
 
-\item{coerce_factor}{(\code{logical(1)}) Should factors with values such as
-"1" and "2.0" be considered numeric-ish? Note that this package uses the
+\item{coerce_factor}{(\code{logical(1)}) Should factors with values such as "1"
+and "2.0" be considered numeric-ish? Note that this package uses the
 character value from the factor, while \code{\link[=as.integer]{as.integer()}} and \code{\link[=as.double]{as.double()}} use
 the integer index of the factor.}
 
-\item{depth}{(\code{integer(1)}) Current recursion depth. Do not manually
-set this parameter.}
+\item{depth}{(\code{integer(1)}) Current recursion depth. Do not manually set this
+parameter.}
 }
 \value{
 \code{are_dbl_ish()} returns a logical vector with the same length as the

--- a/man/are_fct_ish.Rd
+++ b/man/are_fct_ish.Rd
@@ -24,16 +24,16 @@ is_factor_ish(x, ..., levels = NULL, to_na = character(), max_levels = Inf)
 \item{...}{Arguments passed to methods.}
 
 \item{levels}{\code{(character)} The desired factor levels. For factors, a
-vector's \code{levels} play the same role that \code{allowed_values} plays for
-other types: they restrict \code{x} to a fixed set of permitted values.}
+vector's \code{levels} play the same role that \code{allowed_values} plays for other
+types: they restrict \code{x} to a fixed set of permitted values.}
 
 \item{to_na}{\code{(character)} Values to convert to \code{NA}.}
 
-\item{max_levels}{(\code{numeric(1)}) Maximum number of distinct non-\code{NA}
-values allowed across the whole vector after applying \code{to_na}.}
+\item{max_levels}{(\code{numeric(1)}) Maximum number of distinct non-\code{NA} values
+allowed across the whole vector after applying \code{to_na}.}
 
-\item{depth}{(\code{integer(1)}) Current recursion depth. Do not manually
-set this parameter.}
+\item{depth}{(\code{integer(1)}) Current recursion depth. Do not manually set this
+parameter.}
 }
 \value{
 \code{are_fct_ish()} returns a logical vector with the same length as the

--- a/man/are_int_ish.Rd
+++ b/man/are_int_ish.Rd
@@ -29,16 +29,16 @@ is_integer_ish(x, ...)
 
 \item{...}{Arguments passed to methods.}
 
-\item{coerce_character}{(\code{logical(1)}) Should character vectors such as
-"1" and "2.0" be considered numeric-ish?}
+\item{coerce_character}{(\code{logical(1)}) Should character vectors such as "1"
+and "2.0" be considered numeric-ish?}
 
-\item{coerce_factor}{(\code{logical(1)}) Should factors with values such as
-"1" and "2.0" be considered numeric-ish? Note that this package uses the
+\item{coerce_factor}{(\code{logical(1)}) Should factors with values such as "1"
+and "2.0" be considered numeric-ish? Note that this package uses the
 character value from the factor, while \code{\link[=as.integer]{as.integer()}} and \code{\link[=as.double]{as.double()}} use
 the integer index of the factor.}
 
-\item{depth}{(\code{integer(1)}) Current recursion depth. Do not manually
-set this parameter.}
+\item{depth}{(\code{integer(1)}) Current recursion depth. Do not manually set this
+parameter.}
 }
 \value{
 \code{are_int_ish()} returns a logical vector with the same length as the

--- a/man/are_lgl_ish.Rd
+++ b/man/are_lgl_ish.Rd
@@ -23,8 +23,8 @@ is_logical_ish(x, ...)
 
 \item{...}{Arguments passed to methods.}
 
-\item{depth}{(\code{integer(1)}) Current recursion depth. Do not manually
-set this parameter.}
+\item{depth}{(\code{integer(1)}) Current recursion depth. Do not manually set this
+parameter.}
 }
 \value{
 \code{are_lgl_ish()} returns a logical vector with the same length as the

--- a/man/assert_present.Rd
+++ b/man/assert_present.Rd
@@ -12,9 +12,9 @@ assert_present(
 )
 }
 \arguments{
-\item{x}{The argument to stabilize.}
+\item{x}{The object to stabilize.}
 
-\item{x_arg}{(\code{character(1)}) The name of the argument being stabilized
+\item{x_arg}{(\code{character(1)}) The name of the object being stabilized
 to use in error messages. The automatic value will work in most cases, or
 pass it through from higher-level functions to make error messages clearer
 in unexported functions.}
@@ -22,7 +22,7 @@ in unexported functions.}
 \item{call}{\code{(environment)} The execution environment to mention as the
 source of error messages.}
 
-\item{x_class}{(\code{character(1)}) The class name of the argument being
+\item{x_class}{(\code{character(1)}) The class name of the object being
 stabilized to use in error messages. Use this if you remove a special class
 from the object before checking its coercion, but want the error message to
 match the original class.}

--- a/man/assert_present.Rd
+++ b/man/assert_present.Rd
@@ -14,18 +14,18 @@ assert_present(
 \arguments{
 \item{x}{The object to stabilize.}
 
-\item{x_arg}{(\code{character(1)}) The name of the object being stabilized
-to use in error messages. The automatic value will work in most cases, or
-pass it through from higher-level functions to make error messages clearer
-in unexported functions.}
+\item{x_arg}{(\code{character(1)}) The name of the object being stabilized to use
+in error messages. The automatic value will work in most cases, or pass it
+through from higher-level functions to make error messages clearer in
+unexported functions.}
 
 \item{call}{\code{(environment)} The execution environment to mention as the
 source of error messages.}
 
-\item{x_class}{(\code{character(1)}) The class name of the object being
-stabilized to use in error messages. Use this if you remove a special class
-from the object before checking its coercion, but want the error message to
-match the original class.}
+\item{x_class}{(\code{character(1)}) The class name of the object being stabilized
+to use in error messages. Use this if you remove a special class from the
+object before checking its coercion, but want the error message to match
+the original class.}
 }
 \value{
 The value, unchanged.

--- a/man/c_x_to_y.Rd
+++ b/man/c_x_to_y.Rd
@@ -119,7 +119,7 @@
 .check_max_dbl(x, max_val)
 }
 \arguments{
-\item{x}{The argument to stabilize.}
+\item{x}{The object to stabilize.}
 
 \item{levels}{\code{(character)} The desired factor levels. For factors, a
 vector's \code{levels} play the same role that \code{allowed_values} plays for

--- a/man/c_x_to_y.Rd
+++ b/man/c_x_to_y.Rd
@@ -122,8 +122,8 @@
 \item{x}{The object to stabilize.}
 
 \item{levels}{\code{(character)} The desired factor levels. For factors, a
-vector's \code{levels} play the same role that \code{allowed_values} plays for
-other types: they restrict \code{x} to a fixed set of permitted values.}
+vector's \code{levels} play the same role that \code{allowed_values} plays for other
+types: they restrict \code{x} to a fixed set of permitted values.}
 
 \item{to_na}{\code{(character)} Values to convert to \code{NA}.}
 

--- a/man/dot-apply_regex_rule.Rd
+++ b/man/dot-apply_regex_rule.Rd
@@ -12,10 +12,10 @@
 
 \item{x}{The object to stabilize.}
 
-\item{x_arg}{(\code{character(1)}) The name of the object being stabilized
-to use in error messages. The automatic value will work in most cases, or
-pass it through from higher-level functions to make error messages clearer
-in unexported functions.}
+\item{x_arg}{(\code{character(1)}) The name of the object being stabilized to use
+in error messages. The automatic value will work in most cases, or pass it
+through from higher-level functions to make error messages clearer in
+unexported functions.}
 
 \item{call}{\code{(environment)} The execution environment to mention as the
 source of error messages.}

--- a/man/dot-apply_regex_rule.Rd
+++ b/man/dot-apply_regex_rule.Rd
@@ -10,9 +10,9 @@
 \item{rule}{(\code{character(1)}) A regex rule (possibly with a \code{name} and
 \code{negate} attribute).}
 
-\item{x}{The argument to stabilize.}
+\item{x}{The object to stabilize.}
 
-\item{x_arg}{(\code{character(1)}) The name of the argument being stabilized
+\item{x_arg}{(\code{character(1)}) The name of the object being stabilized
 to use in error messages. The automatic value will work in most cases, or
 pass it through from higher-level functions to make error messages clearer
 in unexported functions.}

--- a/man/dot-are_not_fct_ish_chr.Rd
+++ b/man/dot-are_not_fct_ish_chr.Rd
@@ -10,8 +10,8 @@
 \item{x}{The object to check.}
 
 \item{levels}{\code{(character)} The desired factor levels. For factors, a
-vector's \code{levels} play the same role that \code{allowed_values} plays for
-other types: they restrict \code{x} to a fixed set of permitted values.}
+vector's \code{levels} play the same role that \code{allowed_values} plays for other
+types: they restrict \code{x} to a fixed set of permitted values.}
 
 \item{to_na}{\code{(character)} Values to convert to \code{NA}.}
 }

--- a/man/dot-call_specified_fn.Rd
+++ b/man/dot-call_specified_fn.Rd
@@ -11,10 +11,10 @@
 
 \item{.x}{The value to validate.}
 
-\item{.x_arg}{(\code{character(1)}) The name of the object being stabilized
-to use in error messages. The automatic value will work in most cases, or
-pass it through from higher-level functions to make error messages clearer
-in unexported functions.}
+\item{.x_arg}{(\code{character(1)}) The name of the object being stabilized to use
+in error messages. The automatic value will work in most cases, or pass it
+through from higher-level functions to make error messages clearer in
+unexported functions.}
 
 \item{.call}{\code{(environment)} The execution environment to mention as the
 source of error messages.}

--- a/man/dot-call_specified_fn.Rd
+++ b/man/dot-call_specified_fn.Rd
@@ -11,7 +11,7 @@
 
 \item{.x}{The value to validate.}
 
-\item{.x_arg}{(\code{character(1)}) The name of the argument being stabilized
+\item{.x_arg}{(\code{character(1)}) The name of the object being stabilized
 to use in error messages. The automatic value will work in most cases, or
 pass it through from higher-level functions to make error messages clearer
 in unexported functions.}

--- a/man/dot-check_all_named.Rd
+++ b/man/dot-check_all_named.Rd
@@ -9,10 +9,10 @@
 \arguments{
 \item{x}{The object to stabilize.}
 
-\item{x_arg}{(\code{character(1)}) The name of the object being stabilized
-to use in error messages. The automatic value will work in most cases, or
-pass it through from higher-level functions to make error messages clearer
-in unexported functions.}
+\item{x_arg}{(\code{character(1)}) The name of the object being stabilized to use
+in error messages. The automatic value will work in most cases, or pass it
+through from higher-level functions to make error messages clearer in
+unexported functions.}
 
 \item{call}{\code{(environment)} The execution environment to mention as the
 source of error messages.}

--- a/man/dot-check_all_named.Rd
+++ b/man/dot-check_all_named.Rd
@@ -7,9 +7,9 @@
 .check_all_named(x, x_arg = caller_arg(x), call = caller_env())
 }
 \arguments{
-\item{x}{The argument to stabilize.}
+\item{x}{The object to stabilize.}
 
-\item{x_arg}{(\code{character(1)}) The name of the argument being stabilized
+\item{x_arg}{(\code{character(1)}) The name of the object being stabilized
 to use in error messages. The automatic value will work in most cases, or
 pass it through from higher-level functions to make error messages clearer
 in unexported functions.}

--- a/man/dot-check_allowed_values.Rd
+++ b/man/dot-check_allowed_values.Rd
@@ -17,7 +17,7 @@
 \item{allowed_values}{A vector of permitted values, already coerced to the
 same type as \code{x}. \code{NULL} or zero-length skips the check.}
 
-\item{x_arg}{(\code{character(1)}) The name of the argument being stabilized
+\item{x_arg}{(\code{character(1)}) The name of the object being stabilized
 to use in error messages. The automatic value will work in most cases, or
 pass it through from higher-level functions to make error messages clearer
 in unexported functions.}

--- a/man/dot-check_allowed_values.Rd
+++ b/man/dot-check_allowed_values.Rd
@@ -17,10 +17,10 @@
 \item{allowed_values}{A vector of permitted values, already coerced to the
 same type as \code{x}. \code{NULL} or zero-length skips the check.}
 
-\item{x_arg}{(\code{character(1)}) The name of the object being stabilized
-to use in error messages. The automatic value will work in most cases, or
-pass it through from higher-level functions to make error messages clearer
-in unexported functions.}
+\item{x_arg}{(\code{character(1)}) The name of the object being stabilized to use
+in error messages. The automatic value will work in most cases, or pass it
+through from higher-level functions to make error messages clearer in
+unexported functions.}
 
 \item{call}{\code{(environment)} The execution environment to mention as the
 source of error messages.}

--- a/man/dot-check_cast_failures.Rd
+++ b/man/dot-check_cast_failures.Rd
@@ -10,20 +10,20 @@
 \item{failures}{\code{(logical)} A logical vector where \code{TRUE} indicates a
 coercion failure.}
 
-\item{x_class}{(\code{character(1)}) The class name of the object being
-stabilized to use in error messages. Use this if you remove a special class
-from the object before checking its coercion, but want the error message to
-match the original class.}
+\item{x_class}{(\code{character(1)}) The class name of the object being stabilized
+to use in error messages. Use this if you remove a special class from the
+object before checking its coercion, but want the error message to match
+the original class.}
 
 \item{to}{The target object for the coercion.}
 
 \item{due_to}{(\code{character(1)}) A string describing the reason for the
 failure.}
 
-\item{x_arg}{(\code{character(1)}) The name of the object being stabilized
-to use in error messages. The automatic value will work in most cases, or
-pass it through from higher-level functions to make error messages clearer
-in unexported functions.}
+\item{x_arg}{(\code{character(1)}) The name of the object being stabilized to use
+in error messages. The automatic value will work in most cases, or pass it
+through from higher-level functions to make error messages clearer in
+unexported functions.}
 
 \item{call}{\code{(environment)} The execution environment to mention as the
 source of error messages.}

--- a/man/dot-check_cast_failures.Rd
+++ b/man/dot-check_cast_failures.Rd
@@ -10,7 +10,7 @@
 \item{failures}{\code{(logical)} A logical vector where \code{TRUE} indicates a
 coercion failure.}
 
-\item{x_class}{(\code{character(1)}) The class name of the argument being
+\item{x_class}{(\code{character(1)}) The class name of the object being
 stabilized to use in error messages. Use this if you remove a special class
 from the object before checking its coercion, but want the error message to
 match the original class.}
@@ -20,7 +20,7 @@ match the original class.}
 \item{due_to}{(\code{character(1)}) A string describing the reason for the
 failure.}
 
-\item{x_arg}{(\code{character(1)}) The name of the argument being stabilized
+\item{x_arg}{(\code{character(1)}) The name of the object being stabilized
 to use in error messages. The automatic value will work in most cases, or
 pass it through from higher-level functions to make error messages clearer
 in unexported functions.}

--- a/man/dot-check_chr_to_int_failures.Rd
+++ b/man/dot-check_chr_to_int_failures.Rd
@@ -10,12 +10,12 @@
 \item{res}{A list returned by \code{stbl_chr_to_int}, with elements
 \code{result}, \code{non_number}, and \code{bad_precision}.}
 
-\item{x_class}{(\code{character(1)}) The class name of the argument being
+\item{x_class}{(\code{character(1)}) The class name of the object being
 stabilized to use in error messages. Use this if you remove a special class
 from the object before checking its coercion, but want the error message to
 match the original class.}
 
-\item{x_arg}{(\code{character(1)}) The name of the argument being stabilized
+\item{x_arg}{(\code{character(1)}) The name of the object being stabilized
 to use in error messages. The automatic value will work in most cases, or
 pass it through from higher-level functions to make error messages clearer
 in unexported functions.}

--- a/man/dot-check_chr_to_int_failures.Rd
+++ b/man/dot-check_chr_to_int_failures.Rd
@@ -10,15 +10,15 @@
 \item{res}{A list returned by \code{stbl_chr_to_int}, with elements
 \code{result}, \code{non_number}, and \code{bad_precision}.}
 
-\item{x_class}{(\code{character(1)}) The class name of the object being
-stabilized to use in error messages. Use this if you remove a special class
-from the object before checking its coercion, but want the error message to
-match the original class.}
+\item{x_class}{(\code{character(1)}) The class name of the object being stabilized
+to use in error messages. Use this if you remove a special class from the
+object before checking its coercion, but want the error message to match
+the original class.}
 
-\item{x_arg}{(\code{character(1)}) The name of the object being stabilized
-to use in error messages. The automatic value will work in most cases, or
-pass it through from higher-level functions to make error messages clearer
-in unexported functions.}
+\item{x_arg}{(\code{character(1)}) The name of the object being stabilized to use
+in error messages. The automatic value will work in most cases, or pass it
+through from higher-level functions to make error messages clearer in
+unexported functions.}
 
 \item{call}{\code{(environment)} The execution environment to mention as the
 source of error messages.}

--- a/man/dot-check_cpx_to_int_failures.Rd
+++ b/man/dot-check_cpx_to_int_failures.Rd
@@ -10,15 +10,15 @@
 \item{res}{A list returned by \code{stbl_cpx_to_int}, with elements
 \code{result}, \code{non_number}, and \code{bad_precision}.}
 
-\item{x_class}{(\code{character(1)}) The class name of the object being
-stabilized to use in error messages. Use this if you remove a special class
-from the object before checking its coercion, but want the error message to
-match the original class.}
+\item{x_class}{(\code{character(1)}) The class name of the object being stabilized
+to use in error messages. Use this if you remove a special class from the
+object before checking its coercion, but want the error message to match
+the original class.}
 
-\item{x_arg}{(\code{character(1)}) The name of the object being stabilized
-to use in error messages. The automatic value will work in most cases, or
-pass it through from higher-level functions to make error messages clearer
-in unexported functions.}
+\item{x_arg}{(\code{character(1)}) The name of the object being stabilized to use
+in error messages. The automatic value will work in most cases, or pass it
+through from higher-level functions to make error messages clearer in
+unexported functions.}
 
 \item{call}{\code{(environment)} The execution environment to mention as the
 source of error messages.}

--- a/man/dot-check_cpx_to_int_failures.Rd
+++ b/man/dot-check_cpx_to_int_failures.Rd
@@ -10,12 +10,12 @@
 \item{res}{A list returned by \code{stbl_cpx_to_int}, with elements
 \code{result}, \code{non_number}, and \code{bad_precision}.}
 
-\item{x_class}{(\code{character(1)}) The class name of the argument being
+\item{x_class}{(\code{character(1)}) The class name of the object being
 stabilized to use in error messages. Use this if you remove a special class
 from the object before checking its coercion, but want the error message to
 match the original class.}
 
-\item{x_arg}{(\code{character(1)}) The name of the argument being stabilized
+\item{x_arg}{(\code{character(1)}) The name of the object being stabilized
 to use in error messages. The automatic value will work in most cases, or
 pass it through from higher-level functions to make error messages clearer
 in unexported functions.}

--- a/man/dot-check_dbl_to_int_failures.Rd
+++ b/man/dot-check_dbl_to_int_failures.Rd
@@ -10,15 +10,15 @@
 \item{res}{A list returned by \code{stbl_dbl_to_int}, with elements
 \code{result} and \code{bad_precision}.}
 
-\item{x_class}{(\code{character(1)}) The class name of the object being
-stabilized to use in error messages. Use this if you remove a special class
-from the object before checking its coercion, but want the error message to
-match the original class.}
+\item{x_class}{(\code{character(1)}) The class name of the object being stabilized
+to use in error messages. Use this if you remove a special class from the
+object before checking its coercion, but want the error message to match
+the original class.}
 
-\item{x_arg}{(\code{character(1)}) The name of the object being stabilized
-to use in error messages. The automatic value will work in most cases, or
-pass it through from higher-level functions to make error messages clearer
-in unexported functions.}
+\item{x_arg}{(\code{character(1)}) The name of the object being stabilized to use
+in error messages. The automatic value will work in most cases, or pass it
+through from higher-level functions to make error messages clearer in
+unexported functions.}
 
 \item{call}{\code{(environment)} The execution environment to mention as the
 source of error messages.}

--- a/man/dot-check_dbl_to_int_failures.Rd
+++ b/man/dot-check_dbl_to_int_failures.Rd
@@ -10,12 +10,12 @@
 \item{res}{A list returned by \code{stbl_dbl_to_int}, with elements
 \code{result} and \code{bad_precision}.}
 
-\item{x_class}{(\code{character(1)}) The class name of the argument being
+\item{x_class}{(\code{character(1)}) The class name of the object being
 stabilized to use in error messages. Use this if you remove a special class
 from the object before checking its coercion, but want the error message to
 match the original class.}
 
-\item{x_arg}{(\code{character(1)}) The name of the argument being stabilized
+\item{x_arg}{(\code{character(1)}) The name of the object being stabilized
 to use in error messages. The automatic value will work in most cases, or
 pass it through from higher-level functions to make error messages clearer
 in unexported functions.}

--- a/man/dot-check_df_col_names.Rd
+++ b/man/dot-check_df_col_names.Rd
@@ -12,7 +12,7 @@
 \item{col_names}{\code{(character)} Column names that must be present in \code{.x}, or
 \code{NULL} to skip this check.}
 
-\item{x_arg}{(\code{character(1)}) The name of the argument being stabilized
+\item{x_arg}{(\code{character(1)}) The name of the object being stabilized
 to use in error messages. The automatic value will work in most cases, or
 pass it through from higher-level functions to make error messages clearer
 in unexported functions.}

--- a/man/dot-check_df_col_names.Rd
+++ b/man/dot-check_df_col_names.Rd
@@ -12,10 +12,10 @@
 \item{col_names}{\code{(character)} Column names that must be present in \code{.x}, or
 \code{NULL} to skip this check.}
 
-\item{x_arg}{(\code{character(1)}) The name of the object being stabilized
-to use in error messages. The automatic value will work in most cases, or
-pass it through from higher-level functions to make error messages clearer
-in unexported functions.}
+\item{x_arg}{(\code{character(1)}) The name of the object being stabilized to use
+in error messages. The automatic value will work in most cases, or pass it
+through from higher-level functions to make error messages clearer in
+unexported functions.}
 
 \item{call}{\code{(environment)} The execution environment to mention as the
 source of error messages.}

--- a/man/dot-check_df_rows.Rd
+++ b/man/dot-check_df_rows.Rd
@@ -15,10 +15,10 @@
 \item{max_rows}{(\code{integer(1)}) Maximum number of rows allowed, or
 \code{NULL} to skip this check.}
 
-\item{x_arg}{(\code{character(1)}) The name of the object being stabilized
-to use in error messages. The automatic value will work in most cases, or
-pass it through from higher-level functions to make error messages clearer
-in unexported functions.}
+\item{x_arg}{(\code{character(1)}) The name of the object being stabilized to use
+in error messages. The automatic value will work in most cases, or pass it
+through from higher-level functions to make error messages clearer in
+unexported functions.}
 
 \item{call}{\code{(environment)} The execution environment to mention as the
 source of error messages.}

--- a/man/dot-check_df_rows.Rd
+++ b/man/dot-check_df_rows.Rd
@@ -15,7 +15,7 @@
 \item{max_rows}{(\code{integer(1)}) Maximum number of rows allowed, or
 \code{NULL} to skip this check.}
 
-\item{x_arg}{(\code{character(1)}) The name of the argument being stabilized
+\item{x_arg}{(\code{character(1)}) The name of the object being stabilized
 to use in error messages. The automatic value will work in most cases, or
 pass it through from higher-level functions to make error messages clearer
 in unexported functions.}

--- a/man/dot-check_duplicate_names.Rd
+++ b/man/dot-check_duplicate_names.Rd
@@ -13,10 +13,10 @@
 have duplicate names? If \code{FALSE} (default), an error is thrown when any
 named element of \code{.x} shares a name with another.}
 
-\item{.x_arg}{(\code{character(1)}) The name of the object being stabilized
-to use in error messages. The automatic value will work in most cases, or
-pass it through from higher-level functions to make error messages clearer
-in unexported functions.}
+\item{.x_arg}{(\code{character(1)}) The name of the object being stabilized to use
+in error messages. The automatic value will work in most cases, or pass it
+through from higher-level functions to make error messages clearer in
+unexported functions.}
 
 \item{.call}{\code{(environment)} The execution environment to mention as the
 source of error messages.}

--- a/man/dot-check_duplicate_names.Rd
+++ b/man/dot-check_duplicate_names.Rd
@@ -7,13 +7,13 @@
 .check_duplicate_names(.x, .allow_duplicate_names, .x_arg, .call)
 }
 \arguments{
-\item{.x}{The argument to stabilize.}
+\item{.x}{The object to stabilize.}
 
 \item{.allow_duplicate_names}{(\code{logical(1)}) Should \code{.x} be allowed to
 have duplicate names? If \code{FALSE} (default), an error is thrown when any
 named element of \code{.x} shares a name with another.}
 
-\item{.x_arg}{(\code{character(1)}) The name of the argument being stabilized
+\item{.x_arg}{(\code{character(1)}) The name of the object being stabilized
 to use in error messages. The automatic value will work in most cases, or
 pass it through from higher-level functions to make error messages clearer
 in unexported functions.}

--- a/man/dot-check_function_allowed.Rd
+++ b/man/dot-check_function_allowed.Rd
@@ -16,10 +16,10 @@
 
 \item{coerce_function}{(\code{logical(1)}) Should functions be coerced?}
 
-\item{x_arg}{(\code{character(1)}) The name of the object being stabilized
-to use in error messages. The automatic value will work in most cases, or
-pass it through from higher-level functions to make error messages clearer
-in unexported functions.}
+\item{x_arg}{(\code{character(1)}) The name of the object being stabilized to use
+in error messages. The automatic value will work in most cases, or pass it
+through from higher-level functions to make error messages clearer in
+unexported functions.}
 
 \item{call}{\code{(environment)} The execution environment to mention as the
 source of error messages.}

--- a/man/dot-check_function_allowed.Rd
+++ b/man/dot-check_function_allowed.Rd
@@ -16,7 +16,7 @@
 
 \item{coerce_function}{(\code{logical(1)}) Should functions be coerced?}
 
-\item{x_arg}{(\code{character(1)}) The name of the argument being stabilized
+\item{x_arg}{(\code{character(1)}) The name of the object being stabilized
 to use in error messages. The automatic value will work in most cases, or
 pass it through from higher-level functions to make error messages clearer
 in unexported functions.}

--- a/man/dot-check_is_not_primitive.Rd
+++ b/man/dot-check_is_not_primitive.Rd
@@ -9,10 +9,10 @@
 \arguments{
 \item{x}{The object to check.}
 
-\item{x_arg}{(\code{character(1)}) The name of the object being stabilized
-to use in error messages. The automatic value will work in most cases, or
-pass it through from higher-level functions to make error messages clearer
-in unexported functions.}
+\item{x_arg}{(\code{character(1)}) The name of the object being stabilized to use
+in error messages. The automatic value will work in most cases, or pass it
+through from higher-level functions to make error messages clearer in
+unexported functions.}
 
 \item{call}{\code{(environment)} The execution environment to mention as the
 source of error messages.}

--- a/man/dot-check_is_not_primitive.Rd
+++ b/man/dot-check_is_not_primitive.Rd
@@ -9,7 +9,7 @@
 \arguments{
 \item{x}{The object to check.}
 
-\item{x_arg}{(\code{character(1)}) The name of the argument being stabilized
+\item{x_arg}{(\code{character(1)}) The name of the object being stabilized
 to use in error messages. The automatic value will work in most cases, or
 pass it through from higher-level functions to make error messages clearer
 in unexported functions.}

--- a/man/dot-check_lst_failures.Rd
+++ b/man/dot-check_lst_failures.Rd
@@ -12,15 +12,15 @@ C routine.}
 
 \item{to}{The target object for the coercion.}
 
-\item{x_class}{(\code{character(1)}) The class name of the object being
-stabilized to use in error messages. Use this if you remove a special class
-from the object before checking its coercion, but want the error message to
-match the original class.}
+\item{x_class}{(\code{character(1)}) The class name of the object being stabilized
+to use in error messages. Use this if you remove a special class from the
+object before checking its coercion, but want the error message to match
+the original class.}
 
-\item{x_arg}{(\code{character(1)}) The name of the object being stabilized
-to use in error messages. The automatic value will work in most cases, or
-pass it through from higher-level functions to make error messages clearer
-in unexported functions.}
+\item{x_arg}{(\code{character(1)}) The name of the object being stabilized to use
+in error messages. The automatic value will work in most cases, or pass it
+through from higher-level functions to make error messages clearer in
+unexported functions.}
 
 \item{call}{\code{(environment)} The execution environment to mention as the
 source of error messages.}

--- a/man/dot-check_lst_failures.Rd
+++ b/man/dot-check_lst_failures.Rd
@@ -12,12 +12,12 @@ C routine.}
 
 \item{to}{The target object for the coercion.}
 
-\item{x_class}{(\code{character(1)}) The class name of the argument being
+\item{x_class}{(\code{character(1)}) The class name of the object being
 stabilized to use in error messages. Use this if you remove a special class
 from the object before checking its coercion, but want the error message to
 match the original class.}
 
-\item{x_arg}{(\code{character(1)}) The name of the argument being stabilized
+\item{x_arg}{(\code{character(1)}) The name of the object being stabilized
 to use in error messages. The automatic value will work in most cases, or
 pass it through from higher-level functions to make error messages clearer
 in unexported functions.}

--- a/man/dot-check_na.Rd
+++ b/man/dot-check_na.Rd
@@ -11,10 +11,10 @@
 
 \item{allow_na}{(\code{logical(1)}) Are NA values ok?}
 
-\item{x_arg}{(\code{character(1)}) The name of the object being stabilized
-to use in error messages. The automatic value will work in most cases, or
-pass it through from higher-level functions to make error messages clearer
-in unexported functions.}
+\item{x_arg}{(\code{character(1)}) The name of the object being stabilized to use
+in error messages. The automatic value will work in most cases, or pass it
+through from higher-level functions to make error messages clearer in
+unexported functions.}
 
 \item{call}{\code{(environment)} The execution environment to mention as the
 source of error messages.}

--- a/man/dot-check_na.Rd
+++ b/man/dot-check_na.Rd
@@ -11,7 +11,7 @@
 
 \item{allow_na}{(\code{logical(1)}) Are NA values ok?}
 
-\item{x_arg}{(\code{character(1)}) The name of the argument being stabilized
+\item{x_arg}{(\code{character(1)}) The name of the object being stabilized
 to use in error messages. The automatic value will work in most cases, or
 pass it through from higher-level functions to make error messages clearer
 in unexported functions.}

--- a/man/dot-check_not_jagged.Rd
+++ b/man/dot-check_not_jagged.Rd
@@ -12,9 +12,9 @@
 )
 }
 \arguments{
-\item{x}{The argument to stabilize.}
+\item{x}{The object to stabilize.}
 
-\item{x_arg}{(\code{character(1)}) The name of the argument being stabilized
+\item{x_arg}{(\code{character(1)}) The name of the object being stabilized
 to use in error messages. The automatic value will work in most cases, or
 pass it through from higher-level functions to make error messages clearer
 in unexported functions.}
@@ -22,7 +22,7 @@ in unexported functions.}
 \item{call}{\code{(environment)} The execution environment to mention as the
 source of error messages.}
 
-\item{x_class}{(\code{character(1)}) The class name of the argument being
+\item{x_class}{(\code{character(1)}) The class name of the object being
 stabilized to use in error messages. Use this if you remove a special class
 from the object before checking its coercion, but want the error message to
 match the original class.}

--- a/man/dot-check_not_jagged.Rd
+++ b/man/dot-check_not_jagged.Rd
@@ -14,18 +14,18 @@
 \arguments{
 \item{x}{The object to stabilize.}
 
-\item{x_arg}{(\code{character(1)}) The name of the object being stabilized
-to use in error messages. The automatic value will work in most cases, or
-pass it through from higher-level functions to make error messages clearer
-in unexported functions.}
+\item{x_arg}{(\code{character(1)}) The name of the object being stabilized to use
+in error messages. The automatic value will work in most cases, or pass it
+through from higher-level functions to make error messages clearer in
+unexported functions.}
 
 \item{call}{\code{(environment)} The execution environment to mention as the
 source of error messages.}
 
-\item{x_class}{(\code{character(1)}) The class name of the object being
-stabilized to use in error messages. Use this if you remove a special class
-from the object before checking its coercion, but want the error message to
-match the original class.}
+\item{x_class}{(\code{character(1)}) The class name of the object being stabilized
+to use in error messages. Use this if you remove a special class from the
+object before checking its coercion, but want the error message to match
+the original class.}
 }
 \value{
 \code{NULL} invisibly (called for side effects).

--- a/man/dot-check_scalar.Rd
+++ b/man/dot-check_scalar.Rd
@@ -21,7 +21,7 @@
 \item{allow_zero_length}{(\code{logical(1)}) Are zero-length vectors
 acceptable?}
 
-\item{x_arg}{(\code{character(1)}) The name of the argument being stabilized
+\item{x_arg}{(\code{character(1)}) The name of the object being stabilized
 to use in error messages. The automatic value will work in most cases, or
 pass it through from higher-level functions to make error messages clearer
 in unexported functions.}
@@ -29,7 +29,7 @@ in unexported functions.}
 \item{call}{\code{(environment)} The execution environment to mention as the
 source of error messages.}
 
-\item{x_class}{(\code{character(1)}) The class name of the argument being
+\item{x_class}{(\code{character(1)}) The class name of the object being
 stabilized to use in error messages. Use this if you remove a special class
 from the object before checking its coercion, but want the error message to
 match the original class.}

--- a/man/dot-check_scalar.Rd
+++ b/man/dot-check_scalar.Rd
@@ -18,21 +18,20 @@
 
 \item{allow_null}{(\code{logical(1)}) Is NULL an acceptable value?}
 
-\item{allow_zero_length}{(\code{logical(1)}) Are zero-length vectors
-acceptable?}
+\item{allow_zero_length}{(\code{logical(1)}) Are zero-length vectors acceptable?}
 
-\item{x_arg}{(\code{character(1)}) The name of the object being stabilized
-to use in error messages. The automatic value will work in most cases, or
-pass it through from higher-level functions to make error messages clearer
-in unexported functions.}
+\item{x_arg}{(\code{character(1)}) The name of the object being stabilized to use
+in error messages. The automatic value will work in most cases, or pass it
+through from higher-level functions to make error messages clearer in
+unexported functions.}
 
 \item{call}{\code{(environment)} The execution environment to mention as the
 source of error messages.}
 
-\item{x_class}{(\code{character(1)}) The class name of the object being
-stabilized to use in error messages. Use this if you remove a special class
-from the object before checking its coercion, but want the error message to
-match the original class.}
+\item{x_class}{(\code{character(1)}) The class name of the object being stabilized
+to use in error messages. Use this if you remove a special class from the
+object before checking its coercion, but want the error message to match
+the original class.}
 }
 \value{
 \code{NULL} invisibly (called for side effects).

--- a/man/dot-check_size.Rd
+++ b/man/dot-check_size.Rd
@@ -9,16 +9,16 @@
 \arguments{
 \item{x}{The object to check.}
 
-\item{min_size}{(\code{integer(1)}) The minimum size of the object. Object
-size will be tested using \code{\link[vctrs:vec_size]{vctrs::vec_size()}}.}
+\item{min_size}{(\code{integer(1)}) The minimum size of the object. Object size
+will be tested using \code{\link[vctrs:vec_size]{vctrs::vec_size()}}.}
 
-\item{max_size}{(\code{integer(1)}) The maximum size of the object. Object
-size will be tested using \code{\link[vctrs:vec_size]{vctrs::vec_size()}}.}
+\item{max_size}{(\code{integer(1)}) The maximum size of the object. Object size
+will be tested using \code{\link[vctrs:vec_size]{vctrs::vec_size()}}.}
 
-\item{x_arg}{(\code{character(1)}) The name of the object being stabilized
-to use in error messages. The automatic value will work in most cases, or
-pass it through from higher-level functions to make error messages clearer
-in unexported functions.}
+\item{x_arg}{(\code{character(1)}) The name of the object being stabilized to use
+in error messages. The automatic value will work in most cases, or pass it
+through from higher-level functions to make error messages clearer in
+unexported functions.}
 
 \item{call}{\code{(environment)} The execution environment to mention as the
 source of error messages.}

--- a/man/dot-check_size.Rd
+++ b/man/dot-check_size.Rd
@@ -15,7 +15,7 @@ size will be tested using \code{\link[vctrs:vec_size]{vctrs::vec_size()}}.}
 \item{max_size}{(\code{integer(1)}) The maximum size of the object. Object
 size will be tested using \code{\link[vctrs:vec_size]{vctrs::vec_size()}}.}
 
-\item{x_arg}{(\code{character(1)}) The name of the argument being stabilized
+\item{x_arg}{(\code{character(1)}) The name of the object being stabilized
 to use in error messages. The automatic value will work in most cases, or
 pass it through from higher-level functions to make error messages clearer
 in unexported functions.}

--- a/man/dot-check_unique.Rd
+++ b/man/dot-check_unique.Rd
@@ -11,7 +11,7 @@
 
 \item{unique}{(\code{logical(1)}) Should all elements in \code{x} be distinct?}
 
-\item{x_arg}{(\code{character(1)}) The name of the argument being stabilized
+\item{x_arg}{(\code{character(1)}) The name of the object being stabilized
 to use in error messages. The automatic value will work in most cases, or
 pass it through from higher-level functions to make error messages clearer
 in unexported functions.}

--- a/man/dot-check_unique.Rd
+++ b/man/dot-check_unique.Rd
@@ -11,10 +11,10 @@
 
 \item{unique}{(\code{logical(1)}) Should all elements in \code{x} be distinct?}
 
-\item{x_arg}{(\code{character(1)}) The name of the object being stabilized
-to use in error messages. The automatic value will work in most cases, or
-pass it through from higher-level functions to make error messages clearer
-in unexported functions.}
+\item{x_arg}{(\code{character(1)}) The name of the object being stabilized to use
+in error messages. The automatic value will work in most cases, or pass it
+through from higher-level functions to make error messages clearer in
+unexported functions.}
 
 \item{call}{\code{(environment)} The execution environment to mention as the
 source of error messages.}

--- a/man/dot-check_value_chr.Rd
+++ b/man/dot-check_value_chr.Rd
@@ -38,10 +38,10 @@ each element.}
 type). \code{NULL} (default) skips the check. \code{NA} values in \code{x} are permitted
 independently of \code{allowed_values}, subject to \code{allow_na}.}
 
-\item{x_arg}{(\code{character(1)}) The name of the object being stabilized
-to use in error messages. The automatic value will work in most cases, or
-pass it through from higher-level functions to make error messages clearer
-in unexported functions.}
+\item{x_arg}{(\code{character(1)}) The name of the object being stabilized to use
+in error messages. The automatic value will work in most cases, or pass it
+through from higher-level functions to make error messages clearer in
+unexported functions.}
 
 \item{call}{\code{(environment)} The execution environment to mention as the
 source of error messages.}

--- a/man/dot-check_value_chr.Rd
+++ b/man/dot-check_value_chr.Rd
@@ -15,7 +15,7 @@
 )
 }
 \arguments{
-\item{x}{The argument to stabilize.}
+\item{x}{The object to stabilize.}
 
 \item{regex}{\verb{(character, list, or stringr_pattern)} One or more optional
 regular expressions to test against the values of \code{x}. This can be a
@@ -38,7 +38,7 @@ each element.}
 type). \code{NULL} (default) skips the check. \code{NA} values in \code{x} are permitted
 independently of \code{allowed_values}, subject to \code{allow_na}.}
 
-\item{x_arg}{(\code{character(1)}) The name of the argument being stabilized
+\item{x_arg}{(\code{character(1)}) The name of the object being stabilized
 to use in error messages. The automatic value will work in most cases, or
 pass it through from higher-level functions to make error messages clearer
 in unexported functions.}

--- a/man/dot-check_value_dbl.Rd
+++ b/man/dot-check_value_dbl.Rd
@@ -14,7 +14,7 @@
 )
 }
 \arguments{
-\item{x}{The argument to stabilize.}
+\item{x}{The object to stabilize.}
 
 \item{min_value}{(\code{numeric(1)}) The lowest allowed value for \code{x}. If
 \code{NULL} (default) values are not checked.}
@@ -26,7 +26,7 @@
 type). \code{NULL} (default) skips the check. \code{NA} values in \code{x} are permitted
 independently of \code{allowed_values}, subject to \code{allow_na}.}
 
-\item{x_arg}{(\code{character(1)}) The name of the argument being stabilized
+\item{x_arg}{(\code{character(1)}) The name of the object being stabilized
 to use in error messages. The automatic value will work in most cases, or
 pass it through from higher-level functions to make error messages clearer
 in unexported functions.}

--- a/man/dot-check_value_dbl.Rd
+++ b/man/dot-check_value_dbl.Rd
@@ -16,20 +16,20 @@
 \arguments{
 \item{x}{The object to stabilize.}
 
-\item{min_value}{(\code{numeric(1)}) The lowest allowed value for \code{x}. If
-\code{NULL} (default) values are not checked.}
+\item{min_value}{(\code{numeric(1)}) The lowest allowed value for \code{x}. If \code{NULL}
+(default) values are not checked.}
 
-\item{max_value}{(\code{numeric(1)}) The highest allowed value for \code{x}. If
-\code{NULL} (default) values are not checked.}
+\item{max_value}{(\code{numeric(1)}) The highest allowed value for \code{x}. If \code{NULL}
+(default) values are not checked.}
 
 \item{allowed_values}{A vector of permitted values (coerced to the target
 type). \code{NULL} (default) skips the check. \code{NA} values in \code{x} are permitted
 independently of \code{allowed_values}, subject to \code{allow_na}.}
 
-\item{x_arg}{(\code{character(1)}) The name of the object being stabilized
-to use in error messages. The automatic value will work in most cases, or
-pass it through from higher-level functions to make error messages clearer
-in unexported functions.}
+\item{x_arg}{(\code{character(1)}) The name of the object being stabilized to use
+in error messages. The automatic value will work in most cases, or pass it
+through from higher-level functions to make error messages clearer in
+unexported functions.}
 
 \item{call}{\code{(environment)} The execution environment to mention as the
 source of error messages.}

--- a/man/dot-check_value_lgl.Rd
+++ b/man/dot-check_value_lgl.Rd
@@ -18,10 +18,10 @@
 type). \code{NULL} (default) skips the check. \code{NA} values in \code{x} are permitted
 independently of \code{allowed_values}, subject to \code{allow_na}.}
 
-\item{x_arg}{(\code{character(1)}) The name of the object being stabilized
-to use in error messages. The automatic value will work in most cases, or
-pass it through from higher-level functions to make error messages clearer
-in unexported functions.}
+\item{x_arg}{(\code{character(1)}) The name of the object being stabilized to use
+in error messages. The automatic value will work in most cases, or pass it
+through from higher-level functions to make error messages clearer in
+unexported functions.}
 
 \item{call}{\code{(environment)} The execution environment to mention as the
 source of error messages.}

--- a/man/dot-check_value_lgl.Rd
+++ b/man/dot-check_value_lgl.Rd
@@ -12,13 +12,13 @@
 )
 }
 \arguments{
-\item{x}{The argument to stabilize.}
+\item{x}{The object to stabilize.}
 
 \item{allowed_values}{A vector of permitted values (coerced to the target
 type). \code{NULL} (default) skips the check. \code{NA} values in \code{x} are permitted
 independently of \code{allowed_values}, subject to \code{allow_na}.}
 
-\item{x_arg}{(\code{character(1)}) The name of the argument being stabilized
+\item{x_arg}{(\code{character(1)}) The name of the object being stabilized
 to use in error messages. The automatic value will work in most cases, or
 pass it through from higher-level functions to make error messages clearer
 in unexported functions.}

--- a/man/dot-check_value_n_characters.Rd
+++ b/man/dot-check_value_n_characters.Rd
@@ -21,10 +21,10 @@ each element.}
 \item{max_characters}{(\code{integer(1)}) Maximum number of characters allowed in
 each element.}
 
-\item{x_arg}{(\code{character(1)}) The name of the object being stabilized
-to use in error messages. The automatic value will work in most cases, or
-pass it through from higher-level functions to make error messages clearer
-in unexported functions.}
+\item{x_arg}{(\code{character(1)}) The name of the object being stabilized to use
+in error messages. The automatic value will work in most cases, or pass it
+through from higher-level functions to make error messages clearer in
+unexported functions.}
 
 \item{call}{\code{(environment)} The execution environment to mention as the
 source of error messages.}

--- a/man/dot-check_value_n_characters.Rd
+++ b/man/dot-check_value_n_characters.Rd
@@ -13,7 +13,7 @@
 )
 }
 \arguments{
-\item{x}{The argument to stabilize.}
+\item{x}{The object to stabilize.}
 
 \item{min_characters}{(\code{integer(1)}) Minimum number of characters allowed in
 each element.}
@@ -21,7 +21,7 @@ each element.}
 \item{max_characters}{(\code{integer(1)}) Maximum number of characters allowed in
 each element.}
 
-\item{x_arg}{(\code{character(1)}) The name of the argument being stabilized
+\item{x_arg}{(\code{character(1)}) The name of the object being stabilized
 to use in error messages. The automatic value will work in most cases, or
 pass it through from higher-level functions to make error messages clearer
 in unexported functions.}

--- a/man/dot-check_value_regex.Rd
+++ b/man/dot-check_value_regex.Rd
@@ -20,10 +20,10 @@ message that should be displayed. To check that a pattern is \emph{not} matched,
 attach a \code{negate} attribute set to \code{TRUE}. If a complex regex pattern
 throws an error, try installing the stringi package.}
 
-\item{x_arg}{(\code{character(1)}) The name of the object being stabilized
-to use in error messages. The automatic value will work in most cases, or
-pass it through from higher-level functions to make error messages clearer
-in unexported functions.}
+\item{x_arg}{(\code{character(1)}) The name of the object being stabilized to use
+in error messages. The automatic value will work in most cases, or pass it
+through from higher-level functions to make error messages clearer in
+unexported functions.}
 
 \item{call}{\code{(environment)} The execution environment to mention as the
 source of error messages.}

--- a/man/dot-check_value_regex.Rd
+++ b/man/dot-check_value_regex.Rd
@@ -7,7 +7,7 @@
 .check_value_regex(x, regex, x_arg = caller_arg(x), call = caller_env())
 }
 \arguments{
-\item{x}{The argument to stabilize.}
+\item{x}{The object to stabilize.}
 
 \item{regex}{\verb{(character, list, or stringr_pattern)} One or more optional
 regular expressions to test against the values of \code{x}. This can be a
@@ -20,7 +20,7 @@ message that should be displayed. To check that a pattern is \emph{not} matched,
 attach a \code{negate} attribute set to \code{TRUE}. If a complex regex pattern
 throws an error, try installing the stringi package.}
 
-\item{x_arg}{(\code{character(1)}) The name of the argument being stabilized
+\item{x_arg}{(\code{character(1)}) The name of the object being stabilized
 to use in error messages. The automatic value will work in most cases, or
 pass it through from higher-level functions to make error messages clearer
 in unexported functions.}

--- a/man/dot-check_x_no_more_than_y.Rd
+++ b/man/dot-check_x_no_more_than_y.Rd
@@ -17,10 +17,10 @@
 
 \item{y}{The value to compare against.}
 
-\item{x_arg}{(\code{character(1)}) The name of the object being stabilized
-to use in error messages. The automatic value will work in most cases, or
-pass it through from higher-level functions to make error messages clearer
-in unexported functions.}
+\item{x_arg}{(\code{character(1)}) The name of the object being stabilized to use
+in error messages. The automatic value will work in most cases, or pass it
+through from higher-level functions to make error messages clearer in
+unexported functions.}
 
 \item{y_arg}{(\code{character(1)}) The name of the \code{y} value to use in error
 messages.}

--- a/man/dot-check_x_no_more_than_y.Rd
+++ b/man/dot-check_x_no_more_than_y.Rd
@@ -17,12 +17,13 @@
 
 \item{y}{The value to compare against.}
 
-\item{x_arg}{(\code{character(1)}) The name of the argument being stabilized
+\item{x_arg}{(\code{character(1)}) The name of the object being stabilized
 to use in error messages. The automatic value will work in most cases, or
 pass it through from higher-level functions to make error messages clearer
 in unexported functions.}
 
-\item{y_arg}{(\code{character(1)}) The name of the \code{y} argument.}
+\item{y_arg}{(\code{character(1)}) The name of the \code{y} value to use in error
+messages.}
 
 \item{call}{\code{(environment)} The execution environment to mention as the
 source of error messages.}

--- a/man/dot-coerce_fct_levels.Rd
+++ b/man/dot-coerce_fct_levels.Rd
@@ -13,7 +13,7 @@
 )
 }
 \arguments{
-\item{x}{The argument to stabilize.}
+\item{x}{The object to stabilize.}
 
 \item{levels}{\code{(character)} The desired factor levels. For factors, a
 vector's \code{levels} play the same role that \code{allowed_values} plays for
@@ -21,7 +21,7 @@ other types: they restrict \code{x} to a fixed set of permitted values.}
 
 \item{to_na}{\code{(character)} Values to convert to \code{NA}.}
 
-\item{x_arg}{(\code{character(1)}) The name of the argument being stabilized
+\item{x_arg}{(\code{character(1)}) The name of the object being stabilized
 to use in error messages. The automatic value will work in most cases, or
 pass it through from higher-level functions to make error messages clearer
 in unexported functions.}

--- a/man/dot-coerce_fct_levels.Rd
+++ b/man/dot-coerce_fct_levels.Rd
@@ -16,15 +16,15 @@
 \item{x}{The object to stabilize.}
 
 \item{levels}{\code{(character)} The desired factor levels. For factors, a
-vector's \code{levels} play the same role that \code{allowed_values} plays for
-other types: they restrict \code{x} to a fixed set of permitted values.}
+vector's \code{levels} play the same role that \code{allowed_values} plays for other
+types: they restrict \code{x} to a fixed set of permitted values.}
 
 \item{to_na}{\code{(character)} Values to convert to \code{NA}.}
 
-\item{x_arg}{(\code{character(1)}) The name of the object being stabilized
-to use in error messages. The automatic value will work in most cases, or
-pass it through from higher-level functions to make error messages clearer
-in unexported functions.}
+\item{x_arg}{(\code{character(1)}) The name of the object being stabilized to use
+in error messages. The automatic value will work in most cases, or pass it
+through from higher-level functions to make error messages clearer in
+unexported functions.}
 
 \item{call}{\code{(environment)} The execution environment to mention as the
 source of error messages.}

--- a/man/dot-coerce_fct_levels_impl.Rd
+++ b/man/dot-coerce_fct_levels_impl.Rd
@@ -13,7 +13,7 @@
 )
 }
 \arguments{
-\item{x}{The argument to stabilize.}
+\item{x}{The object to stabilize.}
 
 \item{levels}{\code{(character)} The desired factor levels. For factors, a
 vector's \code{levels} play the same role that \code{allowed_values} plays for
@@ -21,7 +21,7 @@ other types: they restrict \code{x} to a fixed set of permitted values.}
 
 \item{to_na}{\code{(character)} Values to convert to \code{NA}.}
 
-\item{x_arg}{(\code{character(1)}) The name of the argument being stabilized
+\item{x_arg}{(\code{character(1)}) The name of the object being stabilized
 to use in error messages. The automatic value will work in most cases, or
 pass it through from higher-level functions to make error messages clearer
 in unexported functions.}

--- a/man/dot-coerce_fct_levels_impl.Rd
+++ b/man/dot-coerce_fct_levels_impl.Rd
@@ -16,15 +16,15 @@
 \item{x}{The object to stabilize.}
 
 \item{levels}{\code{(character)} The desired factor levels. For factors, a
-vector's \code{levels} play the same role that \code{allowed_values} plays for
-other types: they restrict \code{x} to a fixed set of permitted values.}
+vector's \code{levels} play the same role that \code{allowed_values} plays for other
+types: they restrict \code{x} to a fixed set of permitted values.}
 
 \item{to_na}{\code{(character)} Values to convert to \code{NA}.}
 
-\item{x_arg}{(\code{character(1)}) The name of the object being stabilized
-to use in error messages. The automatic value will work in most cases, or
-pass it through from higher-level functions to make error messages clearer
-in unexported functions.}
+\item{x_arg}{(\code{character(1)}) The name of the object being stabilized to use
+in error messages. The automatic value will work in most cases, or pass it
+through from higher-level functions to make error messages clearer in
+unexported functions.}
 
 \item{call}{\code{(environment)} The execution environment to mention as the
 source of error messages.}

--- a/man/dot-coerce_fct_to_na.Rd
+++ b/man/dot-coerce_fct_to_na.Rd
@@ -7,7 +7,7 @@
 .coerce_fct_to_na(x, to_na = character(), call = caller_env())
 }
 \arguments{
-\item{x}{The argument to stabilize.}
+\item{x}{The object to stabilize.}
 
 \item{to_na}{\code{(character)} Values to convert to \code{NA}.}
 

--- a/man/dot-compile_pkg_condition_classes.Rd
+++ b/man/dot-compile_pkg_condition_classes.Rd
@@ -7,8 +7,7 @@
 .compile_pkg_condition_classes(package, ...)
 }
 \arguments{
-\item{package}{(\code{character(1)}) The name of the package to use in
-classes.}
+\item{package}{(\code{character(1)}) The name of the package to use in classes.}
 
 \item{...}{\code{(character)} Components of the class name, from least-specific to
 most.}

--- a/man/dot-compile_pkg_error_classes.Rd
+++ b/man/dot-compile_pkg_error_classes.Rd
@@ -7,8 +7,7 @@
 .compile_pkg_error_classes(package, ...)
 }
 \arguments{
-\item{package}{(\code{character(1)}) The name of the package to use in
-classes.}
+\item{package}{(\code{character(1)}) The name of the package to use in classes.}
 
 \item{...}{\code{(character)} Components of the class name, from least-specific to
 most.}

--- a/man/dot-compile_pkg_message_classes.Rd
+++ b/man/dot-compile_pkg_message_classes.Rd
@@ -7,8 +7,7 @@
 .compile_pkg_message_classes(package, ...)
 }
 \arguments{
-\item{package}{(\code{character(1)}) The name of the package to use in
-classes.}
+\item{package}{(\code{character(1)}) The name of the package to use in classes.}
 
 \item{...}{\code{(character)} Components of the class name, from least-specific to
 most.}

--- a/man/dot-compile_pkg_warning_classes.Rd
+++ b/man/dot-compile_pkg_warning_classes.Rd
@@ -7,8 +7,7 @@
 .compile_pkg_warning_classes(package, ...)
 }
 \arguments{
-\item{package}{(\code{character(1)}) The name of the package to use in
-classes.}
+\item{package}{(\code{character(1)}) The name of the package to use in classes.}
 
 \item{...}{\code{(character)} Components of the class name, from least-specific to
 most.}

--- a/man/dot-define_main_msg.Rd
+++ b/man/dot-define_main_msg.Rd
@@ -7,7 +7,7 @@
 .define_main_msg(x_arg, msg)
 }
 \arguments{
-\item{x_arg}{(\code{character(1)}) The name of the argument being stabilized
+\item{x_arg}{(\code{character(1)}) The name of the object being stabilized
 to use in error messages. The automatic value will work in most cases, or
 pass it through from higher-level functions to make error messages clearer
 in unexported functions.}

--- a/man/dot-define_main_msg.Rd
+++ b/man/dot-define_main_msg.Rd
@@ -7,10 +7,10 @@
 .define_main_msg(x_arg, msg)
 }
 \arguments{
-\item{x_arg}{(\code{character(1)}) The name of the object being stabilized
-to use in error messages. The automatic value will work in most cases, or
-pass it through from higher-level functions to make error messages clearer
-in unexported functions.}
+\item{x_arg}{(\code{character(1)}) The name of the object being stabilized to use
+in error messages. The automatic value will work in most cases, or pass it
+through from higher-level functions to make error messages clearer in
+unexported functions.}
 
 \item{msg}{\code{(character)} The core error message describing the requirement.}
 }

--- a/man/dot-describe_failure_chr.Rd
+++ b/man/dot-describe_failure_chr.Rd
@@ -7,7 +7,7 @@
 .describe_failure_chr(x, success, negate = FALSE)
 }
 \arguments{
-\item{x}{The argument to stabilize.}
+\item{x}{The object to stabilize.}
 
 \item{success}{\code{(logical)} A logical vector indicating which elements of \code{x}
 passed the check.}

--- a/man/dot-describe_failure_dbl_value.Rd
+++ b/man/dot-describe_failure_dbl_value.Rd
@@ -22,7 +22,7 @@
 \item{target_value}{\code{(numeric)} The value against which \code{x} is being
 compared.}
 
-\item{x_arg}{(\code{character(1)}) The name of the argument being stabilized
+\item{x_arg}{(\code{character(1)}) The name of the object being stabilized
 to use in error messages. The automatic value will work in most cases, or
 pass it through from higher-level functions to make error messages clearer
 in unexported functions.}

--- a/man/dot-describe_failure_dbl_value.Rd
+++ b/man/dot-describe_failure_dbl_value.Rd
@@ -22,10 +22,10 @@
 \item{target_value}{\code{(numeric)} The value against which \code{x} is being
 compared.}
 
-\item{x_arg}{(\code{character(1)}) The name of the object being stabilized
-to use in error messages. The automatic value will work in most cases, or
-pass it through from higher-level functions to make error messages clearer
-in unexported functions.}
+\item{x_arg}{(\code{character(1)}) The name of the object being stabilized to use
+in error messages. The automatic value will work in most cases, or pass it
+through from higher-level functions to make error messages clearer in
+unexported functions.}
 }
 \value{
 A named character vector for \code{.stbl_abort()}.

--- a/man/dot-describe_failure_n_characters.Rd
+++ b/man/dot-describe_failure_n_characters.Rd
@@ -15,10 +15,10 @@
 
 \item{direction}{(\code{character(1)}) One of \code{"few"} or \code{"many"}.}
 
-\item{x_arg}{(\code{character(1)}) The name of the object being stabilized
-to use in error messages. The automatic value will work in most cases, or
-pass it through from higher-level functions to make error messages clearer
-in unexported functions.}
+\item{x_arg}{(\code{character(1)}) The name of the object being stabilized to use
+in error messages. The automatic value will work in most cases, or pass it
+through from higher-level functions to make error messages clearer in
+unexported functions.}
 }
 \value{
 A named character vector for \code{\link[=.stbl_abort]{.stbl_abort()}}.

--- a/man/dot-describe_failure_n_characters.Rd
+++ b/man/dot-describe_failure_n_characters.Rd
@@ -15,7 +15,7 @@
 
 \item{direction}{(\code{character(1)}) One of \code{"few"} or \code{"many"}.}
 
-\item{x_arg}{(\code{character(1)}) The name of the argument being stabilized
+\item{x_arg}{(\code{character(1)}) The name of the object being stabilized
 to use in error messages. The automatic value will work in most cases, or
 pass it through from higher-level functions to make error messages clearer
 in unexported functions.}

--- a/man/dot-expect_pkg_condition_snapshot.Rd
+++ b/man/dot-expect_pkg_condition_snapshot.Rd
@@ -20,8 +20,7 @@
 \arguments{
 \item{obj_expr}{An unevaluated expression (from \code{\link[rlang:enexpr]{rlang::enexpr()}}).}
 
-\item{package}{(\code{character(1)}) The name of the package to use in
-classes.}
+\item{package}{(\code{character(1)}) The name of the package to use in classes.}
 
 \item{class_components}{(\code{list}) Passed as \code{...} to \code{expect_fn}.}
 

--- a/man/dot-has_regex_pattern.Rd
+++ b/man/dot-has_regex_pattern.Rd
@@ -7,7 +7,7 @@
 .has_regex_pattern(x, regex)
 }
 \arguments{
-\item{x}{The argument to stabilize.}
+\item{x}{The object to stabilize.}
 
 \item{regex}{\verb{(character, list, or stringr_pattern)} One or more optional
 regular expressions to test against the values of \code{x}. This can be a

--- a/man/dot-shared-params.Rd
+++ b/man/dot-shared-params.Rd
@@ -122,14 +122,14 @@ coercion.}
 
 \item{unique}{(\code{logical(1)}) Should all elements in \code{x} be distinct?}
 
-\item{x}{The argument to stabilize.}
+\item{x}{The object to stabilize.}
 
-\item{x_arg}{(\code{character(1)}) The name of the argument being stabilized
+\item{x_arg}{(\code{character(1)}) The name of the object being stabilized
 to use in error messages. The automatic value will work in most cases, or
 pass it through from higher-level functions to make error messages clearer
 in unexported functions.}
 
-\item{x_class}{(\code{character(1)}) The class name of the argument being
+\item{x_class}{(\code{character(1)}) The class name of the object being
 stabilized to use in error messages. Use this if you remove a special class
 from the object before checking its coercion, but want the error message to
 match the original class.}

--- a/man/dot-shared-params.Rd
+++ b/man/dot-shared-params.Rd
@@ -18,8 +18,7 @@ independently of \code{allowed_values}, subject to \code{allow_na}.}
 
 \item{allow_null}{(\code{logical(1)}) Is NULL an acceptable value?}
 
-\item{allow_zero_length}{(\code{logical(1)}) Are zero-length vectors
-acceptable?}
+\item{allow_zero_length}{(\code{logical(1)}) Are zero-length vectors acceptable?}
 
 \item{are_cls_ish_fn}{The \verb{are_*_ish} function to apply to each element.}
 
@@ -34,18 +33,18 @@ after coercion.}
 \item{check_cls_value_fn_args}{\code{(list)} A list of additional arguments to
 pass to \code{check_cls_value_fn()}.}
 
-\item{coerce_character}{(\code{logical(1)}) Should character vectors such as
-"1" and "2.0" be considered numeric-ish?}
+\item{coerce_character}{(\code{logical(1)}) Should character vectors such as "1"
+and "2.0" be considered numeric-ish?}
 
-\item{coerce_factor}{(\code{logical(1)}) Should factors with values such as
-"1" and "2.0" be considered numeric-ish? Note that this package uses the
+\item{coerce_factor}{(\code{logical(1)}) Should factors with values such as "1"
+and "2.0" be considered numeric-ish? Note that this package uses the
 character value from the factor, while \code{\link[=as.integer]{as.integer()}} and \code{\link[=as.double]{as.double()}} use
 the integer index of the factor.}
 
 \item{coerce_function}{(\code{logical(1)}) Should functions be coerced?}
 
-\item{depth}{(\code{integer(1)}) Current recursion depth. Do not manually
-set this parameter.}
+\item{depth}{(\code{integer(1)}) Current recursion depth. Do not manually set this
+parameter.}
 
 \item{due_to}{(\code{character(1)}) A string describing the reason for the
 failure.}
@@ -57,20 +56,20 @@ failed.}
 rlang, used for a fast path if \code{x} is already the right type.}
 
 \item{levels}{\code{(character)} The desired factor levels. For factors, a
-vector's \code{levels} play the same role that \code{allowed_values} plays for
-other types: they restrict \code{x} to a fixed set of permitted values.}
+vector's \code{levels} play the same role that \code{allowed_values} plays for other
+types: they restrict \code{x} to a fixed set of permitted values.}
 
 \item{max_characters}{(\code{integer(1)}) Maximum number of characters allowed in
 each element.}
 
-\item{max_levels}{(\code{numeric(1)}) Maximum number of distinct non-\code{NA}
-values allowed across the whole vector after applying \code{to_na}.}
+\item{max_levels}{(\code{numeric(1)}) Maximum number of distinct non-\code{NA} values
+allowed across the whole vector after applying \code{to_na}.}
 
-\item{max_size}{(\code{integer(1)}) The maximum size of the object. Object
-size will be tested using \code{\link[vctrs:vec_size]{vctrs::vec_size()}}.}
+\item{max_size}{(\code{integer(1)}) The maximum size of the object. Object size
+will be tested using \code{\link[vctrs:vec_size]{vctrs::vec_size()}}.}
 
-\item{max_value}{(\code{numeric(1)}) The highest allowed value for \code{x}. If
-\code{NULL} (default) values are not checked.}
+\item{max_value}{(\code{numeric(1)}) The highest allowed value for \code{x}. If \code{NULL}
+(default) values are not checked.}
 
 \item{message_env}{(\code{environment}) The execution environment to use to
 evaluate variables in error messages.}
@@ -78,14 +77,13 @@ evaluate variables in error messages.}
 \item{min_characters}{(\code{integer(1)}) Minimum number of characters allowed in
 each element.}
 
-\item{min_size}{(\code{integer(1)}) The minimum size of the object. Object
-size will be tested using \code{\link[vctrs:vec_size]{vctrs::vec_size()}}.}
+\item{min_size}{(\code{integer(1)}) The minimum size of the object. Object size
+will be tested using \code{\link[vctrs:vec_size]{vctrs::vec_size()}}.}
 
-\item{min_value}{(\code{numeric(1)}) The lowest allowed value for \code{x}. If
-\code{NULL} (default) values are not checked.}
+\item{min_value}{(\code{numeric(1)}) The lowest allowed value for \code{x}. If \code{NULL}
+(default) values are not checked.}
 
-\item{package}{(\code{character(1)}) The name of the package to use in
-classes.}
+\item{package}{(\code{character(1)}) The name of the package to use in classes.}
 
 \item{parent}{A parent condition, as you might create during a
 \code{\link[rlang:try_fetch]{rlang::try_fetch()}}. See \code{\link[rlang:abort]{rlang::abort()}} for additional information.}
@@ -124,15 +122,15 @@ coercion.}
 
 \item{x}{The object to stabilize.}
 
-\item{x_arg}{(\code{character(1)}) The name of the object being stabilized
-to use in error messages. The automatic value will work in most cases, or
-pass it through from higher-level functions to make error messages clearer
-in unexported functions.}
+\item{x_arg}{(\code{character(1)}) The name of the object being stabilized to use
+in error messages. The automatic value will work in most cases, or pass it
+through from higher-level functions to make error messages clearer in
+unexported functions.}
 
-\item{x_class}{(\code{character(1)}) The class name of the object being
-stabilized to use in error messages. Use this if you remove a special class
-from the object before checking its coercion, but want the error message to
-match the original class.}
+\item{x_class}{(\code{character(1)}) The class name of the object being stabilized
+to use in error messages. Use this if you remove a special class from the
+object before checking its coercion, but want the error message to match
+the original class.}
 }
 \description{
 These parameters are used in multiple functions. They are defined here to

--- a/man/dot-stabilize_cls.Rd
+++ b/man/dot-stabilize_cls.Rd
@@ -41,26 +41,26 @@ pass to \code{check_cls_value_fn()}.}
 
 \item{allow_na}{(\code{logical(1)}) Are NA values ok?}
 
-\item{min_size}{(\code{integer(1)}) The minimum size of the object. Object
-size will be tested using \code{\link[vctrs:vec_size]{vctrs::vec_size()}}.}
+\item{min_size}{(\code{integer(1)}) The minimum size of the object. Object size
+will be tested using \code{\link[vctrs:vec_size]{vctrs::vec_size()}}.}
 
-\item{max_size}{(\code{integer(1)}) The maximum size of the object. Object
-size will be tested using \code{\link[vctrs:vec_size]{vctrs::vec_size()}}.}
+\item{max_size}{(\code{integer(1)}) The maximum size of the object. Object size
+will be tested using \code{\link[vctrs:vec_size]{vctrs::vec_size()}}.}
 
 \item{unique}{(\code{logical(1)}) Should all elements in \code{x} be distinct?}
 
-\item{x_arg}{(\code{character(1)}) The name of the object being stabilized
-to use in error messages. The automatic value will work in most cases, or
-pass it through from higher-level functions to make error messages clearer
-in unexported functions.}
+\item{x_arg}{(\code{character(1)}) The name of the object being stabilized to use
+in error messages. The automatic value will work in most cases, or pass it
+through from higher-level functions to make error messages clearer in
+unexported functions.}
 
 \item{call}{\code{(environment)} The execution environment to mention as the
 source of error messages.}
 
-\item{x_class}{(\code{character(1)}) The class name of the object being
-stabilized to use in error messages. Use this if you remove a special class
-from the object before checking its coercion, but want the error message to
-match the original class.}
+\item{x_class}{(\code{character(1)}) The class name of the object being stabilized
+to use in error messages. Use this if you remove a special class from the
+object before checking its coercion, but want the error message to match
+the original class.}
 }
 \value{
 \code{x} as a vector of the target class with all checks passed.

--- a/man/dot-stabilize_cls.Rd
+++ b/man/dot-stabilize_cls.Rd
@@ -22,7 +22,7 @@
 )
 }
 \arguments{
-\item{x}{The argument to stabilize.}
+\item{x}{The object to stabilize.}
 
 \item{to_cls_fn}{\verb{(function)} The \verb{to_*()} function to use for coercion.}
 
@@ -49,7 +49,7 @@ size will be tested using \code{\link[vctrs:vec_size]{vctrs::vec_size()}}.}
 
 \item{unique}{(\code{logical(1)}) Should all elements in \code{x} be distinct?}
 
-\item{x_arg}{(\code{character(1)}) The name of the argument being stabilized
+\item{x_arg}{(\code{character(1)}) The name of the object being stabilized
 to use in error messages. The automatic value will work in most cases, or
 pass it through from higher-level functions to make error messages clearer
 in unexported functions.}
@@ -57,7 +57,7 @@ in unexported functions.}
 \item{call}{\code{(environment)} The execution environment to mention as the
 source of error messages.}
 
-\item{x_class}{(\code{character(1)}) The class name of the argument being
+\item{x_class}{(\code{character(1)}) The class name of the object being
 stabilized to use in error messages. Use this if you remove a special class
 from the object before checking its coercion, but want the error message to
 match the original class.}

--- a/man/dot-stabilize_cls_scalar.Rd
+++ b/man/dot-stabilize_cls_scalar.Rd
@@ -20,7 +20,7 @@
 )
 }
 \arguments{
-\item{x}{The argument to stabilize.}
+\item{x}{The object to stabilize.}
 
 \item{to_cls_scalar_fn}{\verb{(function)} The \verb{to_*_scalar()} function to use for
 coercion.}
@@ -43,7 +43,7 @@ acceptable?}
 
 \item{allow_na}{(\code{logical(1)}) Are NA values ok?}
 
-\item{x_arg}{(\code{character(1)}) The name of the argument being stabilized
+\item{x_arg}{(\code{character(1)}) The name of the object being stabilized
 to use in error messages. The automatic value will work in most cases, or
 pass it through from higher-level functions to make error messages clearer
 in unexported functions.}
@@ -51,7 +51,7 @@ in unexported functions.}
 \item{call}{\code{(environment)} The execution environment to mention as the
 source of error messages.}
 
-\item{x_class}{(\code{character(1)}) The class name of the argument being
+\item{x_class}{(\code{character(1)}) The class name of the object being
 stabilized to use in error messages. Use this if you remove a special class
 from the object before checking its coercion, but want the error message to
 match the original class.}

--- a/man/dot-stabilize_cls_scalar.Rd
+++ b/man/dot-stabilize_cls_scalar.Rd
@@ -38,23 +38,22 @@ pass to \code{check_cls_value_fn()}.}
 
 \item{allow_null}{(\code{logical(1)}) Is NULL an acceptable value?}
 
-\item{allow_zero_length}{(\code{logical(1)}) Are zero-length vectors
-acceptable?}
+\item{allow_zero_length}{(\code{logical(1)}) Are zero-length vectors acceptable?}
 
 \item{allow_na}{(\code{logical(1)}) Are NA values ok?}
 
-\item{x_arg}{(\code{character(1)}) The name of the object being stabilized
-to use in error messages. The automatic value will work in most cases, or
-pass it through from higher-level functions to make error messages clearer
-in unexported functions.}
+\item{x_arg}{(\code{character(1)}) The name of the object being stabilized to use
+in error messages. The automatic value will work in most cases, or pass it
+through from higher-level functions to make error messages clearer in
+unexported functions.}
 
 \item{call}{\code{(environment)} The execution environment to mention as the
 source of error messages.}
 
-\item{x_class}{(\code{character(1)}) The class name of the object being
-stabilized to use in error messages. Use this if you remove a special class
-from the object before checking its coercion, but want the error message to
-match the original class.}
+\item{x_class}{(\code{character(1)}) The class name of the object being stabilized
+to use in error messages. Use this if you remove a special class from the
+object before checking its coercion, but want the error message to match
+the original class.}
 }
 \value{
 \code{x} as a scalar of the target class with all checks passed.

--- a/man/dot-stop_bad_levels.Rd
+++ b/man/dot-stop_bad_levels.Rd
@@ -7,7 +7,7 @@
 .stop_bad_levels(x, bad_casts, levels, to_na, x_arg, call)
 }
 \arguments{
-\item{x}{The argument to stabilize.}
+\item{x}{The object to stabilize.}
 
 \item{bad_casts}{\code{(logical)} A logical vector indicating which elements of
 \code{x} are not in the allowed levels.}
@@ -18,7 +18,7 @@ other types: they restrict \code{x} to a fixed set of permitted values.}
 
 \item{to_na}{\code{(character)} Values to convert to \code{NA}.}
 
-\item{x_arg}{(\code{character(1)}) The name of the argument being stabilized
+\item{x_arg}{(\code{character(1)}) The name of the object being stabilized
 to use in error messages. The automatic value will work in most cases, or
 pass it through from higher-level functions to make error messages clearer
 in unexported functions.}

--- a/man/dot-stop_bad_levels.Rd
+++ b/man/dot-stop_bad_levels.Rd
@@ -13,15 +13,15 @@
 \code{x} are not in the allowed levels.}
 
 \item{levels}{\code{(character)} The desired factor levels. For factors, a
-vector's \code{levels} play the same role that \code{allowed_values} plays for
-other types: they restrict \code{x} to a fixed set of permitted values.}
+vector's \code{levels} play the same role that \code{allowed_values} plays for other
+types: they restrict \code{x} to a fixed set of permitted values.}
 
 \item{to_na}{\code{(character)} Values to convert to \code{NA}.}
 
-\item{x_arg}{(\code{character(1)}) The name of the object being stabilized
-to use in error messages. The automatic value will work in most cases, or
-pass it through from higher-level functions to make error messages clearer
-in unexported functions.}
+\item{x_arg}{(\code{character(1)}) The name of the object being stabilized to use
+in error messages. The automatic value will work in most cases, or pass it
+through from higher-level functions to make error messages clearer in
+unexported functions.}
 
 \item{call}{\code{(environment)} The execution environment to mention as the
 source of error messages.}

--- a/man/dot-stop_cant_coerce.Rd
+++ b/man/dot-stop_cant_coerce.Rd
@@ -21,7 +21,7 @@ coercion.}
 
 \item{to_class}{(\code{character(1)}) The target class for the coercion.}
 
-\item{x_arg}{(\code{character(1)}) The name of the argument being stabilized
+\item{x_arg}{(\code{character(1)}) The name of the object being stabilized
 to use in error messages. The automatic value will work in most cases, or
 pass it through from higher-level functions to make error messages clearer
 in unexported functions.}

--- a/man/dot-stop_cant_coerce.Rd
+++ b/man/dot-stop_cant_coerce.Rd
@@ -21,10 +21,10 @@ coercion.}
 
 \item{to_class}{(\code{character(1)}) The target class for the coercion.}
 
-\item{x_arg}{(\code{character(1)}) The name of the object being stabilized
-to use in error messages. The automatic value will work in most cases, or
-pass it through from higher-level functions to make error messages clearer
-in unexported functions.}
+\item{x_arg}{(\code{character(1)}) The name of the object being stabilized to use
+in error messages. The automatic value will work in most cases, or pass it
+through from higher-level functions to make error messages clearer in
+unexported functions.}
 
 \item{call}{\code{(environment)} The execution environment to mention as the
 source of error messages.}

--- a/man/dot-stop_cant_stabilize_any_of.Rd
+++ b/man/dot-stop_cant_stabilize_any_of.Rd
@@ -9,7 +9,7 @@
 \arguments{
 \item{errors}{\code{(list)} List of error conditions from failed attempts.}
 
-\item{x_arg}{(\code{character(1)}) The name of the argument being stabilized
+\item{x_arg}{(\code{character(1)}) The name of the object being stabilized
 to use in error messages. The automatic value will work in most cases, or
 pass it through from higher-level functions to make error messages clearer
 in unexported functions.}

--- a/man/dot-stop_cant_stabilize_any_of.Rd
+++ b/man/dot-stop_cant_stabilize_any_of.Rd
@@ -9,10 +9,10 @@
 \arguments{
 \item{errors}{\code{(list)} List of error conditions from failed attempts.}
 
-\item{x_arg}{(\code{character(1)}) The name of the object being stabilized
-to use in error messages. The automatic value will work in most cases, or
-pass it through from higher-level functions to make error messages clearer
-in unexported functions.}
+\item{x_arg}{(\code{character(1)}) The name of the object being stabilized to use
+in error messages. The automatic value will work in most cases, or pass it
+through from higher-level functions to make error messages clearer in
+unexported functions.}
 
 \item{call}{\code{(environment)} The execution environment to mention as the
 source of error messages.}

--- a/man/dot-stop_function.Rd
+++ b/man/dot-stop_function.Rd
@@ -2,12 +2,12 @@
 % Please edit documentation in R/to_lst.R
 \name{.stop_function}
 \alias{.stop_function}
-\title{Abort because an argument must not be a function}
+\title{Abort because an object must not be a function}
 \usage{
 .stop_function(x_arg, call)
 }
 \arguments{
-\item{x_arg}{(\code{character(1)}) The name of the argument being stabilized
+\item{x_arg}{(\code{character(1)}) The name of the object being stabilized
 to use in error messages. The automatic value will work in most cases, or
 pass it through from higher-level functions to make error messages clearer
 in unexported functions.}
@@ -19,6 +19,6 @@ source of error messages.}
 \code{NULL} invisibly (called for side effects).
 }
 \description{
-Abort because an argument must not be a function
+Abort because an object must not be a function
 }
 \keyword{internal}

--- a/man/dot-stop_function.Rd
+++ b/man/dot-stop_function.Rd
@@ -7,10 +7,10 @@
 .stop_function(x_arg, call)
 }
 \arguments{
-\item{x_arg}{(\code{character(1)}) The name of the object being stabilized
-to use in error messages. The automatic value will work in most cases, or
-pass it through from higher-level functions to make error messages clearer
-in unexported functions.}
+\item{x_arg}{(\code{character(1)}) The name of the object being stabilized to use
+in error messages. The automatic value will work in most cases, or pass it
+through from higher-level functions to make error messages clearer in
+unexported functions.}
 
 \item{call}{\code{(environment)} The execution environment to mention as the
 source of error messages.}

--- a/man/dot-stop_if_anon_fn.Rd
+++ b/man/dot-stop_if_anon_fn.Rd
@@ -9,15 +9,15 @@
 \arguments{
 \item{x_expr}{The expression from the quosure.}
 
-\item{x_class}{(\code{character(1)}) The class name of the object being
-stabilized to use in error messages. Use this if you remove a special class
-from the object before checking its coercion, but want the error message to
-match the original class.}
+\item{x_class}{(\code{character(1)}) The class name of the object being stabilized
+to use in error messages. Use this if you remove a special class from the
+object before checking its coercion, but want the error message to match
+the original class.}
 
-\item{x_arg}{(\code{character(1)}) The name of the object being stabilized
-to use in error messages. The automatic value will work in most cases, or
-pass it through from higher-level functions to make error messages clearer
-in unexported functions.}
+\item{x_arg}{(\code{character(1)}) The name of the object being stabilized to use
+in error messages. The automatic value will work in most cases, or pass it
+through from higher-level functions to make error messages clearer in
+unexported functions.}
 
 \item{call}{\code{(environment)} The execution environment to mention as the
 source of error messages.}

--- a/man/dot-stop_if_anon_fn.Rd
+++ b/man/dot-stop_if_anon_fn.Rd
@@ -9,12 +9,12 @@
 \arguments{
 \item{x_expr}{The expression from the quosure.}
 
-\item{x_class}{(\code{character(1)}) The class name of the argument being
+\item{x_class}{(\code{character(1)}) The class name of the object being
 stabilized to use in error messages. Use this if you remove a special class
 from the object before checking its coercion, but want the error message to
 match the original class.}
 
-\item{x_arg}{(\code{character(1)}) The name of the argument being stabilized
+\item{x_arg}{(\code{character(1)}) The name of the object being stabilized
 to use in error messages. The automatic value will work in most cases, or
 pass it through from higher-level functions to make error messages clearer
 in unexported functions.}

--- a/man/dot-stop_incompatible.Rd
+++ b/man/dot-stop_incompatible.Rd
@@ -16,7 +16,7 @@
 )
 }
 \arguments{
-\item{x_class}{(\code{character(1)}) The class name of the argument being
+\item{x_class}{(\code{character(1)}) The class name of the object being
 stabilized to use in error messages. Use this if you remove a special class
 from the object before checking its coercion, but want the error message to
 match the original class.}
@@ -29,7 +29,7 @@ failed.}
 \item{due_to}{(\code{character(1)}) A string describing the reason for the
 failure.}
 
-\item{x_arg}{(\code{character(1)}) The name of the argument being stabilized
+\item{x_arg}{(\code{character(1)}) The name of the object being stabilized
 to use in error messages. The automatic value will work in most cases, or
 pass it through from higher-level functions to make error messages clearer
 in unexported functions.}

--- a/man/dot-stop_incompatible.Rd
+++ b/man/dot-stop_incompatible.Rd
@@ -16,10 +16,10 @@
 )
 }
 \arguments{
-\item{x_class}{(\code{character(1)}) The class name of the object being
-stabilized to use in error messages. Use this if you remove a special class
-from the object before checking its coercion, but want the error message to
-match the original class.}
+\item{x_class}{(\code{character(1)}) The class name of the object being stabilized
+to use in error messages. Use this if you remove a special class from the
+object before checking its coercion, but want the error message to match
+the original class.}
 
 \item{to}{The target object for the coercion.}
 
@@ -29,10 +29,10 @@ failed.}
 \item{due_to}{(\code{character(1)}) A string describing the reason for the
 failure.}
 
-\item{x_arg}{(\code{character(1)}) The name of the object being stabilized
-to use in error messages. The automatic value will work in most cases, or
-pass it through from higher-level functions to make error messages clearer
-in unexported functions.}
+\item{x_arg}{(\code{character(1)}) The name of the object being stabilized to use
+in error messages. The automatic value will work in most cases, or pass it
+through from higher-level functions to make error messages clearer in
+unexported functions.}
 
 \item{call}{\code{(environment)} The execution environment to mention as the
 source of error messages.}

--- a/man/dot-stop_must.Rd
+++ b/man/dot-stop_must.Rd
@@ -18,7 +18,7 @@
 \arguments{
 \item{msg}{\code{(character)} The core error message describing the requirement.}
 
-\item{x_arg}{(\code{character(1)}) The name of the argument being stabilized
+\item{x_arg}{(\code{character(1)}) The name of the object being stabilized
 to use in error messages. The automatic value will work in most cases, or
 pass it through from higher-level functions to make error messages clearer
 in unexported functions.}

--- a/man/dot-stop_must.Rd
+++ b/man/dot-stop_must.Rd
@@ -18,10 +18,10 @@
 \arguments{
 \item{msg}{\code{(character)} The core error message describing the requirement.}
 
-\item{x_arg}{(\code{character(1)}) The name of the object being stabilized
-to use in error messages. The automatic value will work in most cases, or
-pass it through from higher-level functions to make error messages clearer
-in unexported functions.}
+\item{x_arg}{(\code{character(1)}) The name of the object being stabilized to use
+in error messages. The automatic value will work in most cases, or pass it
+through from higher-level functions to make error messages clearer in
+unexported functions.}
 
 \item{call}{\code{(environment)} The execution environment to mention as the
 source of error messages.}

--- a/man/dot-stop_null.Rd
+++ b/man/dot-stop_null.Rd
@@ -7,10 +7,10 @@
 .stop_null(x_arg, call, parent = NULL, ...)
 }
 \arguments{
-\item{x_arg}{(\code{character(1)}) The name of the object being stabilized
-to use in error messages. The automatic value will work in most cases, or
-pass it through from higher-level functions to make error messages clearer
-in unexported functions.}
+\item{x_arg}{(\code{character(1)}) The name of the object being stabilized to use
+in error messages. The automatic value will work in most cases, or pass it
+through from higher-level functions to make error messages clearer in
+unexported functions.}
 
 \item{call}{\code{(environment)} The execution environment to mention as the
 source of error messages.}

--- a/man/dot-stop_null.Rd
+++ b/man/dot-stop_null.Rd
@@ -2,12 +2,12 @@
 % Please edit documentation in R/aaa-conditions.R
 \name{.stop_null}
 \alias{.stop_null}
-\title{Abort because an argument must not be NULL}
+\title{Abort because an object must not be NULL}
 \usage{
 .stop_null(x_arg, call, parent = NULL, ...)
 }
 \arguments{
-\item{x_arg}{(\code{character(1)}) The name of the argument being stabilized
+\item{x_arg}{(\code{character(1)}) The name of the object being stabilized
 to use in error messages. The automatic value will work in most cases, or
 pass it through from higher-level functions to make error messages clearer
 in unexported functions.}
@@ -25,6 +25,6 @@ source of error messages.}
 \code{NULL} invisibly (called for side effects).
 }
 \description{
-Abort because an argument must not be NULL
+Abort because an object must not be NULL
 }
 \keyword{internal}

--- a/man/dot-to_chr_impl.Rd
+++ b/man/dot-to_chr_impl.Rd
@@ -13,11 +13,11 @@
 )
 }
 \arguments{
-\item{x}{The argument to stabilize.}
+\item{x}{The object to stabilize.}
 
 \item{...}{Arguments passed to methods.}
 
-\item{x_arg}{(\code{character(1)}) The name of the argument being stabilized
+\item{x_arg}{(\code{character(1)}) The name of the object being stabilized
 to use in error messages. The automatic value will work in most cases, or
 pass it through from higher-level functions to make error messages clearer
 in unexported functions.}
@@ -25,13 +25,13 @@ in unexported functions.}
 \item{call}{\code{(environment)} The execution environment to mention as the
 source of error messages.}
 
-\item{x_class}{(\code{character(1)}) The class name of the argument being
+\item{x_class}{(\code{character(1)}) The class name of the object being
 stabilized to use in error messages. Use this if you remove a special class
 from the object before checking its coercion, but want the error message to
 match the original class.}
 }
 \value{
-The argument coerced to character.
+The object coerced to character.
 }
 \description{
 Internal S3 implementation of to_chr

--- a/man/dot-to_chr_impl.Rd
+++ b/man/dot-to_chr_impl.Rd
@@ -17,18 +17,18 @@
 
 \item{...}{Arguments passed to methods.}
 
-\item{x_arg}{(\code{character(1)}) The name of the object being stabilized
-to use in error messages. The automatic value will work in most cases, or
-pass it through from higher-level functions to make error messages clearer
-in unexported functions.}
+\item{x_arg}{(\code{character(1)}) The name of the object being stabilized to use
+in error messages. The automatic value will work in most cases, or pass it
+through from higher-level functions to make error messages clearer in
+unexported functions.}
 
 \item{call}{\code{(environment)} The execution environment to mention as the
 source of error messages.}
 
-\item{x_class}{(\code{character(1)}) The class name of the object being
-stabilized to use in error messages. Use this if you remove a special class
-from the object before checking its coercion, but want the error message to
-match the original class.}
+\item{x_class}{(\code{character(1)}) The class name of the object being stabilized
+to use in error messages. Use this if you remove a special class from the
+object before checking its coercion, but want the error message to match
+the original class.}
 }
 \value{
 The object coerced to character.

--- a/man/dot-to_cls_from_fct.Rd
+++ b/man/dot-to_cls_from_fct.Rd
@@ -25,23 +25,23 @@
 
 \item{to_class}{(\code{character(1)}) The name of the class to coerce to.}
 
-\item{coerce_factor}{(\code{logical(1)}) Should factors with values such as
-"1" and "2.0" be considered numeric-ish? Note that this package uses the
+\item{coerce_factor}{(\code{logical(1)}) Should factors with values such as "1"
+and "2.0" be considered numeric-ish? Note that this package uses the
 character value from the factor, while \code{\link[=as.integer]{as.integer()}} and \code{\link[=as.double]{as.double()}} use
 the integer index of the factor.}
 
-\item{x_arg}{(\code{character(1)}) The name of the object being stabilized
-to use in error messages. The automatic value will work in most cases, or
-pass it through from higher-level functions to make error messages clearer
-in unexported functions.}
+\item{x_arg}{(\code{character(1)}) The name of the object being stabilized to use
+in error messages. The automatic value will work in most cases, or pass it
+through from higher-level functions to make error messages clearer in
+unexported functions.}
 
 \item{call}{\code{(environment)} The execution environment to mention as the
 source of error messages.}
 
-\item{x_class}{(\code{character(1)}) The class name of the object being
-stabilized to use in error messages. Use this if you remove a special class
-from the object before checking its coercion, but want the error message to
-match the original class.}
+\item{x_class}{(\code{character(1)}) The class name of the object being stabilized
+to use in error messages. Use this if you remove a special class from the
+object before checking its coercion, but want the error message to match
+the original class.}
 }
 \value{
 \code{x} coerced to the target class.

--- a/man/dot-to_cls_from_fct.Rd
+++ b/man/dot-to_cls_from_fct.Rd
@@ -16,7 +16,7 @@
 )
 }
 \arguments{
-\item{x}{The argument to stabilize.}
+\item{x}{The object to stabilize.}
 
 \item{to_cls_fn}{\verb{(function)} The \verb{to_*()} function to use for coercion.}
 
@@ -30,7 +30,7 @@
 character value from the factor, while \code{\link[=as.integer]{as.integer()}} and \code{\link[=as.double]{as.double()}} use
 the integer index of the factor.}
 
-\item{x_arg}{(\code{character(1)}) The name of the argument being stabilized
+\item{x_arg}{(\code{character(1)}) The name of the object being stabilized
 to use in error messages. The automatic value will work in most cases, or
 pass it through from higher-level functions to make error messages clearer
 in unexported functions.}
@@ -38,7 +38,7 @@ in unexported functions.}
 \item{call}{\code{(environment)} The execution environment to mention as the
 source of error messages.}
 
-\item{x_class}{(\code{character(1)}) The class name of the argument being
+\item{x_class}{(\code{character(1)}) The class name of the object being
 stabilized to use in error messages. Use this if you remove a special class
 from the object before checking its coercion, but want the error message to
 match the original class.}

--- a/man/dot-to_cls_scalar.Rd
+++ b/man/dot-to_cls_scalar.Rd
@@ -29,21 +29,20 @@ rlang, used for a fast path if \code{x} is already the right type.}
 
 \item{allow_null}{(\code{logical(1)}) Is NULL an acceptable value?}
 
-\item{allow_zero_length}{(\code{logical(1)}) Are zero-length vectors
-acceptable?}
+\item{allow_zero_length}{(\code{logical(1)}) Are zero-length vectors acceptable?}
 
-\item{x_arg}{(\code{character(1)}) The name of the object being stabilized
-to use in error messages. The automatic value will work in most cases, or
-pass it through from higher-level functions to make error messages clearer
-in unexported functions.}
+\item{x_arg}{(\code{character(1)}) The name of the object being stabilized to use
+in error messages. The automatic value will work in most cases, or pass it
+through from higher-level functions to make error messages clearer in
+unexported functions.}
 
 \item{call}{\code{(environment)} The execution environment to mention as the
 source of error messages.}
 
-\item{x_class}{(\code{character(1)}) The class name of the object being
-stabilized to use in error messages. Use this if you remove a special class
-from the object before checking its coercion, but want the error message to
-match the original class.}
+\item{x_class}{(\code{character(1)}) The class name of the object being stabilized
+to use in error messages. Use this if you remove a special class from the
+object before checking its coercion, but want the error message to match
+the original class.}
 }
 \value{
 \code{x} as a scalar of the target class.

--- a/man/dot-to_cls_scalar.Rd
+++ b/man/dot-to_cls_scalar.Rd
@@ -17,7 +17,7 @@
 )
 }
 \arguments{
-\item{x}{The argument to stabilize.}
+\item{x}{The object to stabilize.}
 
 \item{is_rlang_cls_scalar}{\verb{(function)} An \verb{is_scalar_*()} function from
 rlang, used for a fast path if \code{x} is already the right type.}
@@ -32,7 +32,7 @@ rlang, used for a fast path if \code{x} is already the right type.}
 \item{allow_zero_length}{(\code{logical(1)}) Are zero-length vectors
 acceptable?}
 
-\item{x_arg}{(\code{character(1)}) The name of the argument being stabilized
+\item{x_arg}{(\code{character(1)}) The name of the object being stabilized
 to use in error messages. The automatic value will work in most cases, or
 pass it through from higher-level functions to make error messages clearer
 in unexported functions.}
@@ -40,7 +40,7 @@ in unexported functions.}
 \item{call}{\code{(environment)} The execution environment to mention as the
 source of error messages.}
 
-\item{x_class}{(\code{character(1)}) The class name of the argument being
+\item{x_class}{(\code{character(1)}) The class name of the object being
 stabilized to use in error messages. Use this if you remove a special class
 from the object before checking its coercion, but want the error message to
 match the original class.}

--- a/man/dot-to_df_vector.Rd
+++ b/man/dot-to_df_vector.Rd
@@ -7,12 +7,12 @@
 .to_df_vector(x, x_expr, x_arg, call, x_class, ...)
 }
 \arguments{
-\item{x}{The argument to stabilize.}
+\item{x}{The object to stabilize.}
 
 \item{x_expr}{\code{(language)} The unevaluated expression for \code{x}, captured via
 \code{substitute(x)} in the calling method.}
 
-\item{x_arg}{(\code{character(1)}) The name of the argument being stabilized
+\item{x_arg}{(\code{character(1)}) The name of the object being stabilized
 to use in error messages. The automatic value will work in most cases, or
 pass it through from higher-level functions to make error messages clearer
 in unexported functions.}
@@ -20,7 +20,7 @@ in unexported functions.}
 \item{call}{\code{(environment)} The execution environment to mention as the
 source of error messages.}
 
-\item{x_class}{(\code{character(1)}) The class name of the argument being
+\item{x_class}{(\code{character(1)}) The class name of the object being
 stabilized to use in error messages. Use this if you remove a special class
 from the object before checking its coercion, but want the error message to
 match the original class.}

--- a/man/dot-to_df_vector.Rd
+++ b/man/dot-to_df_vector.Rd
@@ -12,18 +12,18 @@
 \item{x_expr}{\code{(language)} The unevaluated expression for \code{x}, captured via
 \code{substitute(x)} in the calling method.}
 
-\item{x_arg}{(\code{character(1)}) The name of the object being stabilized
-to use in error messages. The automatic value will work in most cases, or
-pass it through from higher-level functions to make error messages clearer
-in unexported functions.}
+\item{x_arg}{(\code{character(1)}) The name of the object being stabilized to use
+in error messages. The automatic value will work in most cases, or pass it
+through from higher-level functions to make error messages clearer in
+unexported functions.}
 
 \item{call}{\code{(environment)} The execution environment to mention as the
 source of error messages.}
 
-\item{x_class}{(\code{character(1)}) The class name of the object being
-stabilized to use in error messages. Use this if you remove a special class
-from the object before checking its coercion, but want the error message to
-match the original class.}
+\item{x_class}{(\code{character(1)}) The class name of the object being stabilized
+to use in error messages. Use this if you remove a special class from the
+object before checking its coercion, but want the error message to match
+the original class.}
 
 \item{...}{Arguments passed to methods.}
 }

--- a/man/dot-to_null.Rd
+++ b/man/dot-to_null.Rd
@@ -2,16 +2,16 @@
 % Please edit documentation in R/to_null.R
 \name{.to_null}
 \alias{.to_null}
-\title{Ensure an argument is NULL}
+\title{Ensure an object is NULL}
 \usage{
 .to_null(x, allow_null = TRUE, x_arg = caller_arg(x), call = caller_env())
 }
 \arguments{
-\item{x}{The argument to stabilize.}
+\item{x}{The object to stabilize.}
 
 \item{allow_null}{(\code{logical(1)}) Is NULL an acceptable value?}
 
-\item{x_arg}{(\code{character(1)}) The name of the argument being stabilized
+\item{x_arg}{(\code{character(1)}) The name of the object being stabilized
 to use in error messages. The automatic value will work in most cases, or
 pass it through from higher-level functions to make error messages clearer
 in unexported functions.}
@@ -23,6 +23,6 @@ source of error messages.}
 \code{NULL} or an error.
 }
 \description{
-Ensure an argument is NULL
+Ensure an object is NULL
 }
 \keyword{internal}

--- a/man/dot-to_null.Rd
+++ b/man/dot-to_null.Rd
@@ -11,10 +11,10 @@
 
 \item{allow_null}{(\code{logical(1)}) Is NULL an acceptable value?}
 
-\item{x_arg}{(\code{character(1)}) The name of the object being stabilized
-to use in error messages. The automatic value will work in most cases, or
-pass it through from higher-level functions to make error messages clearer
-in unexported functions.}
+\item{x_arg}{(\code{character(1)}) The name of the object being stabilized to use
+in error messages. The automatic value will work in most cases, or pass it
+through from higher-level functions to make error messages clearer in
+unexported functions.}
 
 \item{call}{\code{(environment)} The execution environment to mention as the
 source of error messages.}

--- a/man/dot-to_num_from_complex.Rd
+++ b/man/dot-to_num_from_complex.Rd
@@ -14,13 +14,13 @@
 )
 }
 \arguments{
-\item{x}{The argument to stabilize.}
+\item{x}{The object to stabilize.}
 
 \item{cast_fn}{\verb{(function)} The \verb{as.*()} function to use for coercion.}
 
 \item{to_type_obj}{An empty object of the target type (e.g., \code{integer()}).}
 
-\item{x_arg}{(\code{character(1)}) The name of the argument being stabilized
+\item{x_arg}{(\code{character(1)}) The name of the object being stabilized
 to use in error messages. The automatic value will work in most cases, or
 pass it through from higher-level functions to make error messages clearer
 in unexported functions.}
@@ -28,7 +28,7 @@ in unexported functions.}
 \item{call}{\code{(environment)} The execution environment to mention as the
 source of error messages.}
 
-\item{x_class}{(\code{character(1)}) The class name of the argument being
+\item{x_class}{(\code{character(1)}) The class name of the object being
 stabilized to use in error messages. Use this if you remove a special class
 from the object before checking its coercion, but want the error message to
 match the original class.}

--- a/man/dot-to_num_from_complex.Rd
+++ b/man/dot-to_num_from_complex.Rd
@@ -20,18 +20,18 @@
 
 \item{to_type_obj}{An empty object of the target type (e.g., \code{integer()}).}
 
-\item{x_arg}{(\code{character(1)}) The name of the object being stabilized
-to use in error messages. The automatic value will work in most cases, or
-pass it through from higher-level functions to make error messages clearer
-in unexported functions.}
+\item{x_arg}{(\code{character(1)}) The name of the object being stabilized to use
+in error messages. The automatic value will work in most cases, or pass it
+through from higher-level functions to make error messages clearer in
+unexported functions.}
 
 \item{call}{\code{(environment)} The execution environment to mention as the
 source of error messages.}
 
-\item{x_class}{(\code{character(1)}) The class name of the object being
-stabilized to use in error messages. Use this if you remove a special class
-from the object before checking its coercion, but want the error message to
-match the original class.}
+\item{x_class}{(\code{character(1)}) The class name of the object being stabilized
+to use in error messages. Use this if you remove a special class from the
+object before checking its coercion, but want the error message to match
+the original class.}
 }
 \value{
 \code{x} coerced to the target class.

--- a/man/dot-try_fns.Rd
+++ b/man/dot-try_fns.Rd
@@ -11,10 +11,10 @@
 
 \item{fns}{\code{(list)} The list of stabilizer or coercion functions to try.}
 
-\item{x_arg}{(\code{character(1)}) The name of the object being stabilized
-to use in error messages. The automatic value will work in most cases, or
-pass it through from higher-level functions to make error messages clearer
-in unexported functions.}
+\item{x_arg}{(\code{character(1)}) The name of the object being stabilized to use
+in error messages. The automatic value will work in most cases, or pass it
+through from higher-level functions to make error messages clearer in
+unexported functions.}
 
 \item{call}{\code{(environment)} The execution environment to mention as the
 source of error messages.}

--- a/man/dot-try_fns.Rd
+++ b/man/dot-try_fns.Rd
@@ -11,7 +11,7 @@
 
 \item{fns}{\code{(list)} The list of stabilizer or coercion functions to try.}
 
-\item{x_arg}{(\code{character(1)}) The name of the argument being stabilized
+\item{x_arg}{(\code{character(1)}) The name of the object being stabilized
 to use in error messages. The automatic value will work in most cases, or
 pass it through from higher-level functions to make error messages clearer
 in unexported functions.}

--- a/man/dot-validate_extra_named_elements.Rd
+++ b/man/dot-validate_extra_named_elements.Rd
@@ -26,10 +26,10 @@ function (\code{\link[=stabilize_chr]{stabilize_chr()}}, etc) or a function prod
 function (\code{\link[=specify_chr]{specify_chr()}}, etc), or \code{NULL} to disallow extra named
 elements.}
 
-\item{.x_arg}{(\code{character(1)}) The name of the object being stabilized
-to use in error messages. The automatic value will work in most cases, or
-pass it through from higher-level functions to make error messages clearer
-in unexported functions.}
+\item{.x_arg}{(\code{character(1)}) The name of the object being stabilized to use
+in error messages. The automatic value will work in most cases, or pass it
+through from higher-level functions to make error messages clearer in
+unexported functions.}
 
 \item{.call}{\code{(environment)} The execution environment to mention as the
 source of error messages.}

--- a/man/dot-validate_extra_named_elements.Rd
+++ b/man/dot-validate_extra_named_elements.Rd
@@ -14,7 +14,7 @@
 )
 }
 \arguments{
-\item{.x}{The argument to stabilize.}
+\item{.x}{The object to stabilize.}
 
 \item{nms}{\code{(character)} Result of \code{rlang::names2(.x)}.}
 
@@ -26,7 +26,7 @@ function (\code{\link[=stabilize_chr]{stabilize_chr()}}, etc) or a function prod
 function (\code{\link[=specify_chr]{specify_chr()}}, etc), or \code{NULL} to disallow extra named
 elements.}
 
-\item{.x_arg}{(\code{character(1)}) The name of the argument being stabilized
+\item{.x_arg}{(\code{character(1)}) The name of the object being stabilized
 to use in error messages. The automatic value will work in most cases, or
 pass it through from higher-level functions to make error messages clearer
 in unexported functions.}

--- a/man/dot-validate_named_elements.Rd
+++ b/man/dot-validate_named_elements.Rd
@@ -14,7 +14,7 @@
 )
 }
 \arguments{
-\item{.x}{The argument to stabilize.}
+\item{.x}{The object to stabilize.}
 
 \item{...}{Named stabilizer functions, such as \verb{stabilize_*} functions
 (\code{\link[=stabilize_chr]{stabilize_chr()}}, etc) or functions produced by \verb{specify_*()} functions
@@ -31,7 +31,7 @@ elements of \code{.x} that are \emph{not} explicitly listed in \code{...}. If \c
 have duplicate names? If \code{FALSE} (default), an error is thrown when any
 named element of \code{.x} shares a name with another.}
 
-\item{.x_arg}{(\code{character(1)}) The name of the argument being stabilized
+\item{.x_arg}{(\code{character(1)}) The name of the object being stabilized
 to use in error messages. The automatic value will work in most cases, or
 pass it through from higher-level functions to make error messages clearer
 in unexported functions.}

--- a/man/dot-validate_named_elements.Rd
+++ b/man/dot-validate_named_elements.Rd
@@ -31,10 +31,10 @@ elements of \code{.x} that are \emph{not} explicitly listed in \code{...}. If \c
 have duplicate names? If \code{FALSE} (default), an error is thrown when any
 named element of \code{.x} shares a name with another.}
 
-\item{.x_arg}{(\code{character(1)}) The name of the object being stabilized
-to use in error messages. The automatic value will work in most cases, or
-pass it through from higher-level functions to make error messages clearer
-in unexported functions.}
+\item{.x_arg}{(\code{character(1)}) The name of the object being stabilized to use
+in error messages. The automatic value will work in most cases, or pass it
+through from higher-level functions to make error messages clearer in
+unexported functions.}
 
 \item{.call}{\code{(environment)} The execution environment to mention as the
 source of error messages.}

--- a/man/dot-validate_required_elements.Rd
+++ b/man/dot-validate_required_elements.Rd
@@ -7,7 +7,7 @@
 .validate_required_elements(.x, element_specs, nms, .x_arg, .call)
 }
 \arguments{
-\item{.x}{The argument to stabilize.}
+\item{.x}{The object to stabilize.}
 
 \item{element_specs}{\code{(list)} Named list of stabilizer functions, such as
 \verb{stabilize_*} functions (\code{\link[=stabilize_chr]{stabilize_chr()}}, etc) or functions produced by
@@ -17,7 +17,7 @@ element.}
 
 \item{nms}{\code{(character)} Result of \code{rlang::names2(.x)}.}
 
-\item{.x_arg}{(\code{character(1)}) The name of the argument being stabilized
+\item{.x_arg}{(\code{character(1)}) The name of the object being stabilized
 to use in error messages. The automatic value will work in most cases, or
 pass it through from higher-level functions to make error messages clearer
 in unexported functions.}

--- a/man/dot-validate_required_elements.Rd
+++ b/man/dot-validate_required_elements.Rd
@@ -17,10 +17,10 @@ element.}
 
 \item{nms}{\code{(character)} Result of \code{rlang::names2(.x)}.}
 
-\item{.x_arg}{(\code{character(1)}) The name of the object being stabilized
-to use in error messages. The automatic value will work in most cases, or
-pass it through from higher-level functions to make error messages clearer
-in unexported functions.}
+\item{.x_arg}{(\code{character(1)}) The name of the object being stabilized to use
+in error messages. The automatic value will work in most cases, or pass it
+through from higher-level functions to make error messages clearer in
+unexported functions.}
 
 \item{.call}{\code{(environment)} The execution environment to mention as the
 source of error messages.}

--- a/man/dot-validate_unnamed_elements.Rd
+++ b/man/dot-validate_unnamed_elements.Rd
@@ -7,7 +7,7 @@
 .validate_unnamed_elements(.x, .unnamed, .x_arg, .call)
 }
 \arguments{
-\item{.x}{The argument to stabilize.}
+\item{.x}{The object to stabilize.}
 
 \item{.unnamed}{A single stabilizer function, such as a \verb{stabilize_*}
 function (\code{\link[=stabilize_chr]{stabilize_chr()}}, etc) or a function produced by a \verb{specify_*()}
@@ -15,7 +15,7 @@ function (\code{\link[=specify_chr]{specify_chr()}}, etc). This function is used
 unnamed elements of \code{.x}. If \code{NULL} (default), any unnamed elements will
 cause an error.}
 
-\item{.x_arg}{(\code{character(1)}) The name of the argument being stabilized
+\item{.x_arg}{(\code{character(1)}) The name of the object being stabilized
 to use in error messages. The automatic value will work in most cases, or
 pass it through from higher-level functions to make error messages clearer
 in unexported functions.}

--- a/man/dot-validate_unnamed_elements.Rd
+++ b/man/dot-validate_unnamed_elements.Rd
@@ -15,10 +15,10 @@ function (\code{\link[=specify_chr]{specify_chr()}}, etc). This function is used
 unnamed elements of \code{.x}. If \code{NULL} (default), any unnamed elements will
 cause an error.}
 
-\item{.x_arg}{(\code{character(1)}) The name of the object being stabilized
-to use in error messages. The automatic value will work in most cases, or
-pass it through from higher-level functions to make error messages clearer
-in unexported functions.}
+\item{.x_arg}{(\code{character(1)}) The name of the object being stabilized to use
+in error messages. The automatic value will work in most cases, or pass it
+through from higher-level functions to make error messages clearer in
+unexported functions.}
 
 \item{.call}{\code{(environment)} The execution environment to mention as the
 source of error messages.}

--- a/man/expect_pkg_error_classes.Rd
+++ b/man/expect_pkg_error_classes.Rd
@@ -9,8 +9,7 @@ expect_pkg_error_classes(object, package, ...)
 \arguments{
 \item{object}{An expression that is expected to throw an error.}
 
-\item{package}{(\code{character(1)}) The name of the package to use in
-classes.}
+\item{package}{(\code{character(1)}) The name of the package to use in classes.}
 
 \item{...}{\code{(character)} Components of the class name, from least-specific to
 most.}

--- a/man/expect_pkg_error_snapshot.Rd
+++ b/man/expect_pkg_error_snapshot.Rd
@@ -16,8 +16,7 @@ expect_pkg_error_snapshot(
 \arguments{
 \item{object}{An expression that is expected to throw an error.}
 
-\item{package}{(\code{character(1)}) The name of the package to use in
-classes.}
+\item{package}{(\code{character(1)}) The name of the package to use in classes.}
 
 \item{...}{\code{(character)} Components of the class name, from least-specific to
 most.}

--- a/man/expect_pkg_message_classes.Rd
+++ b/man/expect_pkg_message_classes.Rd
@@ -9,8 +9,7 @@ expect_pkg_message_classes(object, package, ...)
 \arguments{
 \item{object}{An expression that is expected to throw a message.}
 
-\item{package}{(\code{character(1)}) The name of the package to use in
-classes.}
+\item{package}{(\code{character(1)}) The name of the package to use in classes.}
 
 \item{...}{\code{(character)} Components of the class name, from least-specific to
 most.}

--- a/man/expect_pkg_message_snapshot.Rd
+++ b/man/expect_pkg_message_snapshot.Rd
@@ -16,8 +16,7 @@ expect_pkg_message_snapshot(
 \arguments{
 \item{object}{An expression that is expected to throw a message.}
 
-\item{package}{(\code{character(1)}) The name of the package to use in
-classes.}
+\item{package}{(\code{character(1)}) The name of the package to use in classes.}
 
 \item{...}{\code{(character)} Components of the class name, from least-specific to
 most.}

--- a/man/expect_pkg_warning_classes.Rd
+++ b/man/expect_pkg_warning_classes.Rd
@@ -9,8 +9,7 @@ expect_pkg_warning_classes(object, package, ...)
 \arguments{
 \item{object}{An expression that is expected to throw a warning.}
 
-\item{package}{(\code{character(1)}) The name of the package to use in
-classes.}
+\item{package}{(\code{character(1)}) The name of the package to use in classes.}
 
 \item{...}{\code{(character)} Components of the class name, from least-specific to
 most.}

--- a/man/expect_pkg_warning_snapshot.Rd
+++ b/man/expect_pkg_warning_snapshot.Rd
@@ -16,8 +16,7 @@ expect_pkg_warning_snapshot(
 \arguments{
 \item{object}{An expression that is expected to throw a warning.}
 
-\item{package}{(\code{character(1)}) The name of the package to use in
-classes.}
+\item{package}{(\code{character(1)}) The name of the package to use in classes.}
 
 \item{...}{\code{(character)} Components of the class name, from least-specific to
 most.}

--- a/man/pkg_abort.Rd
+++ b/man/pkg_abort.Rd
@@ -15,8 +15,7 @@ pkg_abort(
 )
 }
 \arguments{
-\item{package}{(\code{character(1)}) The name of the package to use in
-classes.}
+\item{package}{(\code{character(1)}) The name of the package to use in classes.}
 
 \item{message}{(\code{character}) The message for the new error. Messages will be
 formatted with \code{\link[cli:cli_bullets]{cli::cli_bullets()}}.}

--- a/man/pkg_inform.Rd
+++ b/man/pkg_inform.Rd
@@ -15,8 +15,7 @@ pkg_inform(
 )
 }
 \arguments{
-\item{package}{(\code{character(1)}) The name of the package to use in
-classes.}
+\item{package}{(\code{character(1)}) The name of the package to use in classes.}
 
 \item{message}{(\code{character}) The message for the new message condition.
 Messages will be formatted with \code{\link[cli:cli_bullets]{cli::cli_bullets()}}.}

--- a/man/pkg_warn.Rd
+++ b/man/pkg_warn.Rd
@@ -15,8 +15,7 @@ pkg_warn(
 )
 }
 \arguments{
-\item{package}{(\code{character(1)}) The name of the package to use in
-classes.}
+\item{package}{(\code{character(1)}) The name of the package to use in classes.}
 
 \item{message}{(\code{character}) The message for the new warning. Messages will
 be formatted with \code{\link[cli:cli_bullets]{cli::cli_bullets()}}.}

--- a/man/regex_must_match.Rd
+++ b/man/regex_must_match.Rd
@@ -21,7 +21,7 @@ attribute and with \code{\link[=names]{names()}} equal to the generated "must no
 message.
 }
 \description{
-Attach a standardized error message to a \code{regex} argument. By default, the
+Attach a standardized error message to a \code{regex} pattern. By default, the
 message will be "must match the regex pattern \{regex\}". If the input
 \code{regex} has a \code{negate} attribute set to \code{TRUE} (set automatically by
 \code{regex_must_not_match()}), the message will instead be "must not match...".

--- a/man/specify_chr.Rd
+++ b/man/specify_chr.Rd
@@ -56,11 +56,11 @@ specify_character_scalar(
 
 \item{allow_na}{(\code{logical(1)}) Are NA values ok?}
 
-\item{min_size}{(\code{integer(1)}) The minimum size of the object. Object
-size will be tested using \code{\link[vctrs:vec_size]{vctrs::vec_size()}}.}
+\item{min_size}{(\code{integer(1)}) The minimum size of the object. Object size
+will be tested using \code{\link[vctrs:vec_size]{vctrs::vec_size()}}.}
 
-\item{max_size}{(\code{integer(1)}) The maximum size of the object. Object
-size will be tested using \code{\link[vctrs:vec_size]{vctrs::vec_size()}}.}
+\item{max_size}{(\code{integer(1)}) The maximum size of the object. Object size
+will be tested using \code{\link[vctrs:vec_size]{vctrs::vec_size()}}.}
 
 \item{unique}{(\code{logical(1)}) Should all elements in \code{x} be distinct?}
 
@@ -85,8 +85,7 @@ throws an error, try installing the stringi package.}
 type). \code{NULL} (default) skips the check. \code{NA} values in \code{x} are permitted
 independently of \code{allowed_values}, subject to \code{allow_na}.}
 
-\item{allow_zero_length}{(\code{logical(1)}) Are zero-length vectors
-acceptable?}
+\item{allow_zero_length}{(\code{logical(1)}) Are zero-length vectors acceptable?}
 }
 \value{
 A function of class \code{"stbl_specified_fn"} that calls

--- a/man/specify_dbl.Rd
+++ b/man/specify_dbl.Rd
@@ -60,34 +60,33 @@ specify_double_scalar(
 
 \item{allow_na}{(\code{logical(1)}) Are NA values ok?}
 
-\item{coerce_character}{(\code{logical(1)}) Should character vectors such as
-"1" and "2.0" be considered numeric-ish?}
+\item{coerce_character}{(\code{logical(1)}) Should character vectors such as "1"
+and "2.0" be considered numeric-ish?}
 
-\item{coerce_factor}{(\code{logical(1)}) Should factors with values such as
-"1" and "2.0" be considered numeric-ish? Note that this package uses the
+\item{coerce_factor}{(\code{logical(1)}) Should factors with values such as "1"
+and "2.0" be considered numeric-ish? Note that this package uses the
 character value from the factor, while \code{\link[=as.integer]{as.integer()}} and \code{\link[=as.double]{as.double()}} use
 the integer index of the factor.}
 
-\item{min_size}{(\code{integer(1)}) The minimum size of the object. Object
-size will be tested using \code{\link[vctrs:vec_size]{vctrs::vec_size()}}.}
+\item{min_size}{(\code{integer(1)}) The minimum size of the object. Object size
+will be tested using \code{\link[vctrs:vec_size]{vctrs::vec_size()}}.}
 
-\item{max_size}{(\code{integer(1)}) The maximum size of the object. Object
-size will be tested using \code{\link[vctrs:vec_size]{vctrs::vec_size()}}.}
+\item{max_size}{(\code{integer(1)}) The maximum size of the object. Object size
+will be tested using \code{\link[vctrs:vec_size]{vctrs::vec_size()}}.}
 
 \item{unique}{(\code{logical(1)}) Should all elements in \code{x} be distinct?}
 
-\item{min_value}{(\code{numeric(1)}) The lowest allowed value for \code{x}. If
-\code{NULL} (default) values are not checked.}
+\item{min_value}{(\code{numeric(1)}) The lowest allowed value for \code{x}. If \code{NULL}
+(default) values are not checked.}
 
-\item{max_value}{(\code{numeric(1)}) The highest allowed value for \code{x}. If
-\code{NULL} (default) values are not checked.}
+\item{max_value}{(\code{numeric(1)}) The highest allowed value for \code{x}. If \code{NULL}
+(default) values are not checked.}
 
 \item{allowed_values}{A vector of permitted values (coerced to the target
 type). \code{NULL} (default) skips the check. \code{NA} values in \code{x} are permitted
 independently of \code{allowed_values}, subject to \code{allow_na}.}
 
-\item{allow_zero_length}{(\code{logical(1)}) Are zero-length vectors
-acceptable?}
+\item{allow_zero_length}{(\code{logical(1)}) Are zero-length vectors acceptable?}
 }
 \value{
 A function of class \code{"stbl_specified_fn"} that calls

--- a/man/specify_fct.Rd
+++ b/man/specify_fct.Rd
@@ -46,19 +46,18 @@ specify_factor_scalar(
 
 \item{allow_na}{(\code{logical(1)}) Are NA values ok?}
 
-\item{min_size}{(\code{integer(1)}) The minimum size of the object. Object
-size will be tested using \code{\link[vctrs:vec_size]{vctrs::vec_size()}}.}
+\item{min_size}{(\code{integer(1)}) The minimum size of the object. Object size
+will be tested using \code{\link[vctrs:vec_size]{vctrs::vec_size()}}.}
 
-\item{max_size}{(\code{integer(1)}) The maximum size of the object. Object
-size will be tested using \code{\link[vctrs:vec_size]{vctrs::vec_size()}}.}
+\item{max_size}{(\code{integer(1)}) The maximum size of the object. Object size
+will be tested using \code{\link[vctrs:vec_size]{vctrs::vec_size()}}.}
 
 \item{levels}{\code{(character)} Expected levels. If \code{NULL} (default), the levels
 will be computed by \code{\link[base:factor]{base::factor()}}.}
 
 \item{to_na}{\code{(character)} Values to convert to \code{NA}.}
 
-\item{allow_zero_length}{(\code{logical(1)}) Are zero-length vectors
-acceptable?}
+\item{allow_zero_length}{(\code{logical(1)}) Are zero-length vectors acceptable?}
 }
 \value{
 A function of class \code{"stbl_specified_fn"} that calls

--- a/man/specify_int.Rd
+++ b/man/specify_int.Rd
@@ -60,34 +60,33 @@ specify_integer_scalar(
 
 \item{allow_na}{(\code{logical(1)}) Are NA values ok?}
 
-\item{coerce_character}{(\code{logical(1)}) Should character vectors such as
-"1" and "2.0" be considered numeric-ish?}
+\item{coerce_character}{(\code{logical(1)}) Should character vectors such as "1"
+and "2.0" be considered numeric-ish?}
 
-\item{coerce_factor}{(\code{logical(1)}) Should factors with values such as
-"1" and "2.0" be considered numeric-ish? Note that this package uses the
+\item{coerce_factor}{(\code{logical(1)}) Should factors with values such as "1"
+and "2.0" be considered numeric-ish? Note that this package uses the
 character value from the factor, while \code{\link[=as.integer]{as.integer()}} and \code{\link[=as.double]{as.double()}} use
 the integer index of the factor.}
 
-\item{min_size}{(\code{integer(1)}) The minimum size of the object. Object
-size will be tested using \code{\link[vctrs:vec_size]{vctrs::vec_size()}}.}
+\item{min_size}{(\code{integer(1)}) The minimum size of the object. Object size
+will be tested using \code{\link[vctrs:vec_size]{vctrs::vec_size()}}.}
 
-\item{max_size}{(\code{integer(1)}) The maximum size of the object. Object
-size will be tested using \code{\link[vctrs:vec_size]{vctrs::vec_size()}}.}
+\item{max_size}{(\code{integer(1)}) The maximum size of the object. Object size
+will be tested using \code{\link[vctrs:vec_size]{vctrs::vec_size()}}.}
 
 \item{unique}{(\code{logical(1)}) Should all elements in \code{x} be distinct?}
 
-\item{min_value}{(\code{numeric(1)}) The lowest allowed value for \code{x}. If
-\code{NULL} (default) values are not checked.}
+\item{min_value}{(\code{numeric(1)}) The lowest allowed value for \code{x}. If \code{NULL}
+(default) values are not checked.}
 
-\item{max_value}{(\code{numeric(1)}) The highest allowed value for \code{x}. If
-\code{NULL} (default) values are not checked.}
+\item{max_value}{(\code{numeric(1)}) The highest allowed value for \code{x}. If \code{NULL}
+(default) values are not checked.}
 
 \item{allowed_values}{A vector of permitted values (coerced to the target
 type). \code{NULL} (default) skips the check. \code{NA} values in \code{x} are permitted
 independently of \code{allowed_values}, subject to \code{allow_na}.}
 
-\item{allow_zero_length}{(\code{logical(1)}) Are zero-length vectors
-acceptable?}
+\item{allow_zero_length}{(\code{logical(1)}) Are zero-length vectors acceptable?}
 }
 \value{
 A function of class \code{"stbl_specified_fn"} that calls

--- a/man/specify_lgl.Rd
+++ b/man/specify_lgl.Rd
@@ -42,18 +42,17 @@ specify_logical_scalar(
 
 \item{allow_na}{(\code{logical(1)}) Are NA values ok?}
 
-\item{min_size}{(\code{integer(1)}) The minimum size of the object. Object
-size will be tested using \code{\link[vctrs:vec_size]{vctrs::vec_size()}}.}
+\item{min_size}{(\code{integer(1)}) The minimum size of the object. Object size
+will be tested using \code{\link[vctrs:vec_size]{vctrs::vec_size()}}.}
 
-\item{max_size}{(\code{integer(1)}) The maximum size of the object. Object
-size will be tested using \code{\link[vctrs:vec_size]{vctrs::vec_size()}}.}
+\item{max_size}{(\code{integer(1)}) The maximum size of the object. Object size
+will be tested using \code{\link[vctrs:vec_size]{vctrs::vec_size()}}.}
 
 \item{allowed_values}{A vector of permitted values (coerced to the target
 type). \code{NULL} (default) skips the check. \code{NA} values in \code{x} are permitted
 independently of \code{allowed_values}, subject to \code{allow_na}.}
 
-\item{allow_zero_length}{(\code{logical(1)}) Are zero-length vectors
-acceptable?}
+\item{allow_zero_length}{(\code{logical(1)}) Are zero-length vectors acceptable?}
 }
 \value{
 A function of class \code{"stbl_specified_fn"} that calls

--- a/man/specify_lst.Rd
+++ b/man/specify_lst.Rd
@@ -48,11 +48,11 @@ If \code{TRUE}, duplicated elements are rejected.}
 
 \item{.allow_null}{(\code{logical(1)}) Is NULL an acceptable value?}
 
-\item{.min_size}{(\code{integer(1)}) The minimum size of the object. Object
-size will be tested using \code{\link[vctrs:vec_size]{vctrs::vec_size()}}.}
+\item{.min_size}{(\code{integer(1)}) The minimum size of the object. Object size
+will be tested using \code{\link[vctrs:vec_size]{vctrs::vec_size()}}.}
 
-\item{.max_size}{(\code{integer(1)}) The maximum size of the object. Object
-size will be tested using \code{\link[vctrs:vec_size]{vctrs::vec_size()}}.}
+\item{.max_size}{(\code{integer(1)}) The maximum size of the object. Object size
+will be tested using \code{\link[vctrs:vec_size]{vctrs::vec_size()}}.}
 }
 \value{
 A function of class \code{"stbl_specified_fn"} that calls

--- a/man/stabilize_any_of.Rd
+++ b/man/stabilize_any_of.Rd
@@ -40,18 +40,18 @@ calls (\code{\link[=specify_chr]{specify_chr()}}, etc.). For \code{to_any_of()}:
 \code{integer()}, \code{character()}) that determine the target types to try, passed
 as the \code{.to} argument of \code{\link[=to]{to()}}.}
 
-\item{x_arg}{(\code{character(1)}) The name of the object being stabilized
-to use in error messages. The automatic value will work in most cases, or
-pass it through from higher-level functions to make error messages clearer
-in unexported functions.}
+\item{x_arg}{(\code{character(1)}) The name of the object being stabilized to use
+in error messages. The automatic value will work in most cases, or pass it
+through from higher-level functions to make error messages clearer in
+unexported functions.}
 
 \item{call}{\code{(environment)} The execution environment to mention as the
 source of error messages.}
 
-\item{x_class}{(\code{character(1)}) The class name of the object being
-stabilized to use in error messages. Use this if you remove a special class
-from the object before checking its coercion, but want the error message to
-match the original class.}
+\item{x_class}{(\code{character(1)}) The class name of the object being stabilized
+to use in error messages. Use this if you remove a special class from the
+object before checking its coercion, but want the error message to match
+the original class.}
 }
 \value{
 \code{x} coerced or validated by the first successful function or

--- a/man/stabilize_any_of.Rd
+++ b/man/stabilize_any_of.Rd
@@ -31,7 +31,7 @@ to_any_of(
 )
 }
 \arguments{
-\item{x}{The argument to stabilize.}
+\item{x}{The object to stabilize.}
 
 \item{...}{For \code{stabilize_any_of()}: unnamed stabilizer or coercion
 functions, such as \verb{stabilize_*} functions (\code{\link[=stabilize_chr]{stabilize_chr()}}, etc.),
@@ -40,7 +40,7 @@ calls (\code{\link[=specify_chr]{specify_chr()}}, etc.). For \code{to_any_of()}:
 \code{integer()}, \code{character()}) that determine the target types to try, passed
 as the \code{.to} argument of \code{\link[=to]{to()}}.}
 
-\item{x_arg}{(\code{character(1)}) The name of the argument being stabilized
+\item{x_arg}{(\code{character(1)}) The name of the object being stabilized
 to use in error messages. The automatic value will work in most cases, or
 pass it through from higher-level functions to make error messages clearer
 in unexported functions.}
@@ -48,7 +48,7 @@ in unexported functions.}
 \item{call}{\code{(environment)} The execution environment to mention as the
 source of error messages.}
 
-\item{x_class}{(\code{character(1)}) The class name of the argument being
+\item{x_class}{(\code{character(1)}) The class name of the object being
 stabilized to use in error messages. Use this if you remove a special class
 from the object before checking its coercion, but want the error message to
 match the original class.}

--- a/man/stabilize_arg.Rd
+++ b/man/stabilize_arg.Rd
@@ -38,29 +38,28 @@ stabilize_arg_scalar(
 
 \item{allow_na}{(\code{logical(1)}) Are NA values ok?}
 
-\item{min_size}{(\code{integer(1)}) The minimum size of the object. Object
-size will be tested using \code{\link[vctrs:vec_size]{vctrs::vec_size()}}.}
+\item{min_size}{(\code{integer(1)}) The minimum size of the object. Object size
+will be tested using \code{\link[vctrs:vec_size]{vctrs::vec_size()}}.}
 
-\item{max_size}{(\code{integer(1)}) The maximum size of the object. Object
-size will be tested using \code{\link[vctrs:vec_size]{vctrs::vec_size()}}.}
+\item{max_size}{(\code{integer(1)}) The maximum size of the object. Object size
+will be tested using \code{\link[vctrs:vec_size]{vctrs::vec_size()}}.}
 
 \item{unique}{(\code{logical(1)}) Should all elements in \code{x} be distinct?}
 
-\item{x_arg}{(\code{character(1)}) The name of the object being stabilized
-to use in error messages. The automatic value will work in most cases, or
-pass it through from higher-level functions to make error messages clearer
-in unexported functions.}
+\item{x_arg}{(\code{character(1)}) The name of the object being stabilized to use
+in error messages. The automatic value will work in most cases, or pass it
+through from higher-level functions to make error messages clearer in
+unexported functions.}
 
 \item{call}{\code{(environment)} The execution environment to mention as the
 source of error messages.}
 
-\item{x_class}{(\code{character(1)}) The class name of the object being
-stabilized to use in error messages. Use this if you remove a special class
-from the object before checking its coercion, but want the error message to
-match the original class.}
+\item{x_class}{(\code{character(1)}) The class name of the object being stabilized
+to use in error messages. Use this if you remove a special class from the
+object before checking its coercion, but want the error message to match
+the original class.}
 
-\item{allow_zero_length}{(\code{logical(1)}) Are zero-length vectors
-acceptable?}
+\item{allow_zero_length}{(\code{logical(1)}) Are zero-length vectors acceptable?}
 }
 \value{
 \code{x}, or an error condition with classes \verb{<stbl-error>},

--- a/man/stabilize_arg.Rd
+++ b/man/stabilize_arg.Rd
@@ -3,7 +3,7 @@
 \name{stabilize_arg}
 \alias{stabilize_arg}
 \alias{stabilize_arg_scalar}
-\title{Ensure an argument meets expectations}
+\title{Ensure an object meets expectations}
 \usage{
 stabilize_arg(
   x,
@@ -30,7 +30,7 @@ stabilize_arg_scalar(
 )
 }
 \arguments{
-\item{x}{The argument to stabilize.}
+\item{x}{The object to stabilize.}
 
 \item{...}{Arguments passed to methods.}
 
@@ -46,7 +46,7 @@ size will be tested using \code{\link[vctrs:vec_size]{vctrs::vec_size()}}.}
 
 \item{unique}{(\code{logical(1)}) Should all elements in \code{x} be distinct?}
 
-\item{x_arg}{(\code{character(1)}) The name of the argument being stabilized
+\item{x_arg}{(\code{character(1)}) The name of the object being stabilized
 to use in error messages. The automatic value will work in most cases, or
 pass it through from higher-level functions to make error messages clearer
 in unexported functions.}
@@ -54,7 +54,7 @@ in unexported functions.}
 \item{call}{\code{(environment)} The execution environment to mention as the
 source of error messages.}
 
-\item{x_class}{(\code{character(1)}) The class name of the argument being
+\item{x_class}{(\code{character(1)}) The class name of the object being
 stabilized to use in error messages. Use this if you remove a special class
 from the object before checking its coercion, but want the error message to
 match the original class.}
@@ -81,7 +81,7 @@ specific class by failure mode:
 \code{stabilize_arg()} is used by other functions such as \code{\link[=stabilize_int]{stabilize_int()}}. Use
 \code{stabilize_arg()} if the type-specific functions will not work for your use
 case, but you would still like to check things like size or whether the
-argument is NULL.
+object is NULL.
 
 \code{stabilize_arg_scalar()} is optimized to check for length-1 vectors.
 }

--- a/man/stabilize_chr.Rd
+++ b/man/stabilize_chr.Rd
@@ -76,7 +76,7 @@ stabilise_character(
 )
 }
 \arguments{
-\item{x}{The argument to stabilize.}
+\item{x}{The object to stabilize.}
 
 \item{...}{Arguments passed to methods.}
 
@@ -113,7 +113,7 @@ throws an error, try installing the stringi package.}
 type). \code{NULL} (default) skips the check. \code{NA} values in \code{x} are permitted
 independently of \code{allowed_values}, subject to \code{allow_na}.}
 
-\item{x_arg}{(\code{character(1)}) The name of the argument being stabilized
+\item{x_arg}{(\code{character(1)}) The name of the object being stabilized
 to use in error messages. The automatic value will work in most cases, or
 pass it through from higher-level functions to make error messages clearer
 in unexported functions.}
@@ -121,7 +121,7 @@ in unexported functions.}
 \item{call}{\code{(environment)} The execution environment to mention as the
 source of error messages.}
 
-\item{x_class}{(\code{character(1)}) The class name of the argument being
+\item{x_class}{(\code{character(1)}) The class name of the object being
 stabilized to use in error messages. Use this if you remove a special class
 from the object before checking its coercion, but want the error message to
 match the original class.}

--- a/man/stabilize_chr.Rd
+++ b/man/stabilize_chr.Rd
@@ -84,11 +84,11 @@ stabilise_character(
 
 \item{allow_na}{(\code{logical(1)}) Are NA values ok?}
 
-\item{min_size}{(\code{integer(1)}) The minimum size of the object. Object
-size will be tested using \code{\link[vctrs:vec_size]{vctrs::vec_size()}}.}
+\item{min_size}{(\code{integer(1)}) The minimum size of the object. Object size
+will be tested using \code{\link[vctrs:vec_size]{vctrs::vec_size()}}.}
 
-\item{max_size}{(\code{integer(1)}) The maximum size of the object. Object
-size will be tested using \code{\link[vctrs:vec_size]{vctrs::vec_size()}}.}
+\item{max_size}{(\code{integer(1)}) The maximum size of the object. Object size
+will be tested using \code{\link[vctrs:vec_size]{vctrs::vec_size()}}.}
 
 \item{unique}{(\code{logical(1)}) Should all elements in \code{x} be distinct?}
 
@@ -113,18 +113,18 @@ throws an error, try installing the stringi package.}
 type). \code{NULL} (default) skips the check. \code{NA} values in \code{x} are permitted
 independently of \code{allowed_values}, subject to \code{allow_na}.}
 
-\item{x_arg}{(\code{character(1)}) The name of the object being stabilized
-to use in error messages. The automatic value will work in most cases, or
-pass it through from higher-level functions to make error messages clearer
-in unexported functions.}
+\item{x_arg}{(\code{character(1)}) The name of the object being stabilized to use
+in error messages. The automatic value will work in most cases, or pass it
+through from higher-level functions to make error messages clearer in
+unexported functions.}
 
 \item{call}{\code{(environment)} The execution environment to mention as the
 source of error messages.}
 
-\item{x_class}{(\code{character(1)}) The class name of the object being
-stabilized to use in error messages. Use this if you remove a special class
-from the object before checking its coercion, but want the error message to
-match the original class.}
+\item{x_class}{(\code{character(1)}) The class name of the object being stabilized
+to use in error messages. Use this if you remove a special class from the
+object before checking its coercion, but want the error message to match
+the original class.}
 }
 \value{
 The input as a character vector, or an error condition with classes

--- a/man/stabilize_chr_scalar.Rd
+++ b/man/stabilize_chr_scalar.Rd
@@ -74,8 +74,7 @@ stabilise_character_scalar(
 
 \item{allow_null}{(\code{logical(1)}) Is NULL an acceptable value?}
 
-\item{allow_zero_length}{(\code{logical(1)}) Are zero-length vectors
-acceptable?}
+\item{allow_zero_length}{(\code{logical(1)}) Are zero-length vectors acceptable?}
 
 \item{allow_na}{(\code{logical(1)}) Are NA values ok?}
 
@@ -100,18 +99,18 @@ throws an error, try installing the stringi package.}
 type). \code{NULL} (default) skips the check. \code{NA} values in \code{x} are permitted
 independently of \code{allowed_values}, subject to \code{allow_na}.}
 
-\item{x_arg}{(\code{character(1)}) The name of the object being stabilized
-to use in error messages. The automatic value will work in most cases, or
-pass it through from higher-level functions to make error messages clearer
-in unexported functions.}
+\item{x_arg}{(\code{character(1)}) The name of the object being stabilized to use
+in error messages. The automatic value will work in most cases, or pass it
+through from higher-level functions to make error messages clearer in
+unexported functions.}
 
 \item{call}{\code{(environment)} The execution environment to mention as the
 source of error messages.}
 
-\item{x_class}{(\code{character(1)}) The class name of the object being
-stabilized to use in error messages. Use this if you remove a special class
-from the object before checking its coercion, but want the error message to
-match the original class.}
+\item{x_class}{(\code{character(1)}) The class name of the object being stabilized
+to use in error messages. Use this if you remove a special class from the
+object before checking its coercion, but want the error message to match
+the original class.}
 }
 \value{
 The input as a length-1 character vector, or an error condition with

--- a/man/stabilize_chr_scalar.Rd
+++ b/man/stabilize_chr_scalar.Rd
@@ -68,7 +68,7 @@ stabilise_character_scalar(
 )
 }
 \arguments{
-\item{x}{The argument to stabilize.}
+\item{x}{The object to stabilize.}
 
 \item{...}{Arguments passed to methods.}
 
@@ -100,7 +100,7 @@ throws an error, try installing the stringi package.}
 type). \code{NULL} (default) skips the check. \code{NA} values in \code{x} are permitted
 independently of \code{allowed_values}, subject to \code{allow_na}.}
 
-\item{x_arg}{(\code{character(1)}) The name of the argument being stabilized
+\item{x_arg}{(\code{character(1)}) The name of the object being stabilized
 to use in error messages. The automatic value will work in most cases, or
 pass it through from higher-level functions to make error messages clearer
 in unexported functions.}
@@ -108,7 +108,7 @@ in unexported functions.}
 \item{call}{\code{(environment)} The execution environment to mention as the
 source of error messages.}
 
-\item{x_class}{(\code{character(1)}) The class name of the argument being
+\item{x_class}{(\code{character(1)}) The class name of the object being
 stabilized to use in error messages. Use this if you remove a special class
 from the object before checking its coercion, but want the error message to
 match the original class.}

--- a/man/stabilize_dbl.Rd
+++ b/man/stabilize_dbl.Rd
@@ -80,7 +80,7 @@ stabilise_double(
 )
 }
 \arguments{
-\item{x}{The argument to stabilize.}
+\item{x}{The object to stabilize.}
 
 \item{...}{Arguments passed to methods.}
 
@@ -114,7 +114,7 @@ size will be tested using \code{\link[vctrs:vec_size]{vctrs::vec_size()}}.}
 type). \code{NULL} (default) skips the check. \code{NA} values in \code{x} are permitted
 independently of \code{allowed_values}, subject to \code{allow_na}.}
 
-\item{x_arg}{(\code{character(1)}) The name of the argument being stabilized
+\item{x_arg}{(\code{character(1)}) The name of the object being stabilized
 to use in error messages. The automatic value will work in most cases, or
 pass it through from higher-level functions to make error messages clearer
 in unexported functions.}
@@ -122,7 +122,7 @@ in unexported functions.}
 \item{call}{\code{(environment)} The execution environment to mention as the
 source of error messages.}
 
-\item{x_class}{(\code{character(1)}) The class name of the argument being
+\item{x_class}{(\code{character(1)}) The class name of the object being
 stabilized to use in error messages. Use this if you remove a special class
 from the object before checking its coercion, but want the error message to
 match the original class.}

--- a/man/stabilize_dbl.Rd
+++ b/man/stabilize_dbl.Rd
@@ -88,44 +88,44 @@ stabilise_double(
 
 \item{allow_na}{(\code{logical(1)}) Are NA values ok?}
 
-\item{coerce_character}{(\code{logical(1)}) Should character vectors such as
-"1" and "2.0" be considered numeric-ish?}
+\item{coerce_character}{(\code{logical(1)}) Should character vectors such as "1"
+and "2.0" be considered numeric-ish?}
 
-\item{coerce_factor}{(\code{logical(1)}) Should factors with values such as
-"1" and "2.0" be considered numeric-ish? Note that this package uses the
+\item{coerce_factor}{(\code{logical(1)}) Should factors with values such as "1"
+and "2.0" be considered numeric-ish? Note that this package uses the
 character value from the factor, while \code{\link[=as.integer]{as.integer()}} and \code{\link[=as.double]{as.double()}} use
 the integer index of the factor.}
 
-\item{min_size}{(\code{integer(1)}) The minimum size of the object. Object
-size will be tested using \code{\link[vctrs:vec_size]{vctrs::vec_size()}}.}
+\item{min_size}{(\code{integer(1)}) The minimum size of the object. Object size
+will be tested using \code{\link[vctrs:vec_size]{vctrs::vec_size()}}.}
 
-\item{max_size}{(\code{integer(1)}) The maximum size of the object. Object
-size will be tested using \code{\link[vctrs:vec_size]{vctrs::vec_size()}}.}
+\item{max_size}{(\code{integer(1)}) The maximum size of the object. Object size
+will be tested using \code{\link[vctrs:vec_size]{vctrs::vec_size()}}.}
 
 \item{unique}{(\code{logical(1)}) Should all elements in \code{x} be distinct?}
 
-\item{min_value}{(\code{numeric(1)}) The lowest allowed value for \code{x}. If
-\code{NULL} (default) values are not checked.}
+\item{min_value}{(\code{numeric(1)}) The lowest allowed value for \code{x}. If \code{NULL}
+(default) values are not checked.}
 
-\item{max_value}{(\code{numeric(1)}) The highest allowed value for \code{x}. If
-\code{NULL} (default) values are not checked.}
+\item{max_value}{(\code{numeric(1)}) The highest allowed value for \code{x}. If \code{NULL}
+(default) values are not checked.}
 
 \item{allowed_values}{A vector of permitted values (coerced to the target
 type). \code{NULL} (default) skips the check. \code{NA} values in \code{x} are permitted
 independently of \code{allowed_values}, subject to \code{allow_na}.}
 
-\item{x_arg}{(\code{character(1)}) The name of the object being stabilized
-to use in error messages. The automatic value will work in most cases, or
-pass it through from higher-level functions to make error messages clearer
-in unexported functions.}
+\item{x_arg}{(\code{character(1)}) The name of the object being stabilized to use
+in error messages. The automatic value will work in most cases, or pass it
+through from higher-level functions to make error messages clearer in
+unexported functions.}
 
 \item{call}{\code{(environment)} The execution environment to mention as the
 source of error messages.}
 
-\item{x_class}{(\code{character(1)}) The class name of the object being
-stabilized to use in error messages. Use this if you remove a special class
-from the object before checking its coercion, but want the error message to
-match the original class.}
+\item{x_class}{(\code{character(1)}) The class name of the object being stabilized
+to use in error messages. Use this if you remove a special class from the
+object before checking its coercion, but want the error message to match
+the original class.}
 }
 \value{
 The input as a double vector, or an error condition with classes

--- a/man/stabilize_dbl_scalar.Rd
+++ b/man/stabilize_dbl_scalar.Rd
@@ -78,41 +78,40 @@ stabilise_double_scalar(
 
 \item{allow_null}{(\code{logical(1)}) Is NULL an acceptable value?}
 
-\item{allow_zero_length}{(\code{logical(1)}) Are zero-length vectors
-acceptable?}
+\item{allow_zero_length}{(\code{logical(1)}) Are zero-length vectors acceptable?}
 
 \item{allow_na}{(\code{logical(1)}) Are NA values ok?}
 
-\item{coerce_character}{(\code{logical(1)}) Should character vectors such as
-"1" and "2.0" be considered numeric-ish?}
+\item{coerce_character}{(\code{logical(1)}) Should character vectors such as "1"
+and "2.0" be considered numeric-ish?}
 
-\item{coerce_factor}{(\code{logical(1)}) Should factors with values such as
-"1" and "2.0" be considered numeric-ish? Note that this package uses the
+\item{coerce_factor}{(\code{logical(1)}) Should factors with values such as "1"
+and "2.0" be considered numeric-ish? Note that this package uses the
 character value from the factor, while \code{\link[=as.integer]{as.integer()}} and \code{\link[=as.double]{as.double()}} use
 the integer index of the factor.}
 
-\item{min_value}{(\code{numeric(1)}) The lowest allowed value for \code{x}. If
-\code{NULL} (default) values are not checked.}
+\item{min_value}{(\code{numeric(1)}) The lowest allowed value for \code{x}. If \code{NULL}
+(default) values are not checked.}
 
-\item{max_value}{(\code{numeric(1)}) The highest allowed value for \code{x}. If
-\code{NULL} (default) values are not checked.}
+\item{max_value}{(\code{numeric(1)}) The highest allowed value for \code{x}. If \code{NULL}
+(default) values are not checked.}
 
 \item{allowed_values}{A vector of permitted values (coerced to the target
 type). \code{NULL} (default) skips the check. \code{NA} values in \code{x} are permitted
 independently of \code{allowed_values}, subject to \code{allow_na}.}
 
-\item{x_arg}{(\code{character(1)}) The name of the object being stabilized
-to use in error messages. The automatic value will work in most cases, or
-pass it through from higher-level functions to make error messages clearer
-in unexported functions.}
+\item{x_arg}{(\code{character(1)}) The name of the object being stabilized to use
+in error messages. The automatic value will work in most cases, or pass it
+through from higher-level functions to make error messages clearer in
+unexported functions.}
 
 \item{call}{\code{(environment)} The execution environment to mention as the
 source of error messages.}
 
-\item{x_class}{(\code{character(1)}) The class name of the object being
-stabilized to use in error messages. Use this if you remove a special class
-from the object before checking its coercion, but want the error message to
-match the original class.}
+\item{x_class}{(\code{character(1)}) The class name of the object being stabilized
+to use in error messages. Use this if you remove a special class from the
+object before checking its coercion, but want the error message to match
+the original class.}
 }
 \value{
 The input as a length-1 double vector, or an error condition with

--- a/man/stabilize_dbl_scalar.Rd
+++ b/man/stabilize_dbl_scalar.Rd
@@ -72,7 +72,7 @@ stabilise_double_scalar(
 )
 }
 \arguments{
-\item{x}{The argument to stabilize.}
+\item{x}{The object to stabilize.}
 
 \item{...}{Arguments passed to methods.}
 
@@ -101,7 +101,7 @@ the integer index of the factor.}
 type). \code{NULL} (default) skips the check. \code{NA} values in \code{x} are permitted
 independently of \code{allowed_values}, subject to \code{allow_na}.}
 
-\item{x_arg}{(\code{character(1)}) The name of the argument being stabilized
+\item{x_arg}{(\code{character(1)}) The name of the object being stabilized
 to use in error messages. The automatic value will work in most cases, or
 pass it through from higher-level functions to make error messages clearer
 in unexported functions.}
@@ -109,7 +109,7 @@ in unexported functions.}
 \item{call}{\code{(environment)} The execution environment to mention as the
 source of error messages.}
 
-\item{x_class}{(\code{character(1)}) The class name of the argument being
+\item{x_class}{(\code{character(1)}) The class name of the object being
 stabilized to use in error messages. Use this if you remove a special class
 from the object before checking its coercion, but want the error message to
 match the original class.}

--- a/man/stabilize_df.Rd
+++ b/man/stabilize_df.Rd
@@ -5,7 +5,7 @@
 \alias{stabilise_df}
 \alias{stabilize_data_frame}
 \alias{stabilise_data_frame}
-\title{Ensure a data frame argument meets expectations}
+\title{Ensure a data frame meets expectations}
 \usage{
 stabilize_df(
   .x,
@@ -60,7 +60,7 @@ stabilise_data_frame(
 )
 }
 \arguments{
-\item{.x}{The argument to stabilize.}
+\item{.x}{The object to stabilize.}
 
 \item{...}{Named stabilizer functions, such as \verb{stabilize_*} functions
 (\code{\link[=stabilize_chr]{stabilize_chr()}}, etc) or functions produced by \verb{specify_*()} functions
@@ -85,7 +85,7 @@ cause an error. Unlike \code{...}, this does not validate the column contents.}
 
 \item{.allow_null}{(\code{logical(1)}) Is NULL an acceptable value?}
 
-\item{.x_arg}{(\code{character(1)}) The name of the argument being stabilized
+\item{.x_arg}{(\code{character(1)}) The name of the object being stabilized
 to use in error messages. The automatic value will work in most cases, or
 pass it through from higher-level functions to make error messages clearer
 in unexported functions.}
@@ -93,7 +93,7 @@ in unexported functions.}
 \item{.call}{\code{(environment)} The execution environment to mention as the
 source of error messages.}
 
-\item{.x_class}{(\code{character(1)}) The class name of the argument being
+\item{.x_class}{(\code{character(1)}) The class name of the object being
 stabilized to use in error messages. Use this if you remove a special class
 from the object before checking its coercion, but want the error message to
 match the original class.}

--- a/man/stabilize_df.Rd
+++ b/man/stabilize_df.Rd
@@ -85,18 +85,18 @@ cause an error. Unlike \code{...}, this does not validate the column contents.}
 
 \item{.allow_null}{(\code{logical(1)}) Is NULL an acceptable value?}
 
-\item{.x_arg}{(\code{character(1)}) The name of the object being stabilized
-to use in error messages. The automatic value will work in most cases, or
-pass it through from higher-level functions to make error messages clearer
-in unexported functions.}
+\item{.x_arg}{(\code{character(1)}) The name of the object being stabilized to use
+in error messages. The automatic value will work in most cases, or pass it
+through from higher-level functions to make error messages clearer in
+unexported functions.}
 
 \item{.call}{\code{(environment)} The execution environment to mention as the
 source of error messages.}
 
-\item{.x_class}{(\code{character(1)}) The class name of the object being
-stabilized to use in error messages. Use this if you remove a special class
-from the object before checking its coercion, but want the error message to
-match the original class.}
+\item{.x_class}{(\code{character(1)}) The class name of the object being stabilized
+to use in error messages. Use this if you remove a special class from the
+object before checking its coercion, but want the error message to match
+the original class.}
 }
 \value{
 The validated data frame, or an error condition with classes

--- a/man/stabilize_fct.Rd
+++ b/man/stabilize_fct.Rd
@@ -72,29 +72,29 @@ stabilise_factor(
 
 \item{allow_na}{(\code{logical(1)}) Are NA values ok?}
 
-\item{min_size}{(\code{integer(1)}) The minimum size of the object. Object
-size will be tested using \code{\link[vctrs:vec_size]{vctrs::vec_size()}}.}
+\item{min_size}{(\code{integer(1)}) The minimum size of the object. Object size
+will be tested using \code{\link[vctrs:vec_size]{vctrs::vec_size()}}.}
 
-\item{max_size}{(\code{integer(1)}) The maximum size of the object. Object
-size will be tested using \code{\link[vctrs:vec_size]{vctrs::vec_size()}}.}
+\item{max_size}{(\code{integer(1)}) The maximum size of the object. Object size
+will be tested using \code{\link[vctrs:vec_size]{vctrs::vec_size()}}.}
 
 \item{levels}{\code{(character)} Expected levels. If \code{NULL} (default), the levels
 will be computed by \code{\link[base:factor]{base::factor()}}.}
 
 \item{to_na}{\code{(character)} Values to convert to \code{NA}.}
 
-\item{x_arg}{(\code{character(1)}) The name of the object being stabilized
-to use in error messages. The automatic value will work in most cases, or
-pass it through from higher-level functions to make error messages clearer
-in unexported functions.}
+\item{x_arg}{(\code{character(1)}) The name of the object being stabilized to use
+in error messages. The automatic value will work in most cases, or pass it
+through from higher-level functions to make error messages clearer in
+unexported functions.}
 
 \item{call}{\code{(environment)} The execution environment to mention as the
 source of error messages.}
 
-\item{x_class}{(\code{character(1)}) The class name of the object being
-stabilized to use in error messages. Use this if you remove a special class
-from the object before checking its coercion, but want the error message to
-match the original class.}
+\item{x_class}{(\code{character(1)}) The class name of the object being stabilized
+to use in error messages. Use this if you remove a special class from the
+object before checking its coercion, but want the error message to match
+the original class.}
 }
 \value{
 The input as a factor, or an error condition with classes

--- a/man/stabilize_fct.Rd
+++ b/man/stabilize_fct.Rd
@@ -64,7 +64,7 @@ stabilise_factor(
 )
 }
 \arguments{
-\item{x}{The argument to stabilize.}
+\item{x}{The object to stabilize.}
 
 \item{...}{Arguments passed to methods.}
 
@@ -83,7 +83,7 @@ will be computed by \code{\link[base:factor]{base::factor()}}.}
 
 \item{to_na}{\code{(character)} Values to convert to \code{NA}.}
 
-\item{x_arg}{(\code{character(1)}) The name of the argument being stabilized
+\item{x_arg}{(\code{character(1)}) The name of the object being stabilized
 to use in error messages. The automatic value will work in most cases, or
 pass it through from higher-level functions to make error messages clearer
 in unexported functions.}
@@ -91,7 +91,7 @@ in unexported functions.}
 \item{call}{\code{(environment)} The execution environment to mention as the
 source of error messages.}
 
-\item{x_class}{(\code{character(1)}) The class name of the argument being
+\item{x_class}{(\code{character(1)}) The class name of the object being
 stabilized to use in error messages. Use this if you remove a special class
 from the object before checking its coercion, but want the error message to
 match the original class.}

--- a/man/stabilize_fct_scalar.Rd
+++ b/man/stabilize_fct_scalar.Rd
@@ -66,8 +66,7 @@ stabilise_factor_scalar(
 
 \item{allow_null}{(\code{logical(1)}) Is NULL an acceptable value?}
 
-\item{allow_zero_length}{(\code{logical(1)}) Are zero-length vectors
-acceptable?}
+\item{allow_zero_length}{(\code{logical(1)}) Are zero-length vectors acceptable?}
 
 \item{allow_na}{(\code{logical(1)}) Are NA values ok?}
 
@@ -76,18 +75,18 @@ will be computed by \code{\link[base:factor]{base::factor()}}.}
 
 \item{to_na}{\code{(character)} Values to convert to \code{NA}.}
 
-\item{x_arg}{(\code{character(1)}) The name of the object being stabilized
-to use in error messages. The automatic value will work in most cases, or
-pass it through from higher-level functions to make error messages clearer
-in unexported functions.}
+\item{x_arg}{(\code{character(1)}) The name of the object being stabilized to use
+in error messages. The automatic value will work in most cases, or pass it
+through from higher-level functions to make error messages clearer in
+unexported functions.}
 
 \item{call}{\code{(environment)} The execution environment to mention as the
 source of error messages.}
 
-\item{x_class}{(\code{character(1)}) The class name of the object being
-stabilized to use in error messages. Use this if you remove a special class
-from the object before checking its coercion, but want the error message to
-match the original class.}
+\item{x_class}{(\code{character(1)}) The class name of the object being stabilized
+to use in error messages. Use this if you remove a special class from the
+object before checking its coercion, but want the error message to match
+the original class.}
 }
 \value{
 The input as a length-1 factor, or an error condition with classes

--- a/man/stabilize_fct_scalar.Rd
+++ b/man/stabilize_fct_scalar.Rd
@@ -60,7 +60,7 @@ stabilise_factor_scalar(
 )
 }
 \arguments{
-\item{x}{The argument to stabilize.}
+\item{x}{The object to stabilize.}
 
 \item{...}{Arguments passed to methods.}
 
@@ -76,7 +76,7 @@ will be computed by \code{\link[base:factor]{base::factor()}}.}
 
 \item{to_na}{\code{(character)} Values to convert to \code{NA}.}
 
-\item{x_arg}{(\code{character(1)}) The name of the argument being stabilized
+\item{x_arg}{(\code{character(1)}) The name of the object being stabilized
 to use in error messages. The automatic value will work in most cases, or
 pass it through from higher-level functions to make error messages clearer
 in unexported functions.}
@@ -84,7 +84,7 @@ in unexported functions.}
 \item{call}{\code{(environment)} The execution environment to mention as the
 source of error messages.}
 
-\item{x_class}{(\code{character(1)}) The class name of the argument being
+\item{x_class}{(\code{character(1)}) The class name of the object being
 stabilized to use in error messages. Use this if you remove a special class
 from the object before checking its coercion, but want the error message to
 match the original class.}

--- a/man/stabilize_int.Rd
+++ b/man/stabilize_int.Rd
@@ -88,44 +88,44 @@ stabilise_integer(
 
 \item{allow_na}{(\code{logical(1)}) Are NA values ok?}
 
-\item{coerce_character}{(\code{logical(1)}) Should character vectors such as
-"1" and "2.0" be considered numeric-ish?}
+\item{coerce_character}{(\code{logical(1)}) Should character vectors such as "1"
+and "2.0" be considered numeric-ish?}
 
-\item{coerce_factor}{(\code{logical(1)}) Should factors with values such as
-"1" and "2.0" be considered numeric-ish? Note that this package uses the
+\item{coerce_factor}{(\code{logical(1)}) Should factors with values such as "1"
+and "2.0" be considered numeric-ish? Note that this package uses the
 character value from the factor, while \code{\link[=as.integer]{as.integer()}} and \code{\link[=as.double]{as.double()}} use
 the integer index of the factor.}
 
-\item{min_size}{(\code{integer(1)}) The minimum size of the object. Object
-size will be tested using \code{\link[vctrs:vec_size]{vctrs::vec_size()}}.}
+\item{min_size}{(\code{integer(1)}) The minimum size of the object. Object size
+will be tested using \code{\link[vctrs:vec_size]{vctrs::vec_size()}}.}
 
-\item{max_size}{(\code{integer(1)}) The maximum size of the object. Object
-size will be tested using \code{\link[vctrs:vec_size]{vctrs::vec_size()}}.}
+\item{max_size}{(\code{integer(1)}) The maximum size of the object. Object size
+will be tested using \code{\link[vctrs:vec_size]{vctrs::vec_size()}}.}
 
 \item{unique}{(\code{logical(1)}) Should all elements in \code{x} be distinct?}
 
-\item{min_value}{(\code{numeric(1)}) The lowest allowed value for \code{x}. If
-\code{NULL} (default) values are not checked.}
+\item{min_value}{(\code{numeric(1)}) The lowest allowed value for \code{x}. If \code{NULL}
+(default) values are not checked.}
 
-\item{max_value}{(\code{numeric(1)}) The highest allowed value for \code{x}. If
-\code{NULL} (default) values are not checked.}
+\item{max_value}{(\code{numeric(1)}) The highest allowed value for \code{x}. If \code{NULL}
+(default) values are not checked.}
 
 \item{allowed_values}{A vector of permitted values (coerced to the target
 type). \code{NULL} (default) skips the check. \code{NA} values in \code{x} are permitted
 independently of \code{allowed_values}, subject to \code{allow_na}.}
 
-\item{x_arg}{(\code{character(1)}) The name of the object being stabilized
-to use in error messages. The automatic value will work in most cases, or
-pass it through from higher-level functions to make error messages clearer
-in unexported functions.}
+\item{x_arg}{(\code{character(1)}) The name of the object being stabilized to use
+in error messages. The automatic value will work in most cases, or pass it
+through from higher-level functions to make error messages clearer in
+unexported functions.}
 
 \item{call}{\code{(environment)} The execution environment to mention as the
 source of error messages.}
 
-\item{x_class}{(\code{character(1)}) The class name of the object being
-stabilized to use in error messages. Use this if you remove a special class
-from the object before checking its coercion, but want the error message to
-match the original class.}
+\item{x_class}{(\code{character(1)}) The class name of the object being stabilized
+to use in error messages. Use this if you remove a special class from the
+object before checking its coercion, but want the error message to match
+the original class.}
 }
 \value{
 The input as an integer vector, or an error condition with classes

--- a/man/stabilize_int.Rd
+++ b/man/stabilize_int.Rd
@@ -80,7 +80,7 @@ stabilise_integer(
 )
 }
 \arguments{
-\item{x}{The argument to stabilize.}
+\item{x}{The object to stabilize.}
 
 \item{...}{Arguments passed to methods.}
 
@@ -114,7 +114,7 @@ size will be tested using \code{\link[vctrs:vec_size]{vctrs::vec_size()}}.}
 type). \code{NULL} (default) skips the check. \code{NA} values in \code{x} are permitted
 independently of \code{allowed_values}, subject to \code{allow_na}.}
 
-\item{x_arg}{(\code{character(1)}) The name of the argument being stabilized
+\item{x_arg}{(\code{character(1)}) The name of the object being stabilized
 to use in error messages. The automatic value will work in most cases, or
 pass it through from higher-level functions to make error messages clearer
 in unexported functions.}
@@ -122,7 +122,7 @@ in unexported functions.}
 \item{call}{\code{(environment)} The execution environment to mention as the
 source of error messages.}
 
-\item{x_class}{(\code{character(1)}) The class name of the argument being
+\item{x_class}{(\code{character(1)}) The class name of the object being
 stabilized to use in error messages. Use this if you remove a special class
 from the object before checking its coercion, but want the error message to
 match the original class.}

--- a/man/stabilize_int_scalar.Rd
+++ b/man/stabilize_int_scalar.Rd
@@ -72,7 +72,7 @@ stabilise_integer_scalar(
 )
 }
 \arguments{
-\item{x}{The argument to stabilize.}
+\item{x}{The object to stabilize.}
 
 \item{...}{Arguments passed to methods.}
 
@@ -101,7 +101,7 @@ the integer index of the factor.}
 type). \code{NULL} (default) skips the check. \code{NA} values in \code{x} are permitted
 independently of \code{allowed_values}, subject to \code{allow_na}.}
 
-\item{x_arg}{(\code{character(1)}) The name of the argument being stabilized
+\item{x_arg}{(\code{character(1)}) The name of the object being stabilized
 to use in error messages. The automatic value will work in most cases, or
 pass it through from higher-level functions to make error messages clearer
 in unexported functions.}
@@ -109,7 +109,7 @@ in unexported functions.}
 \item{call}{\code{(environment)} The execution environment to mention as the
 source of error messages.}
 
-\item{x_class}{(\code{character(1)}) The class name of the argument being
+\item{x_class}{(\code{character(1)}) The class name of the object being
 stabilized to use in error messages. Use this if you remove a special class
 from the object before checking its coercion, but want the error message to
 match the original class.}

--- a/man/stabilize_int_scalar.Rd
+++ b/man/stabilize_int_scalar.Rd
@@ -78,41 +78,40 @@ stabilise_integer_scalar(
 
 \item{allow_null}{(\code{logical(1)}) Is NULL an acceptable value?}
 
-\item{allow_zero_length}{(\code{logical(1)}) Are zero-length vectors
-acceptable?}
+\item{allow_zero_length}{(\code{logical(1)}) Are zero-length vectors acceptable?}
 
 \item{allow_na}{(\code{logical(1)}) Are NA values ok?}
 
-\item{coerce_character}{(\code{logical(1)}) Should character vectors such as
-"1" and "2.0" be considered numeric-ish?}
+\item{coerce_character}{(\code{logical(1)}) Should character vectors such as "1"
+and "2.0" be considered numeric-ish?}
 
-\item{coerce_factor}{(\code{logical(1)}) Should factors with values such as
-"1" and "2.0" be considered numeric-ish? Note that this package uses the
+\item{coerce_factor}{(\code{logical(1)}) Should factors with values such as "1"
+and "2.0" be considered numeric-ish? Note that this package uses the
 character value from the factor, while \code{\link[=as.integer]{as.integer()}} and \code{\link[=as.double]{as.double()}} use
 the integer index of the factor.}
 
-\item{min_value}{(\code{numeric(1)}) The lowest allowed value for \code{x}. If
-\code{NULL} (default) values are not checked.}
+\item{min_value}{(\code{numeric(1)}) The lowest allowed value for \code{x}. If \code{NULL}
+(default) values are not checked.}
 
-\item{max_value}{(\code{numeric(1)}) The highest allowed value for \code{x}. If
-\code{NULL} (default) values are not checked.}
+\item{max_value}{(\code{numeric(1)}) The highest allowed value for \code{x}. If \code{NULL}
+(default) values are not checked.}
 
 \item{allowed_values}{A vector of permitted values (coerced to the target
 type). \code{NULL} (default) skips the check. \code{NA} values in \code{x} are permitted
 independently of \code{allowed_values}, subject to \code{allow_na}.}
 
-\item{x_arg}{(\code{character(1)}) The name of the object being stabilized
-to use in error messages. The automatic value will work in most cases, or
-pass it through from higher-level functions to make error messages clearer
-in unexported functions.}
+\item{x_arg}{(\code{character(1)}) The name of the object being stabilized to use
+in error messages. The automatic value will work in most cases, or pass it
+through from higher-level functions to make error messages clearer in
+unexported functions.}
 
 \item{call}{\code{(environment)} The execution environment to mention as the
 source of error messages.}
 
-\item{x_class}{(\code{character(1)}) The class name of the object being
-stabilized to use in error messages. Use this if you remove a special class
-from the object before checking its coercion, but want the error message to
-match the original class.}
+\item{x_class}{(\code{character(1)}) The class name of the object being stabilized
+to use in error messages. Use this if you remove a special class from the
+object before checking its coercion, but want the error message to match
+the original class.}
 }
 \value{
 The input as a length-1 integer vector, or an error condition with

--- a/man/stabilize_lgl.Rd
+++ b/man/stabilize_lgl.Rd
@@ -60,7 +60,7 @@ stabilise_logical(
 )
 }
 \arguments{
-\item{x}{The argument to stabilize.}
+\item{x}{The object to stabilize.}
 
 \item{...}{Arguments passed to methods.}
 
@@ -78,7 +78,7 @@ size will be tested using \code{\link[vctrs:vec_size]{vctrs::vec_size()}}.}
 type). \code{NULL} (default) skips the check. \code{NA} values in \code{x} are permitted
 independently of \code{allowed_values}, subject to \code{allow_na}.}
 
-\item{x_arg}{(\code{character(1)}) The name of the argument being stabilized
+\item{x_arg}{(\code{character(1)}) The name of the object being stabilized
 to use in error messages. The automatic value will work in most cases, or
 pass it through from higher-level functions to make error messages clearer
 in unexported functions.}
@@ -86,7 +86,7 @@ in unexported functions.}
 \item{call}{\code{(environment)} The execution environment to mention as the
 source of error messages.}
 
-\item{x_class}{(\code{character(1)}) The class name of the argument being
+\item{x_class}{(\code{character(1)}) The class name of the object being
 stabilized to use in error messages. Use this if you remove a special class
 from the object before checking its coercion, but want the error message to
 match the original class.}

--- a/man/stabilize_lgl.Rd
+++ b/man/stabilize_lgl.Rd
@@ -68,28 +68,28 @@ stabilise_logical(
 
 \item{allow_na}{(\code{logical(1)}) Are NA values ok?}
 
-\item{min_size}{(\code{integer(1)}) The minimum size of the object. Object
-size will be tested using \code{\link[vctrs:vec_size]{vctrs::vec_size()}}.}
+\item{min_size}{(\code{integer(1)}) The minimum size of the object. Object size
+will be tested using \code{\link[vctrs:vec_size]{vctrs::vec_size()}}.}
 
-\item{max_size}{(\code{integer(1)}) The maximum size of the object. Object
-size will be tested using \code{\link[vctrs:vec_size]{vctrs::vec_size()}}.}
+\item{max_size}{(\code{integer(1)}) The maximum size of the object. Object size
+will be tested using \code{\link[vctrs:vec_size]{vctrs::vec_size()}}.}
 
 \item{allowed_values}{A vector of permitted values (coerced to the target
 type). \code{NULL} (default) skips the check. \code{NA} values in \code{x} are permitted
 independently of \code{allowed_values}, subject to \code{allow_na}.}
 
-\item{x_arg}{(\code{character(1)}) The name of the object being stabilized
-to use in error messages. The automatic value will work in most cases, or
-pass it through from higher-level functions to make error messages clearer
-in unexported functions.}
+\item{x_arg}{(\code{character(1)}) The name of the object being stabilized to use
+in error messages. The automatic value will work in most cases, or pass it
+through from higher-level functions to make error messages clearer in
+unexported functions.}
 
 \item{call}{\code{(environment)} The execution environment to mention as the
 source of error messages.}
 
-\item{x_class}{(\code{character(1)}) The class name of the object being
-stabilized to use in error messages. Use this if you remove a special class
-from the object before checking its coercion, but want the error message to
-match the original class.}
+\item{x_class}{(\code{character(1)}) The class name of the object being stabilized
+to use in error messages. Use this if you remove a special class from the
+object before checking its coercion, but want the error message to match
+the original class.}
 }
 \value{
 The input as a logical vector, or an error condition with classes

--- a/man/stabilize_lgl_scalar.Rd
+++ b/man/stabilize_lgl_scalar.Rd
@@ -56,7 +56,7 @@ stabilise_logical_scalar(
 )
 }
 \arguments{
-\item{x}{The argument to stabilize.}
+\item{x}{The object to stabilize.}
 
 \item{...}{Arguments passed to methods.}
 
@@ -71,7 +71,7 @@ acceptable?}
 type). \code{NULL} (default) skips the check. \code{NA} values in \code{x} are permitted
 independently of \code{allowed_values}, subject to \code{allow_na}.}
 
-\item{x_arg}{(\code{character(1)}) The name of the argument being stabilized
+\item{x_arg}{(\code{character(1)}) The name of the object being stabilized
 to use in error messages. The automatic value will work in most cases, or
 pass it through from higher-level functions to make error messages clearer
 in unexported functions.}
@@ -79,7 +79,7 @@ in unexported functions.}
 \item{call}{\code{(environment)} The execution environment to mention as the
 source of error messages.}
 
-\item{x_class}{(\code{character(1)}) The class name of the argument being
+\item{x_class}{(\code{character(1)}) The class name of the object being
 stabilized to use in error messages. Use this if you remove a special class
 from the object before checking its coercion, but want the error message to
 match the original class.}

--- a/man/stabilize_lgl_scalar.Rd
+++ b/man/stabilize_lgl_scalar.Rd
@@ -62,8 +62,7 @@ stabilise_logical_scalar(
 
 \item{allow_null}{(\code{logical(1)}) Is NULL an acceptable value?}
 
-\item{allow_zero_length}{(\code{logical(1)}) Are zero-length vectors
-acceptable?}
+\item{allow_zero_length}{(\code{logical(1)}) Are zero-length vectors acceptable?}
 
 \item{allow_na}{(\code{logical(1)}) Are NA values ok?}
 
@@ -71,18 +70,18 @@ acceptable?}
 type). \code{NULL} (default) skips the check. \code{NA} values in \code{x} are permitted
 independently of \code{allowed_values}, subject to \code{allow_na}.}
 
-\item{x_arg}{(\code{character(1)}) The name of the object being stabilized
-to use in error messages. The automatic value will work in most cases, or
-pass it through from higher-level functions to make error messages clearer
-in unexported functions.}
+\item{x_arg}{(\code{character(1)}) The name of the object being stabilized to use
+in error messages. The automatic value will work in most cases, or pass it
+through from higher-level functions to make error messages clearer in
+unexported functions.}
 
 \item{call}{\code{(environment)} The execution environment to mention as the
 source of error messages.}
 
-\item{x_class}{(\code{character(1)}) The class name of the object being
-stabilized to use in error messages. Use this if you remove a special class
-from the object before checking its coercion, but want the error message to
-match the original class.}
+\item{x_class}{(\code{character(1)}) The class name of the object being stabilized
+to use in error messages. Use this if you remove a special class from the
+object before checking its coercion, but want the error message to match
+the original class.}
 }
 \value{
 The input as a length-1 logical vector, or an error condition with

--- a/man/stabilize_lst.Rd
+++ b/man/stabilize_lst.Rd
@@ -5,7 +5,7 @@
 \alias{stabilize_list}
 \alias{stabilise_lst}
 \alias{stabilise_list}
-\title{Ensure a list argument meets expectations}
+\title{Ensure a list meets expectations}
 \usage{
 stabilize_lst(
   .x,
@@ -68,7 +68,7 @@ stabilise_list(
 )
 }
 \arguments{
-\item{.x}{The argument to stabilize.}
+\item{.x}{The object to stabilize.}
 
 \item{...}{Named stabilizer functions, such as \verb{stabilize_*} functions
 (\code{\link[=stabilize_chr]{stabilize_chr()}}, etc) or functions produced by \verb{specify_*()} functions
@@ -102,7 +102,7 @@ size will be tested using \code{\link[vctrs:vec_size]{vctrs::vec_size()}}.}
 \item{.max_size}{(\code{integer(1)}) The maximum size of the object. Object
 size will be tested using \code{\link[vctrs:vec_size]{vctrs::vec_size()}}.}
 
-\item{.x_arg}{(\code{character(1)}) The name of the argument being stabilized
+\item{.x_arg}{(\code{character(1)}) The name of the object being stabilized
 to use in error messages. The automatic value will work in most cases, or
 pass it through from higher-level functions to make error messages clearer
 in unexported functions.}
@@ -110,7 +110,7 @@ in unexported functions.}
 \item{.call}{\code{(environment)} The execution environment to mention as the
 source of error messages.}
 
-\item{.x_class}{(\code{character(1)}) The class name of the argument being
+\item{.x_class}{(\code{character(1)}) The class name of the object being
 stabilized to use in error messages. Use this if you remove a special class
 from the object before checking its coercion, but want the error message to
 match the original class.}

--- a/man/stabilize_lst.Rd
+++ b/man/stabilize_lst.Rd
@@ -96,24 +96,24 @@ If \code{TRUE}, duplicated elements are rejected.}
 
 \item{.allow_null}{(\code{logical(1)}) Is NULL an acceptable value?}
 
-\item{.min_size}{(\code{integer(1)}) The minimum size of the object. Object
-size will be tested using \code{\link[vctrs:vec_size]{vctrs::vec_size()}}.}
+\item{.min_size}{(\code{integer(1)}) The minimum size of the object. Object size
+will be tested using \code{\link[vctrs:vec_size]{vctrs::vec_size()}}.}
 
-\item{.max_size}{(\code{integer(1)}) The maximum size of the object. Object
-size will be tested using \code{\link[vctrs:vec_size]{vctrs::vec_size()}}.}
+\item{.max_size}{(\code{integer(1)}) The maximum size of the object. Object size
+will be tested using \code{\link[vctrs:vec_size]{vctrs::vec_size()}}.}
 
-\item{.x_arg}{(\code{character(1)}) The name of the object being stabilized
-to use in error messages. The automatic value will work in most cases, or
-pass it through from higher-level functions to make error messages clearer
-in unexported functions.}
+\item{.x_arg}{(\code{character(1)}) The name of the object being stabilized to use
+in error messages. The automatic value will work in most cases, or pass it
+through from higher-level functions to make error messages clearer in
+unexported functions.}
 
 \item{.call}{\code{(environment)} The execution environment to mention as the
 source of error messages.}
 
-\item{.x_class}{(\code{character(1)}) The class name of the object being
-stabilized to use in error messages. Use this if you remove a special class
-from the object before checking its coercion, but want the error message to
-match the original class.}
+\item{.x_class}{(\code{character(1)}) The class name of the object being stabilized
+to use in error messages. Use this if you remove a special class from the
+object before checking its coercion, but want the error message to match
+the original class.}
 }
 \value{
 The validated list, or an error condition with classes

--- a/man/stabilize_present.Rd
+++ b/man/stabilize_present.Rd
@@ -7,9 +7,9 @@
 stabilize_present(x, x_arg = caller_arg(x), call = caller_env())
 }
 \arguments{
-\item{x}{The argument to stabilize.}
+\item{x}{The object to stabilize.}
 
-\item{x_arg}{(\code{character(1)}) The name of the argument being stabilized
+\item{x_arg}{(\code{character(1)}) The name of the object being stabilized
 to use in error messages. The automatic value will work in most cases, or
 pass it through from higher-level functions to make error messages clearer
 in unexported functions.}

--- a/man/stabilize_present.Rd
+++ b/man/stabilize_present.Rd
@@ -9,10 +9,10 @@ stabilize_present(x, x_arg = caller_arg(x), call = caller_env())
 \arguments{
 \item{x}{The object to stabilize.}
 
-\item{x_arg}{(\code{character(1)}) The name of the object being stabilized
-to use in error messages. The automatic value will work in most cases, or
-pass it through from higher-level functions to make error messages clearer
-in unexported functions.}
+\item{x_arg}{(\code{character(1)}) The name of the object being stabilized to use
+in error messages. The automatic value will work in most cases, or pass it
+through from higher-level functions to make error messages clearer in
+unexported functions.}
 
 \item{call}{\code{(environment)} The execution environment to mention as the
 source of error messages.}

--- a/man/stbl-package.Rd
+++ b/man/stbl-package.Rd
@@ -4,11 +4,11 @@
 \name{stbl-package}
 \alias{stbl}
 \alias{stbl-package}
-\title{stbl: Stabilize Function Arguments}
+\title{stbl: Stabilize Objects}
 \description{
 \if{html}{\figure{logo.svg}{options: style='float: right' alt='logo' width='120'}}
 
-A set of consistent, opinionated functions to quickly check function arguments, coerce them to the desired configuration, or deliver informative error messages when that is not possible.
+A set of consistent, opinionated functions to quickly check objects, coerce them to the desired configuration, or deliver informative error messages when that is not possible.
 }
 \seealso{
 Useful links:

--- a/man/to.Rd
+++ b/man/to.Rd
@@ -115,14 +115,14 @@ to(
 )
 }
 \arguments{
-\item{x}{The argument to stabilize.}
+\item{x}{The object to stabilize.}
 
 \item{.to}{A prototype that determines the target type (e.g., \code{integer()},
 \code{factor(levels = c("a", "b"))}).}
 
 \item{...}{Arguments passed to methods and on to \verb{to_*()} functions.}
 
-\item{x_arg}{(\code{character(1)}) The name of the argument being stabilized
+\item{x_arg}{(\code{character(1)}) The name of the object being stabilized
 to use in error messages. The automatic value will work in most cases, or
 pass it through from higher-level functions to make error messages clearer
 in unexported functions.}
@@ -130,7 +130,7 @@ in unexported functions.}
 \item{call}{\code{(environment)} The execution environment to mention as the
 source of error messages.}
 
-\item{x_class}{(\code{character(1)}) The class name of the argument being
+\item{x_class}{(\code{character(1)}) The class name of the object being
 stabilized to use in error messages. Use this if you remove a special class
 from the object before checking its coercion, but want the error message to
 match the original class.}

--- a/man/to.Rd
+++ b/man/to.Rd
@@ -122,22 +122,22 @@ to(
 
 \item{...}{Arguments passed to methods and on to \verb{to_*()} functions.}
 
-\item{x_arg}{(\code{character(1)}) The name of the object being stabilized
-to use in error messages. The automatic value will work in most cases, or
-pass it through from higher-level functions to make error messages clearer
-in unexported functions.}
+\item{x_arg}{(\code{character(1)}) The name of the object being stabilized to use
+in error messages. The automatic value will work in most cases, or pass it
+through from higher-level functions to make error messages clearer in
+unexported functions.}
 
 \item{call}{\code{(environment)} The execution environment to mention as the
 source of error messages.}
 
-\item{x_class}{(\code{character(1)}) The class name of the object being
-stabilized to use in error messages. Use this if you remove a special class
-from the object before checking its coercion, but want the error message to
-match the original class.}
+\item{x_class}{(\code{character(1)}) The class name of the object being stabilized
+to use in error messages. Use this if you remove a special class from the
+object before checking its coercion, but want the error message to match
+the original class.}
 
 \item{levels}{\code{(character)} The desired factor levels. For factors, a
-vector's \code{levels} play the same role that \code{allowed_values} plays for
-other types: they restrict \code{x} to a fixed set of permitted values.}
+vector's \code{levels} play the same role that \code{allowed_values} plays for other
+types: they restrict \code{x} to a fixed set of permitted values.}
 }
 \value{
 \code{x} coerced to the type of \code{.to}.

--- a/man/to_chr.Rd
+++ b/man/to_chr.Rd
@@ -22,11 +22,11 @@ to_character(
 )
 }
 \arguments{
-\item{x}{The argument to stabilize.}
+\item{x}{The object to stabilize.}
 
 \item{...}{Arguments passed to methods.}
 
-\item{x_arg}{(\code{character(1)}) The name of the argument being stabilized
+\item{x_arg}{(\code{character(1)}) The name of the object being stabilized
 to use in error messages. The automatic value will work in most cases, or
 pass it through from higher-level functions to make error messages clearer
 in unexported functions.}
@@ -34,7 +34,7 @@ in unexported functions.}
 \item{call}{\code{(environment)} The execution environment to mention as the
 source of error messages.}
 
-\item{x_class}{(\code{character(1)}) The class name of the argument being
+\item{x_class}{(\code{character(1)}) The class name of the object being
 stabilized to use in error messages. Use this if you remove a special class
 from the object before checking its coercion, but want the error message to
 match the original class.}

--- a/man/to_chr.Rd
+++ b/man/to_chr.Rd
@@ -26,18 +26,18 @@ to_character(
 
 \item{...}{Arguments passed to methods.}
 
-\item{x_arg}{(\code{character(1)}) The name of the object being stabilized
-to use in error messages. The automatic value will work in most cases, or
-pass it through from higher-level functions to make error messages clearer
-in unexported functions.}
+\item{x_arg}{(\code{character(1)}) The name of the object being stabilized to use
+in error messages. The automatic value will work in most cases, or pass it
+through from higher-level functions to make error messages clearer in
+unexported functions.}
 
 \item{call}{\code{(environment)} The execution environment to mention as the
 source of error messages.}
 
-\item{x_class}{(\code{character(1)}) The class name of the object being
-stabilized to use in error messages. Use this if you remove a special class
-from the object before checking its coercion, but want the error message to
-match the original class.}
+\item{x_class}{(\code{character(1)}) The class name of the object being stabilized
+to use in error messages. Use this if you remove a special class from the
+object before checking its coercion, but want the error message to match
+the original class.}
 }
 \value{
 The input as a character vector.

--- a/man/to_chr_scalar.Rd
+++ b/man/to_chr_scalar.Rd
@@ -26,7 +26,7 @@ to_character_scalar(
 )
 }
 \arguments{
-\item{x}{The argument to stabilize.}
+\item{x}{The object to stabilize.}
 
 \item{...}{Arguments passed to methods.}
 
@@ -35,7 +35,7 @@ to_character_scalar(
 \item{allow_zero_length}{(\code{logical(1)}) Are zero-length vectors
 acceptable?}
 
-\item{x_arg}{(\code{character(1)}) The name of the argument being stabilized
+\item{x_arg}{(\code{character(1)}) The name of the object being stabilized
 to use in error messages. The automatic value will work in most cases, or
 pass it through from higher-level functions to make error messages clearer
 in unexported functions.}
@@ -43,7 +43,7 @@ in unexported functions.}
 \item{call}{\code{(environment)} The execution environment to mention as the
 source of error messages.}
 
-\item{x_class}{(\code{character(1)}) The class name of the argument being
+\item{x_class}{(\code{character(1)}) The class name of the object being
 stabilized to use in error messages. Use this if you remove a special class
 from the object before checking its coercion, but want the error message to
 match the original class.}

--- a/man/to_chr_scalar.Rd
+++ b/man/to_chr_scalar.Rd
@@ -32,21 +32,20 @@ to_character_scalar(
 
 \item{allow_null}{(\code{logical(1)}) Is NULL an acceptable value?}
 
-\item{allow_zero_length}{(\code{logical(1)}) Are zero-length vectors
-acceptable?}
+\item{allow_zero_length}{(\code{logical(1)}) Are zero-length vectors acceptable?}
 
-\item{x_arg}{(\code{character(1)}) The name of the object being stabilized
-to use in error messages. The automatic value will work in most cases, or
-pass it through from higher-level functions to make error messages clearer
-in unexported functions.}
+\item{x_arg}{(\code{character(1)}) The name of the object being stabilized to use
+in error messages. The automatic value will work in most cases, or pass it
+through from higher-level functions to make error messages clearer in
+unexported functions.}
 
 \item{call}{\code{(environment)} The execution environment to mention as the
 source of error messages.}
 
-\item{x_class}{(\code{character(1)}) The class name of the object being
-stabilized to use in error messages. Use this if you remove a special class
-from the object before checking its coercion, but want the error message to
-match the original class.}
+\item{x_class}{(\code{character(1)}) The class name of the object being stabilized
+to use in error messages. Use this if you remove a special class from the
+object before checking its coercion, but want the error message to match
+the original class.}
 }
 \value{
 The input as a length-1 character vector.

--- a/man/to_dbl.Rd
+++ b/man/to_dbl.Rd
@@ -45,11 +45,11 @@ to_double(
 )
 }
 \arguments{
-\item{x}{The argument to stabilize.}
+\item{x}{The object to stabilize.}
 
 \item{...}{Arguments passed to methods.}
 
-\item{x_arg}{(\code{character(1)}) The name of the argument being stabilized
+\item{x_arg}{(\code{character(1)}) The name of the object being stabilized
 to use in error messages. The automatic value will work in most cases, or
 pass it through from higher-level functions to make error messages clearer
 in unexported functions.}
@@ -57,7 +57,7 @@ in unexported functions.}
 \item{call}{\code{(environment)} The execution environment to mention as the
 source of error messages.}
 
-\item{x_class}{(\code{character(1)}) The class name of the argument being
+\item{x_class}{(\code{character(1)}) The class name of the object being
 stabilized to use in error messages. Use this if you remove a special class
 from the object before checking its coercion, but want the error message to
 match the original class.}

--- a/man/to_dbl.Rd
+++ b/man/to_dbl.Rd
@@ -49,26 +49,26 @@ to_double(
 
 \item{...}{Arguments passed to methods.}
 
-\item{x_arg}{(\code{character(1)}) The name of the object being stabilized
-to use in error messages. The automatic value will work in most cases, or
-pass it through from higher-level functions to make error messages clearer
-in unexported functions.}
+\item{x_arg}{(\code{character(1)}) The name of the object being stabilized to use
+in error messages. The automatic value will work in most cases, or pass it
+through from higher-level functions to make error messages clearer in
+unexported functions.}
 
 \item{call}{\code{(environment)} The execution environment to mention as the
 source of error messages.}
 
-\item{x_class}{(\code{character(1)}) The class name of the object being
-stabilized to use in error messages. Use this if you remove a special class
-from the object before checking its coercion, but want the error message to
-match the original class.}
+\item{x_class}{(\code{character(1)}) The class name of the object being stabilized
+to use in error messages. Use this if you remove a special class from the
+object before checking its coercion, but want the error message to match
+the original class.}
 
 \item{allow_null}{(\code{logical(1)}) Is NULL an acceptable value?}
 
-\item{coerce_character}{(\code{logical(1)}) Should character vectors such as
-"1" and "2.0" be considered numeric-ish?}
+\item{coerce_character}{(\code{logical(1)}) Should character vectors such as "1"
+and "2.0" be considered numeric-ish?}
 
-\item{coerce_factor}{(\code{logical(1)}) Should factors with values such as
-"1" and "2.0" be considered numeric-ish? Note that this package uses the
+\item{coerce_factor}{(\code{logical(1)}) Should factors with values such as "1"
+and "2.0" be considered numeric-ish? Note that this package uses the
 character value from the factor, while \code{\link[=as.integer]{as.integer()}} and \code{\link[=as.double]{as.double()}} use
 the integer index of the factor.}
 }

--- a/man/to_dbl_scalar.Rd
+++ b/man/to_dbl_scalar.Rd
@@ -26,7 +26,7 @@ to_double_scalar(
 )
 }
 \arguments{
-\item{x}{The argument to stabilize.}
+\item{x}{The object to stabilize.}
 
 \item{...}{Arguments passed to methods.}
 
@@ -35,7 +35,7 @@ to_double_scalar(
 \item{allow_zero_length}{(\code{logical(1)}) Are zero-length vectors
 acceptable?}
 
-\item{x_arg}{(\code{character(1)}) The name of the argument being stabilized
+\item{x_arg}{(\code{character(1)}) The name of the object being stabilized
 to use in error messages. The automatic value will work in most cases, or
 pass it through from higher-level functions to make error messages clearer
 in unexported functions.}
@@ -43,7 +43,7 @@ in unexported functions.}
 \item{call}{\code{(environment)} The execution environment to mention as the
 source of error messages.}
 
-\item{x_class}{(\code{character(1)}) The class name of the argument being
+\item{x_class}{(\code{character(1)}) The class name of the object being
 stabilized to use in error messages. Use this if you remove a special class
 from the object before checking its coercion, but want the error message to
 match the original class.}

--- a/man/to_dbl_scalar.Rd
+++ b/man/to_dbl_scalar.Rd
@@ -32,21 +32,20 @@ to_double_scalar(
 
 \item{allow_null}{(\code{logical(1)}) Is NULL an acceptable value?}
 
-\item{allow_zero_length}{(\code{logical(1)}) Are zero-length vectors
-acceptable?}
+\item{allow_zero_length}{(\code{logical(1)}) Are zero-length vectors acceptable?}
 
-\item{x_arg}{(\code{character(1)}) The name of the object being stabilized
-to use in error messages. The automatic value will work in most cases, or
-pass it through from higher-level functions to make error messages clearer
-in unexported functions.}
+\item{x_arg}{(\code{character(1)}) The name of the object being stabilized to use
+in error messages. The automatic value will work in most cases, or pass it
+through from higher-level functions to make error messages clearer in
+unexported functions.}
 
 \item{call}{\code{(environment)} The execution environment to mention as the
 source of error messages.}
 
-\item{x_class}{(\code{character(1)}) The class name of the object being
-stabilized to use in error messages. Use this if you remove a special class
-from the object before checking its coercion, but want the error message to
-match the original class.}
+\item{x_class}{(\code{character(1)}) The class name of the object being stabilized
+to use in error messages. Use this if you remove a special class from the
+object before checking its coercion, but want the error message to match
+the original class.}
 }
 \value{
 The input as a length-1 double vector.

--- a/man/to_df.Rd
+++ b/man/to_df.Rd
@@ -29,18 +29,18 @@ to_data_frame(
 
 \item{...}{Arguments passed to \code{\link[base:as.data.frame]{base::as.data.frame()}} or other methods.}
 
-\item{x_arg}{(\code{character(1)}) The name of the object being stabilized
-to use in error messages. The automatic value will work in most cases, or
-pass it through from higher-level functions to make error messages clearer
-in unexported functions.}
+\item{x_arg}{(\code{character(1)}) The name of the object being stabilized to use
+in error messages. The automatic value will work in most cases, or pass it
+through from higher-level functions to make error messages clearer in
+unexported functions.}
 
 \item{call}{\code{(environment)} The execution environment to mention as the
 source of error messages.}
 
-\item{x_class}{(\code{character(1)}) The class name of the object being
-stabilized to use in error messages. Use this if you remove a special class
-from the object before checking its coercion, but want the error message to
-match the original class.}
+\item{x_class}{(\code{character(1)}) The class name of the object being stabilized
+to use in error messages. Use this if you remove a special class from the
+object before checking its coercion, but want the error message to match
+the original class.}
 
 \item{allow_null}{(\code{logical(1)}) Is NULL an acceptable value?}
 }

--- a/man/to_df.Rd
+++ b/man/to_df.Rd
@@ -4,7 +4,7 @@
 \alias{to_df}
 \alias{to_data_frame}
 \alias{to_df.NULL}
-\title{Ensure a data frame argument meets expectations}
+\title{Ensure a data frame meets expectations}
 \usage{
 to_df(
   x,
@@ -25,11 +25,11 @@ to_data_frame(
 \method{to_df}{`NULL`}(x, ..., allow_null = TRUE, x_arg = caller_arg(x), call = caller_env())
 }
 \arguments{
-\item{x}{The argument to stabilize.}
+\item{x}{The object to stabilize.}
 
 \item{...}{Arguments passed to \code{\link[base:as.data.frame]{base::as.data.frame()}} or other methods.}
 
-\item{x_arg}{(\code{character(1)}) The name of the argument being stabilized
+\item{x_arg}{(\code{character(1)}) The name of the object being stabilized
 to use in error messages. The automatic value will work in most cases, or
 pass it through from higher-level functions to make error messages clearer
 in unexported functions.}
@@ -37,7 +37,7 @@ in unexported functions.}
 \item{call}{\code{(environment)} The execution environment to mention as the
 source of error messages.}
 
-\item{x_class}{(\code{character(1)}) The class name of the argument being
+\item{x_class}{(\code{character(1)}) The class name of the object being
 stabilized to use in error messages. Use this if you remove a special class
 from the object before checking its coercion, but want the error message to
 match the original class.}
@@ -45,10 +45,10 @@ match the original class.}
 \item{allow_null}{(\code{logical(1)}) Is NULL an acceptable value?}
 }
 \value{
-The argument as a data frame.
+The object as a data frame.
 }
 \description{
-\code{to_df()} checks whether an argument can be coerced to a data frame,
+\code{to_df()} checks whether an object can be coerced to a data frame,
 returning it silently if so. Otherwise an informative error message is
 signaled. \code{to_data_frame()} is a synonym of \code{to_df()}.
 }

--- a/man/to_fct.Rd
+++ b/man/to_fct.Rd
@@ -38,18 +38,18 @@ will be computed by \code{\link[base:factor]{base::factor()}}.}
 
 \item{to_na}{\code{(character)} Values to convert to \code{NA}.}
 
-\item{x_arg}{(\code{character(1)}) The name of the object being stabilized
-to use in error messages. The automatic value will work in most cases, or
-pass it through from higher-level functions to make error messages clearer
-in unexported functions.}
+\item{x_arg}{(\code{character(1)}) The name of the object being stabilized to use
+in error messages. The automatic value will work in most cases, or pass it
+through from higher-level functions to make error messages clearer in
+unexported functions.}
 
 \item{call}{\code{(environment)} The execution environment to mention as the
 source of error messages.}
 
-\item{x_class}{(\code{character(1)}) The class name of the object being
-stabilized to use in error messages. Use this if you remove a special class
-from the object before checking its coercion, but want the error message to
-match the original class.}
+\item{x_class}{(\code{character(1)}) The class name of the object being stabilized
+to use in error messages. Use this if you remove a special class from the
+object before checking its coercion, but want the error message to match
+the original class.}
 
 \item{allow_null}{(\code{logical(1)}) Is NULL an acceptable value?}
 }

--- a/man/to_fct.Rd
+++ b/man/to_fct.Rd
@@ -29,7 +29,7 @@ to_factor(
 \method{to_fct}{`NULL`}(x, ..., allow_null = TRUE, x_arg = caller_arg(x), call = caller_env())
 }
 \arguments{
-\item{x}{The argument to stabilize.}
+\item{x}{The object to stabilize.}
 
 \item{...}{Arguments passed to methods.}
 
@@ -38,7 +38,7 @@ will be computed by \code{\link[base:factor]{base::factor()}}.}
 
 \item{to_na}{\code{(character)} Values to convert to \code{NA}.}
 
-\item{x_arg}{(\code{character(1)}) The name of the argument being stabilized
+\item{x_arg}{(\code{character(1)}) The name of the object being stabilized
 to use in error messages. The automatic value will work in most cases, or
 pass it through from higher-level functions to make error messages clearer
 in unexported functions.}
@@ -46,7 +46,7 @@ in unexported functions.}
 \item{call}{\code{(environment)} The execution environment to mention as the
 source of error messages.}
 
-\item{x_class}{(\code{character(1)}) The class name of the argument being
+\item{x_class}{(\code{character(1)}) The class name of the object being
 stabilized to use in error messages. Use this if you remove a special class
 from the object before checking its coercion, but want the error message to
 match the original class.}

--- a/man/to_fct_scalar.Rd
+++ b/man/to_fct_scalar.Rd
@@ -30,7 +30,7 @@ to_factor_scalar(
 )
 }
 \arguments{
-\item{x}{The argument to stabilize.}
+\item{x}{The object to stabilize.}
 
 \item{...}{Arguments passed to methods.}
 
@@ -44,7 +44,7 @@ will be computed by \code{\link[base:factor]{base::factor()}}.}
 
 \item{to_na}{\code{(character)} Values to convert to \code{NA}.}
 
-\item{x_arg}{(\code{character(1)}) The name of the argument being stabilized
+\item{x_arg}{(\code{character(1)}) The name of the object being stabilized
 to use in error messages. The automatic value will work in most cases, or
 pass it through from higher-level functions to make error messages clearer
 in unexported functions.}
@@ -52,7 +52,7 @@ in unexported functions.}
 \item{call}{\code{(environment)} The execution environment to mention as the
 source of error messages.}
 
-\item{x_class}{(\code{character(1)}) The class name of the argument being
+\item{x_class}{(\code{character(1)}) The class name of the object being
 stabilized to use in error messages. Use this if you remove a special class
 from the object before checking its coercion, but want the error message to
 match the original class.}

--- a/man/to_fct_scalar.Rd
+++ b/man/to_fct_scalar.Rd
@@ -36,26 +36,25 @@ to_factor_scalar(
 
 \item{allow_null}{(\code{logical(1)}) Is NULL an acceptable value?}
 
-\item{allow_zero_length}{(\code{logical(1)}) Are zero-length vectors
-acceptable?}
+\item{allow_zero_length}{(\code{logical(1)}) Are zero-length vectors acceptable?}
 
 \item{levels}{\code{(character)} Expected levels. If \code{NULL} (default), the levels
 will be computed by \code{\link[base:factor]{base::factor()}}.}
 
 \item{to_na}{\code{(character)} Values to convert to \code{NA}.}
 
-\item{x_arg}{(\code{character(1)}) The name of the object being stabilized
-to use in error messages. The automatic value will work in most cases, or
-pass it through from higher-level functions to make error messages clearer
-in unexported functions.}
+\item{x_arg}{(\code{character(1)}) The name of the object being stabilized to use
+in error messages. The automatic value will work in most cases, or pass it
+through from higher-level functions to make error messages clearer in
+unexported functions.}
 
 \item{call}{\code{(environment)} The execution environment to mention as the
 source of error messages.}
 
-\item{x_class}{(\code{character(1)}) The class name of the object being
-stabilized to use in error messages. Use this if you remove a special class
-from the object before checking its coercion, but want the error message to
-match the original class.}
+\item{x_class}{(\code{character(1)}) The class name of the object being stabilized
+to use in error messages. Use this if you remove a special class from the
+object before checking its coercion, but want the error message to match
+the original class.}
 }
 \value{
 The input as a length-1 factor.

--- a/man/to_fn.Rd
+++ b/man/to_fn.Rd
@@ -50,18 +50,18 @@ to_function(
 
 \item{...}{Arguments passed to methods.}
 
-\item{x_arg}{(\code{character(1)}) The name of the object being stabilized
-to use in error messages. The automatic value will work in most cases, or
-pass it through from higher-level functions to make error messages clearer
-in unexported functions.}
+\item{x_arg}{(\code{character(1)}) The name of the object being stabilized to use
+in error messages. The automatic value will work in most cases, or pass it
+through from higher-level functions to make error messages clearer in
+unexported functions.}
 
 \item{call}{\code{(environment)} The execution environment to mention as the
 source of error messages.}
 
-\item{x_class}{(\code{character(1)}) The class name of the object being
-stabilized to use in error messages. Use this if you remove a special class
-from the object before checking its coercion, but want the error message to
-match the original class.}
+\item{x_class}{(\code{character(1)}) The class name of the object being stabilized
+to use in error messages. Use this if you remove a special class from the
+object before checking its coercion, but want the error message to match
+the original class.}
 
 \item{allow_null}{(\code{logical(1)}) Is NULL an acceptable value?}
 

--- a/man/to_fn.Rd
+++ b/man/to_fn.Rd
@@ -46,11 +46,11 @@ to_function(
 )
 }
 \arguments{
-\item{x}{The argument to stabilize.}
+\item{x}{The object to stabilize.}
 
 \item{...}{Arguments passed to methods.}
 
-\item{x_arg}{(\code{character(1)}) The name of the argument being stabilized
+\item{x_arg}{(\code{character(1)}) The name of the object being stabilized
 to use in error messages. The automatic value will work in most cases, or
 pass it through from higher-level functions to make error messages clearer
 in unexported functions.}
@@ -58,7 +58,7 @@ in unexported functions.}
 \item{call}{\code{(environment)} The execution environment to mention as the
 source of error messages.}
 
-\item{x_class}{(\code{character(1)}) The class name of the argument being
+\item{x_class}{(\code{character(1)}) The class name of the object being
 stabilized to use in error messages. Use this if you remove a special class
 from the object before checking its coercion, but want the error message to
 match the original class.}

--- a/man/to_int.Rd
+++ b/man/to_int.Rd
@@ -45,11 +45,11 @@ to_integer(
 )
 }
 \arguments{
-\item{x}{The argument to stabilize.}
+\item{x}{The object to stabilize.}
 
 \item{...}{Arguments passed to methods.}
 
-\item{x_arg}{(\code{character(1)}) The name of the argument being stabilized
+\item{x_arg}{(\code{character(1)}) The name of the object being stabilized
 to use in error messages. The automatic value will work in most cases, or
 pass it through from higher-level functions to make error messages clearer
 in unexported functions.}
@@ -57,7 +57,7 @@ in unexported functions.}
 \item{call}{\code{(environment)} The execution environment to mention as the
 source of error messages.}
 
-\item{x_class}{(\code{character(1)}) The class name of the argument being
+\item{x_class}{(\code{character(1)}) The class name of the object being
 stabilized to use in error messages. Use this if you remove a special class
 from the object before checking its coercion, but want the error message to
 match the original class.}

--- a/man/to_int.Rd
+++ b/man/to_int.Rd
@@ -49,26 +49,26 @@ to_integer(
 
 \item{...}{Arguments passed to methods.}
 
-\item{x_arg}{(\code{character(1)}) The name of the object being stabilized
-to use in error messages. The automatic value will work in most cases, or
-pass it through from higher-level functions to make error messages clearer
-in unexported functions.}
+\item{x_arg}{(\code{character(1)}) The name of the object being stabilized to use
+in error messages. The automatic value will work in most cases, or pass it
+through from higher-level functions to make error messages clearer in
+unexported functions.}
 
 \item{call}{\code{(environment)} The execution environment to mention as the
 source of error messages.}
 
-\item{x_class}{(\code{character(1)}) The class name of the object being
-stabilized to use in error messages. Use this if you remove a special class
-from the object before checking its coercion, but want the error message to
-match the original class.}
+\item{x_class}{(\code{character(1)}) The class name of the object being stabilized
+to use in error messages. Use this if you remove a special class from the
+object before checking its coercion, but want the error message to match
+the original class.}
 
 \item{allow_null}{(\code{logical(1)}) Is NULL an acceptable value?}
 
-\item{coerce_character}{(\code{logical(1)}) Should character vectors such as
-"1" and "2.0" be considered numeric-ish?}
+\item{coerce_character}{(\code{logical(1)}) Should character vectors such as "1"
+and "2.0" be considered numeric-ish?}
 
-\item{coerce_factor}{(\code{logical(1)}) Should factors with values such as
-"1" and "2.0" be considered numeric-ish? Note that this package uses the
+\item{coerce_factor}{(\code{logical(1)}) Should factors with values such as "1"
+and "2.0" be considered numeric-ish? Note that this package uses the
 character value from the factor, while \code{\link[=as.integer]{as.integer()}} and \code{\link[=as.double]{as.double()}} use
 the integer index of the factor.}
 }

--- a/man/to_int_scalar.Rd
+++ b/man/to_int_scalar.Rd
@@ -26,7 +26,7 @@ to_integer_scalar(
 )
 }
 \arguments{
-\item{x}{The argument to stabilize.}
+\item{x}{The object to stabilize.}
 
 \item{...}{Arguments passed to methods.}
 
@@ -35,7 +35,7 @@ to_integer_scalar(
 \item{allow_zero_length}{(\code{logical(1)}) Are zero-length vectors
 acceptable?}
 
-\item{x_arg}{(\code{character(1)}) The name of the argument being stabilized
+\item{x_arg}{(\code{character(1)}) The name of the object being stabilized
 to use in error messages. The automatic value will work in most cases, or
 pass it through from higher-level functions to make error messages clearer
 in unexported functions.}
@@ -43,7 +43,7 @@ in unexported functions.}
 \item{call}{\code{(environment)} The execution environment to mention as the
 source of error messages.}
 
-\item{x_class}{(\code{character(1)}) The class name of the argument being
+\item{x_class}{(\code{character(1)}) The class name of the object being
 stabilized to use in error messages. Use this if you remove a special class
 from the object before checking its coercion, but want the error message to
 match the original class.}

--- a/man/to_int_scalar.Rd
+++ b/man/to_int_scalar.Rd
@@ -32,21 +32,20 @@ to_integer_scalar(
 
 \item{allow_null}{(\code{logical(1)}) Is NULL an acceptable value?}
 
-\item{allow_zero_length}{(\code{logical(1)}) Are zero-length vectors
-acceptable?}
+\item{allow_zero_length}{(\code{logical(1)}) Are zero-length vectors acceptable?}
 
-\item{x_arg}{(\code{character(1)}) The name of the object being stabilized
-to use in error messages. The automatic value will work in most cases, or
-pass it through from higher-level functions to make error messages clearer
-in unexported functions.}
+\item{x_arg}{(\code{character(1)}) The name of the object being stabilized to use
+in error messages. The automatic value will work in most cases, or pass it
+through from higher-level functions to make error messages clearer in
+unexported functions.}
 
 \item{call}{\code{(environment)} The execution environment to mention as the
 source of error messages.}
 
-\item{x_class}{(\code{character(1)}) The class name of the object being
-stabilized to use in error messages. Use this if you remove a special class
-from the object before checking its coercion, but want the error message to
-match the original class.}
+\item{x_class}{(\code{character(1)}) The class name of the object being stabilized
+to use in error messages. Use this if you remove a special class from the
+object before checking its coercion, but want the error message to match
+the original class.}
 }
 \value{
 The input as a length-1 integer vector.

--- a/man/to_lgl.Rd
+++ b/man/to_lgl.Rd
@@ -29,18 +29,18 @@ to_logical(
 
 \item{...}{Arguments passed to methods.}
 
-\item{x_arg}{(\code{character(1)}) The name of the object being stabilized
-to use in error messages. The automatic value will work in most cases, or
-pass it through from higher-level functions to make error messages clearer
-in unexported functions.}
+\item{x_arg}{(\code{character(1)}) The name of the object being stabilized to use
+in error messages. The automatic value will work in most cases, or pass it
+through from higher-level functions to make error messages clearer in
+unexported functions.}
 
 \item{call}{\code{(environment)} The execution environment to mention as the
 source of error messages.}
 
-\item{x_class}{(\code{character(1)}) The class name of the object being
-stabilized to use in error messages. Use this if you remove a special class
-from the object before checking its coercion, but want the error message to
-match the original class.}
+\item{x_class}{(\code{character(1)}) The class name of the object being stabilized
+to use in error messages. Use this if you remove a special class from the
+object before checking its coercion, but want the error message to match
+the original class.}
 
 \item{allow_null}{(\code{logical(1)}) Is NULL an acceptable value?}
 }

--- a/man/to_lgl.Rd
+++ b/man/to_lgl.Rd
@@ -25,11 +25,11 @@ to_logical(
 \method{to_lgl}{`NULL`}(x, ..., allow_null = TRUE, x_arg = caller_arg(x), call = caller_env())
 }
 \arguments{
-\item{x}{The argument to stabilize.}
+\item{x}{The object to stabilize.}
 
 \item{...}{Arguments passed to methods.}
 
-\item{x_arg}{(\code{character(1)}) The name of the argument being stabilized
+\item{x_arg}{(\code{character(1)}) The name of the object being stabilized
 to use in error messages. The automatic value will work in most cases, or
 pass it through from higher-level functions to make error messages clearer
 in unexported functions.}
@@ -37,7 +37,7 @@ in unexported functions.}
 \item{call}{\code{(environment)} The execution environment to mention as the
 source of error messages.}
 
-\item{x_class}{(\code{character(1)}) The class name of the argument being
+\item{x_class}{(\code{character(1)}) The class name of the object being
 stabilized to use in error messages. Use this if you remove a special class
 from the object before checking its coercion, but want the error message to
 match the original class.}

--- a/man/to_lgl_scalar.Rd
+++ b/man/to_lgl_scalar.Rd
@@ -32,21 +32,20 @@ to_logical_scalar(
 
 \item{allow_null}{(\code{logical(1)}) Is NULL an acceptable value?}
 
-\item{allow_zero_length}{(\code{logical(1)}) Are zero-length vectors
-acceptable?}
+\item{allow_zero_length}{(\code{logical(1)}) Are zero-length vectors acceptable?}
 
-\item{x_arg}{(\code{character(1)}) The name of the object being stabilized
-to use in error messages. The automatic value will work in most cases, or
-pass it through from higher-level functions to make error messages clearer
-in unexported functions.}
+\item{x_arg}{(\code{character(1)}) The name of the object being stabilized to use
+in error messages. The automatic value will work in most cases, or pass it
+through from higher-level functions to make error messages clearer in
+unexported functions.}
 
 \item{call}{\code{(environment)} The execution environment to mention as the
 source of error messages.}
 
-\item{x_class}{(\code{character(1)}) The class name of the object being
-stabilized to use in error messages. Use this if you remove a special class
-from the object before checking its coercion, but want the error message to
-match the original class.}
+\item{x_class}{(\code{character(1)}) The class name of the object being stabilized
+to use in error messages. Use this if you remove a special class from the
+object before checking its coercion, but want the error message to match
+the original class.}
 }
 \value{
 The input as a length-1 logical vector.

--- a/man/to_lgl_scalar.Rd
+++ b/man/to_lgl_scalar.Rd
@@ -26,7 +26,7 @@ to_logical_scalar(
 )
 }
 \arguments{
-\item{x}{The argument to stabilize.}
+\item{x}{The object to stabilize.}
 
 \item{...}{Arguments passed to methods.}
 
@@ -35,7 +35,7 @@ to_logical_scalar(
 \item{allow_zero_length}{(\code{logical(1)}) Are zero-length vectors
 acceptable?}
 
-\item{x_arg}{(\code{character(1)}) The name of the argument being stabilized
+\item{x_arg}{(\code{character(1)}) The name of the object being stabilized
 to use in error messages. The automatic value will work in most cases, or
 pass it through from higher-level functions to make error messages clearer
 in unexported functions.}
@@ -43,7 +43,7 @@ in unexported functions.}
 \item{call}{\code{(environment)} The execution environment to mention as the
 source of error messages.}
 
-\item{x_class}{(\code{character(1)}) The class name of the argument being
+\item{x_class}{(\code{character(1)}) The class name of the object being
 stabilized to use in error messages. Use this if you remove a special class
 from the object before checking its coercion, but want the error message to
 match the original class.}

--- a/man/to_lst.Rd
+++ b/man/to_lst.Rd
@@ -7,7 +7,7 @@
 \alias{to_lst.default}
 \alias{to_lst.NULL}
 \alias{to_lst.function}
-\title{Ensure a list argument meets expectations}
+\title{Ensure a list meets expectations}
 \usage{
 to_lst(x, ..., x_arg = caller_arg(x), call = caller_env())
 
@@ -28,11 +28,11 @@ to_list(x, ..., x_arg = caller_arg(x), call = caller_env())
 )
 }
 \arguments{
-\item{x}{The argument to stabilize.}
+\item{x}{The object to stabilize.}
 
 \item{...}{Arguments passed to \code{\link[base:as.list]{base::as.list()}} or other methods.}
 
-\item{x_arg}{(\code{character(1)}) The name of the argument being stabilized
+\item{x_arg}{(\code{character(1)}) The name of the object being stabilized
 to use in error messages. The automatic value will work in most cases, or
 pass it through from higher-level functions to make error messages clearer
 in unexported functions.}
@@ -45,10 +45,10 @@ source of error messages.}
 \item{coerce_function}{(\code{logical(1)}) Should functions be coerced?}
 }
 \value{
-The argument as a list.
+The object as a list.
 }
 \description{
-\code{to_lst()} checks whether an argument can be coerced to a list without losing
+\code{to_lst()} checks whether an object can be coerced to a list without losing
 information, returning it silently if so. Otherwise an informative error
 message is signaled. \code{to_list()} is a synonym of \code{to_lst()}.
 }

--- a/man/to_lst.Rd
+++ b/man/to_lst.Rd
@@ -32,10 +32,10 @@ to_list(x, ..., x_arg = caller_arg(x), call = caller_env())
 
 \item{...}{Arguments passed to \code{\link[base:as.list]{base::as.list()}} or other methods.}
 
-\item{x_arg}{(\code{character(1)}) The name of the object being stabilized
-to use in error messages. The automatic value will work in most cases, or
-pass it through from higher-level functions to make error messages clearer
-in unexported functions.}
+\item{x_arg}{(\code{character(1)}) The name of the object being stabilized to use
+in error messages. The automatic value will work in most cases, or pass it
+through from higher-level functions to make error messages clearer in
+unexported functions.}
 
 \item{call}{\code{(environment)} The execution environment to mention as the
 source of error messages.}


### PR DESCRIPTION
Closes #323

Reworded documentation (roxygen comments in `R/`, `README.Rmd`, and `DESCRIPTION`) to say "object" instead of "argument" where the docs describe the value being validated/coerced by stbl, reflecting that the package now handles more than just function arguments.

Left "argument" as-is where it genuinely refers to a real R function argument, e.g.:
- `@param ... Arguments passed to methods.`
- `regex`, `to_na`, `definition_env` parameter references
- the `vignettes/stbl.Rmd` walkthrough, which specifically validates the arguments of a `register_user()` example function
- `specify_cls.R`, which is about arguments of generated/constructed functions

No behavior changes. `devtools::test()` and `devtools::check(error_on = "warning")` both pass with no new warnings/errors/notes. Per the issue, no NEWS bullet was added and no tests were changed.