### PR TITLE
Include failing values alongside locations in error messages (#332)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,7 @@
 ## New features
 
 * Errors raised for element-wise failures now carry an integer `locations` element on the condition object, giving the positions in the input that failed the check. Handlers can read these positions via `cnd$locations` (#274).
+* Errors raised for incompatible-value coercion failures (e.g. `to_dbl(c("1", "b"))`) now also carry a `values` element on the condition object, giving the values that failed to coerce, and the message includes a "Values:" bullet alongside "Locations:" (#332).
 * New function `ignore_stbl_error()` silently catches a `{stbl}` error with the specified `subclass` and returns `NULL`, allowing callers to suppress expected validation failures (#178).
 * New function `replace_stbl_error()` catches a `{stbl}` error with the specified `subclass` and replaces its message with a custom one. An optional `additional_class` argument prepends extra classes to the error class list (#178).
 * New function `stabilize_any_of()` validates `x` by trying each unnamed stabilizer function in `...` in order, returning the first successful result. If all functions fail, an informative error combining the individual failure messages is thrown. New function `to_any_of()` works analogously, accepting type prototypes (e.g. `integer()`, `character()`) in `...` and dispatching to [to()] (#215, #285).

--- a/R/aaa-conditions.R
+++ b/R/aaa-conditions.R
@@ -194,6 +194,7 @@ rlang::caller_env
 #' @inherit .shared-return-conditions return
 #' @keywords internal
 .stop_incompatible <- function(
+  x,
   x_class,
   to,
   failures,
@@ -205,18 +206,22 @@ rlang::caller_env
 ) {
   to_class <- object_type(to)
   locations <- which(failures)
+  values <- x[locations]
+  value_chrs <- as.character(values)
   .stop_must(
     msg = "{.cls {x_class}} must be coercible to {.cls {to_class}}",
     x_arg = x_arg,
     additional_msg = c(
       x = "Can't convert some values due to {due_to}.",
-      "*" = "Locations: {locations}"
+      "*" = "Locations: {locations}",
+      "*" = "Values: {.val {value_chrs}}"
     ),
     call = call,
     subclass = c("incompatible_values", to_class),
     message_env = rlang::current_env(),
     parent = parent,
     locations = locations,
+    values = values,
     ...
   )
 }

--- a/R/check.R
+++ b/R/check.R
@@ -238,9 +238,18 @@
 #' @inheritParams .stop_incompatible
 #' @inherit .shared-return-conditions return
 #' @keywords internal
-.check_cast_failures <- function(failures, x_class, to, due_to, x_arg, call) {
+.check_cast_failures <- function(
+  x,
+  failures,
+  x_class,
+  to,
+  due_to,
+  x_arg,
+  call
+) {
   if (any(failures)) {
     .stop_incompatible(
+      x = x,
       x_class = x_class,
       to = to,
       failures = failures,

--- a/R/cls_unexported.R
+++ b/R/cls_unexported.R
@@ -215,6 +215,7 @@
   x_na <- is.na(x)
   failures <- (cast != x & !x_na) | xor(x_na, is.na(cast))
   .check_cast_failures(
+    x,
     failures,
     x_class,
     to_type_obj,
@@ -233,8 +234,9 @@
 #' @inheritParams .stop_incompatible
 #' @inherit .shared-return-conditions return
 #' @keywords internal
-.check_lst_failures <- function(valid, to, x_class, x_arg, call) {
+.check_lst_failures <- function(x, valid, to, x_class, x_arg, call) {
   .check_cast_failures(
+    x,
     !valid,
     x_class,
     to,

--- a/R/to_chr.R
+++ b/R/to_chr.R
@@ -126,7 +126,7 @@ to_character <- to_chr
   x_class = object_type(x)
 ) {
   res <- .Call(stbl_lst_to_chr, x)
-  .check_lst_failures(res[["valid"]], character(), x_class, x_arg, call)
+  .check_lst_failures(x, res[["valid"]], character(), x_class, x_arg, call)
   res[["result"]]
 }
 

--- a/R/to_date.R
+++ b/R/to_date.R
@@ -72,6 +72,7 @@ to_date.character <- function(
   parsed <- as.Date(x, format = "%Y-%m-%d")
   failures <- not_na & (!well_shaped | is.na(parsed))
   .check_cast_failures(
+    x,
     failures,
     x_class,
     .date_type_obj(),

--- a/R/to_dbl.R
+++ b/R/to_dbl.R
@@ -58,7 +58,7 @@ to_dbl.list <- function(
   x_class = object_type(x)
 ) {
   res <- .Call(stbl_lst_to_dbl, x)
-  .check_lst_failures(res[["valid"]], double(), x_class, x_arg, call)
+  .check_lst_failures(x, res[["valid"]], double(), x_class, x_arg, call)
   res[["result"]]
 }
 
@@ -89,6 +89,7 @@ to_dbl.character <- function(
   if (coerce_character) {
     res <- .Call(stbl_chr_to_dbl, x)
     .check_cast_failures(
+      x,
       !res[["valid"]],
       x_class,
       double(),
@@ -120,6 +121,7 @@ to_dbl.factor <- function(
   if (coerce_factor) {
     res <- .Call(stbl_fct_to_dbl, x)
     .check_cast_failures(
+      x,
       !res[["valid"]],
       x_class,
       double(),
@@ -147,6 +149,7 @@ to_dbl.complex <- function(
 ) {
   res <- .Call(stbl_cpx_to_dbl, x)
   .check_cast_failures(
+    x,
     !res[["valid"]],
     x_class,
     double(),

--- a/R/to_dttm.R
+++ b/R/to_dttm.R
@@ -96,6 +96,7 @@ to_dttm.character <- function(
   }
   failures <- not_na & (!well_shaped | is.na(parsed))
   .check_cast_failures(
+    x,
     failures,
     x_class,
     .datetime_type_obj(),

--- a/R/to_dur.R
+++ b/R/to_dur.R
@@ -140,6 +140,7 @@ to_dur.character <- function(
 
   failures <- not_na & !well_shaped
   .check_cast_failures(
+    x,
     failures,
     x_class,
     .duration_type_obj(),

--- a/R/to_fct.R
+++ b/R/to_fct.R
@@ -115,7 +115,7 @@ to_fct.list <- function(
   x_class = object_type(x)
 ) {
   res <- .Call(stbl_lst_to_fct, x)
-  .check_lst_failures(res[["valid"]], factor(), x_class, x_arg, call)
+  .check_lst_failures(x, res[["valid"]], factor(), x_class, x_arg, call)
   .coerce_fct_levels(res[["result"]], levels, to_na, x_arg, call)
 }
 

--- a/R/to_int.R
+++ b/R/to_int.R
@@ -59,7 +59,7 @@ to_int.list <- function(
   x_class = object_type(x)
 ) {
   res <- .Call(stbl_lst_to_int, x)
-  .check_lst_failures(res[["valid"]], integer(), x_class, x_arg, call)
+  .check_lst_failures(x, res[["valid"]], integer(), x_class, x_arg, call)
   res[["result"]]
 }
 
@@ -72,7 +72,7 @@ to_int.double <- function(
   x_class = object_type(x)
 ) {
   res <- .Call(stbl_dbl_to_int, x)
-  .check_dbl_to_int_failures(res, x_class, x_arg, call)
+  .check_dbl_to_int_failures(x, res, x_class, x_arg, call)
   res[["result"]]
 }
 
@@ -97,7 +97,7 @@ to_int.character <- function(
   )
   if (coerce_character) {
     res <- .Call(stbl_chr_to_int, x)
-    .check_chr_to_int_failures(res, x_class, x_arg, call)
+    .check_chr_to_int_failures(x, res, x_class, x_arg, call)
     return(res[["result"]])
   }
   .stop_cant_coerce(
@@ -121,7 +121,7 @@ to_int.factor <- function(
   coerce_factor <- to_lgl_scalar(coerce_factor, call = call)
   if (coerce_factor) {
     res <- .Call(stbl_fct_to_int, x)
-    .check_chr_to_int_failures(res, x_class, x_arg, call)
+    .check_chr_to_int_failures(x, res, x_class, x_arg, call)
     return(res[["result"]])
   }
   .stop_cant_coerce(
@@ -141,7 +141,7 @@ to_int.complex <- function(
   x_class = object_type(x)
 ) {
   res <- .Call(stbl_cpx_to_int, x)
-  .check_cpx_to_int_failures(res, x_class, x_arg, call)
+  .check_cpx_to_int_failures(x, res, x_class, x_arg, call)
   return(res[["result"]])
 }
 
@@ -198,13 +198,14 @@ to_integer_scalar <- to_int_scalar
 #' @inheritParams .shared-params
 #' @inherit .shared-return-conditions return
 #' @keywords internal
-.check_chr_to_int_failures <- function(res, x_class, x_arg, call) {
+.check_chr_to_int_failures <- function(x, res, x_class, x_arg, call) {
   non_number <- res[["non_number"]]
   bad_precision <- res[["bad_precision"]]
   if (!any(non_number) && !any(bad_precision)) {
     return(invisible(NULL))
   }
   .check_cast_failures(
+    x,
     non_number,
     x_class,
     integer(),
@@ -213,6 +214,7 @@ to_integer_scalar <- to_int_scalar
     call
   )
   .stop_incompatible(
+    x,
     x_class,
     integer(),
     bad_precision,
@@ -229,12 +231,13 @@ to_integer_scalar <- to_int_scalar
 #' @inheritParams .shared-params
 #' @inherit .shared-return-conditions return
 #' @keywords internal
-.check_dbl_to_int_failures <- function(res, x_class, x_arg, call) {
+.check_dbl_to_int_failures <- function(x, res, x_class, x_arg, call) {
   bad_precision <- res[["bad_precision"]]
   if (!any(bad_precision)) {
     return(invisible(NULL))
   }
   .stop_incompatible(
+    x,
     x_class,
     integer(),
     bad_precision,
@@ -251,13 +254,14 @@ to_integer_scalar <- to_int_scalar
 #' @inheritParams .shared-params
 #' @inherit .shared-return-conditions return
 #' @keywords internal
-.check_cpx_to_int_failures <- function(res, x_class, x_arg, call) {
+.check_cpx_to_int_failures <- function(x, res, x_class, x_arg, call) {
   non_number <- res[["non_number"]]
   bad_precision <- res[["bad_precision"]]
   if (!any(non_number) && !any(bad_precision)) {
     return(invisible(NULL))
   }
   .check_cast_failures(
+    x,
     non_number,
     x_class,
     integer(),
@@ -266,6 +270,7 @@ to_integer_scalar <- to_int_scalar
     call
   )
   .stop_incompatible(
+    x,
     x_class,
     integer(),
     bad_precision,

--- a/R/to_lgl.R
+++ b/R/to_lgl.R
@@ -66,6 +66,7 @@ to_lgl.character <- function(
   res <- .Call(stbl_chr_to_lgl, x)
   failures <- !res[["valid"]]
   .check_cast_failures(
+    x,
     failures,
     x_class,
     logical(),
@@ -88,6 +89,7 @@ to_lgl.factor <- function(
   res <- .Call(stbl_fct_to_lgl, x)
   failures <- !res[["valid"]]
   .check_cast_failures(
+    x,
     failures,
     x_class,
     logical(),
@@ -107,7 +109,7 @@ to_lgl.list <- function(
   x_class = object_type(x)
 ) {
   res <- .Call(stbl_lst_to_lgl, x)
-  .check_lst_failures(res[["valid"]], logical(), x_class, x_arg, call)
+  .check_lst_failures(x, res[["valid"]], logical(), x_class, x_arg, call)
   res[["result"]]
 }
 

--- a/R/to_time.R
+++ b/R/to_time.R
@@ -82,6 +82,7 @@ to_time.character <- function(
   }
   failures <- not_na & (!well_shaped | is.na(utc_seconds))
   .check_cast_failures(
+    x,
     failures,
     x_class,
     .time_type_obj(),
@@ -167,6 +168,7 @@ to_time.numeric <- function(
   # doesn't unambiguously resolve to a time of day.
   failures <- !is.na(x) & (x < 0 | x >= 86400)
   .check_cast_failures(
+    x,
     failures,
     x_class,
     .time_type_obj(),

--- a/man/dot-check_cast_failures.Rd
+++ b/man/dot-check_cast_failures.Rd
@@ -4,9 +4,11 @@
 \alias{.check_cast_failures}
 \title{Check for coercion failures and stop if any are found}
 \usage{
-.check_cast_failures(failures, x_class, to, due_to, x_arg, call)
+.check_cast_failures(x, failures, x_class, to, due_to, x_arg, call)
 }
 \arguments{
+\item{x}{The object to stabilize.}
+
 \item{failures}{\code{(logical)} A logical vector where \code{TRUE} indicates a
 coercion failure.}
 

--- a/man/dot-check_chr_to_int_failures.Rd
+++ b/man/dot-check_chr_to_int_failures.Rd
@@ -4,9 +4,11 @@
 \alias{.check_chr_to_int_failures}
 \title{Check for character to integer coercion failures}
 \usage{
-.check_chr_to_int_failures(res, x_class, x_arg, call)
+.check_chr_to_int_failures(x, res, x_class, x_arg, call)
 }
 \arguments{
+\item{x}{The object to stabilize.}
+
 \item{res}{A list returned by \code{stbl_chr_to_int}, with elements
 \code{result}, \code{non_number}, and \code{bad_precision}.}
 

--- a/man/dot-check_cpx_to_int_failures.Rd
+++ b/man/dot-check_cpx_to_int_failures.Rd
@@ -4,9 +4,11 @@
 \alias{.check_cpx_to_int_failures}
 \title{Check for complex to integer coercion failures}
 \usage{
-.check_cpx_to_int_failures(res, x_class, x_arg, call)
+.check_cpx_to_int_failures(x, res, x_class, x_arg, call)
 }
 \arguments{
+\item{x}{The object to stabilize.}
+
 \item{res}{A list returned by \code{stbl_cpx_to_int}, with elements
 \code{result}, \code{non_number}, and \code{bad_precision}.}
 

--- a/man/dot-check_dbl_to_int_failures.Rd
+++ b/man/dot-check_dbl_to_int_failures.Rd
@@ -4,9 +4,11 @@
 \alias{.check_dbl_to_int_failures}
 \title{Check for double to integer coercion failures}
 \usage{
-.check_dbl_to_int_failures(res, x_class, x_arg, call)
+.check_dbl_to_int_failures(x, res, x_class, x_arg, call)
 }
 \arguments{
+\item{x}{The object to stabilize.}
+
 \item{res}{A list returned by \code{stbl_dbl_to_int}, with elements
 \code{result} and \code{bad_precision}.}
 

--- a/man/dot-check_lst_failures.Rd
+++ b/man/dot-check_lst_failures.Rd
@@ -4,9 +4,11 @@
 \alias{.check_lst_failures}
 \title{Check list coercion failures and error if any element could not be converted}
 \usage{
-.check_lst_failures(valid, to, x_class, x_arg, call)
+.check_lst_failures(x, valid, to, x_class, x_arg, call)
 }
 \arguments{
+\item{x}{The object to stabilize.}
+
 \item{valid}{\code{(logical)} The \code{valid} vector returned by a \verb{stbl_lst_to_*}
 C routine.}
 

--- a/man/dot-stop_incompatible.Rd
+++ b/man/dot-stop_incompatible.Rd
@@ -5,6 +5,7 @@
 \title{Abort with an "incompatible type" message}
 \usage{
 .stop_incompatible(
+  x,
   x_class,
   to,
   failures,
@@ -16,6 +17,8 @@
 )
 }
 \arguments{
+\item{x}{The object to stabilize.}
+
 \item{x_class}{(\code{character(1)}) The class name of the object being stabilized
 to use in error messages. Use this if you remove a special class from the
 object before checking its coercion, but want the error message to match

--- a/pkgdown/assets/slides/everyday.html
+++ b/pkgdown/assets/slides/everyday.html
@@ -1440,7 +1440,8 @@ introduced by coercion</code></pre>
 <pre><code>Error in `compile_order_df()`:
 ! `prices` &lt;character&gt; must be coercible to &lt;double&gt;
 ✖ Can&#39;t convert some values due to incompatible values.
-• Locations: 2</code></pre>
+• Locations: 2
+• Values: &quot;b&quot;</code></pre>
 </div>
 </div>
 <aside class="notes">

--- a/pkgdown/assets/slides/everyday.html
+++ b/pkgdown/assets/slides/everyday.html
@@ -1444,19 +1444,6 @@ introduced by coercion</code></pre>
 • Values: &quot;b&quot;</code></pre>
 </div>
 </div>
-<aside class="notes">
-<p>I’m actually updating this error message, you’ll see the new version on the next slide.</p>
-<style type="text/css">
-span.MJX_Assistive_MathML {
-position:absolute!important;
-clip: rect(1px, 1px, 1px, 1px);
-padding: 1px 0 0 0!important;
-border: 0!important;
-height: 1px!important;
-width: 1px!important;
-overflow: hidden!important;
-display:block!important;
-}</style></aside>
 </section>
 <section id="tell-users-how-to-fix-mistakes-4" class="slide level2">
 <h2>Tell users how to fix mistakes</h2>

--- a/pkgdown/menus/slides/everyday.qmd
+++ b/pkgdown/menus/slides/everyday.qmd
@@ -391,10 +391,6 @@ compile_order_df(
 )
 ```
 
-::: notes
-I'm actually updating this error message, you'll see the new version on the next slide.
-:::
-
 ## Tell users how to fix mistakes
 
 ```{r}

--- a/tests/testthat/_snaps/aaa-conditions.md
+++ b/tests/testthat/_snaps/aaa-conditions.md
@@ -73,27 +73,29 @@
       Error:
       ! `my_arg` must not be <NULL>.
 
-# .stop_incompatible() throws the expected error (#95, #310)
+# .stop_incompatible() throws the expected error (#95, #310, #332)
 
     Code
-      .stop_incompatible("character", integer(), c(FALSE, TRUE, FALSE, TRUE),
-      "some reason", "my_arg", rlang::current_env())
+      .stop_incompatible(c("a", "b", "c", "d"), "character", integer(), c(FALSE, TRUE,
+        FALSE, TRUE), "some reason", "my_arg", rlang::current_env())
     Condition <stbl-error-incompatible_values-integer>
       Error:
       ! `my_arg` <character> must be coercible to <integer>
       x Can't convert some values due to some reason.
       * Locations: 2 and 4
+      * Values: "b" and "d"
 
-# .stop_incompatible() passes dots (#95, #310)
+# .stop_incompatible() passes dots (#95, #310, #332)
 
     Code
-      .stop_incompatible("character", integer(), c(FALSE, TRUE, FALSE, TRUE),
-      "some reason", "my_arg", rlang::current_env(), .internal = TRUE)
+      .stop_incompatible(c("a", "b", "c", "d"), "character", integer(), c(FALSE, TRUE,
+        FALSE, TRUE), "some reason", "my_arg", rlang::current_env(), .internal = TRUE)
     Condition <stbl-error-incompatible_values-integer>
       Error:
       ! `my_arg` <character> must be coercible to <integer>
       x Can't convert some values due to some reason.
       * Locations: 2 and 4
+      * Values: "b" and "d"
       i This is an internal error that was detected in the stbl package.
         Please report it at <https://github.com/wranglezone/stbl/issues> with a reprex (<https://tidyverse.org/help/>) and the full backtrace.
 

--- a/tests/testthat/_snaps/check.md
+++ b/tests/testthat/_snaps/check.md
@@ -73,16 +73,17 @@
       * `2` = 2
       * `1` = 1
 
-# .check_cast_failures() works (#310)
+# .check_cast_failures() works (#310, #332)
 
     Code
-      .check_cast_failures(failures = failures, x_class = "character", to = logical(),
-      due_to = "incompatible values", x_arg = "test_arg", call = rlang::current_env())
+      .check_cast_failures(x = c("a", "b", "c", "d"), failures = failures, x_class = "character",
+      to = logical(), due_to = "incompatible values", x_arg = "test_arg", call = rlang::current_env())
     Condition <stbl-error-incompatible_values-logical>
       Error:
       ! `test_arg` <character> must be coercible to <logical>
       x Can't convert some values due to incompatible values.
       * Locations: 2 and 4
+      * Values: "b" and "d"
 
 # .check_all_named() works (#203)
 

--- a/tests/testthat/_snaps/stabilize_date.md
+++ b/tests/testthat/_snaps/stabilize_date.md
@@ -108,6 +108,7 @@
       ! `"11/13/2018"` <character> must be coercible to <date>
       x Can't convert some values due to invalid or ambiguous date format.
       * Locations: 1
+      * Values: "11/13/2018"
 
 # stabilize_date_scalar() respects allow_null (#104)
 

--- a/tests/testthat/_snaps/stabilize_df.md
+++ b/tests/testthat/_snaps/stabilize_df.md
@@ -47,6 +47,7 @@
       ! `data.frame(count = "not-an-int")[["count"]]` <character> must be coercible to <integer>
       x Can't convert some values due to incompatible values.
       * Locations: 1
+      * Values: "not-an-int"
 
 # stabilize_df() errors on extra columns by default (#142)
 
@@ -67,6 +68,7 @@
       ! `data.frame(a = 1L, b = "not-int")[["b"]]` <character> must be coercible to <integer>
       x Can't convert some values due to incompatible values.
       * Locations: 1
+      * Values: "not-int"
 
 # stabilize_df() enforces .min_rows (snapshot) (#142)
 

--- a/tests/testthat/_snaps/stabilize_dttm.md
+++ b/tests/testthat/_snaps/stabilize_dttm.md
@@ -108,6 +108,7 @@
       ! `"2024-01-01 12:00:00"` <character> must be coercible to <datetime>
       x Can't convert some values due to invalid or ambiguous date-time format.
       * Locations: 1
+      * Values: "2024-01-01 12:00:00"
 
 # stabilize_dttm() rejects an unrecognized tz (#105)
 

--- a/tests/testthat/_snaps/stabilize_dur.md
+++ b/tests/testthat/_snaps/stabilize_dur.md
@@ -108,6 +108,7 @@
       ! `"P"` <character> must be coercible to <duration>
       x Can't convert some values due to invalid or ambiguous duration format.
       * Locations: 1
+      * Values: "P"
 
 # stabilize_dur_scalar() respects allow_null (#295)
 

--- a/tests/testthat/_snaps/stabilize_lst.md
+++ b/tests/testthat/_snaps/stabilize_lst.md
@@ -39,6 +39,7 @@
       ! `list(count = "not-an-int")[["count"]]` <character> must be coercible to <integer>
       x Can't convert some values due to incompatible values.
       * Locations: 1
+      * Values: "not-an-int"
 
 # stabilize_lst() errors on extra named elements by default (#110)
 
@@ -76,6 +77,7 @@
       ! `.named` <character> must be coercible to <logical>
       x Can't convert some values due to incompatible values.
       * Locations: 1
+      * Values: "yes"
 
 # stabilize_lst() errors on unnamed elements by default (#110)
 
@@ -113,6 +115,7 @@
       ! `.unnamed` <character> must be coercible to <logical>
       x Can't convert some values due to incompatible values.
       * Locations: 1
+      * Values: "yes"
 
 # stabilize_lst() enforces .min_size (#110)
 

--- a/tests/testthat/_snaps/stabilize_time.md
+++ b/tests/testthat/_snaps/stabilize_time.md
@@ -108,6 +108,7 @@
       ! `"13:20:00"` <character> must be coercible to <time>
       x Can't convert some values due to invalid or ambiguous time format.
       * Locations: 1
+      * Values: "13:20:00"
 
 # stabilize_time_scalar() respects allow_null (#294)
 

--- a/tests/testthat/_snaps/to_chr.md
+++ b/tests/testthat/_snaps/to_chr.md
@@ -32,6 +32,7 @@
       ! `given` <list> must be coercible to <character>
       x Can't convert some values due to incompatible element types.
       * Locations: 1
+      * Values: "function (x, ...) UseMethod(\"mean\")"
 
 ---
 
@@ -42,6 +43,7 @@
       ! `val` <list> must be coercible to <character>
       x Can't convert some values due to incompatible element types.
       * Locations: 1
+      * Values: "function (x, ...) UseMethod(\"mean\")"
 
 ---
 
@@ -52,6 +54,7 @@
       ! `given` <list> must be coercible to <character>
       x Can't convert some values due to incompatible element types.
       * Locations: 2
+      * Values: "function (x, ...) UseMethod(\"mean\")"
 
 ---
 
@@ -62,6 +65,7 @@
       ! `val` <list> must be coercible to <character>
       x Can't convert some values due to incompatible element types.
       * Locations: 2
+      * Values: "function (x, ...) UseMethod(\"mean\")"
 
 ---
 
@@ -88,6 +92,7 @@
       ! `given` <list> must be coercible to <character>
       x Can't convert some values due to incompatible element types.
       * Locations: 2
+      * Values: "1:5"
 
 ---
 
@@ -98,6 +103,7 @@
       ! `val` <list> must be coercible to <character>
       x Can't convert some values due to incompatible element types.
       * Locations: 2
+      * Values: "1:5"
 
 # to_chr_scalar() errors for non-scalars (#22)
 
@@ -126,6 +132,7 @@
       ! `given` <list> must be coercible to <character>
       x Can't convert some values due to incompatible element types.
       * Locations: 1
+      * Values: "1:10"
 
 ---
 
@@ -136,6 +143,7 @@
       ! `val` <list> must be coercible to <character>
       x Can't convert some values due to incompatible element types.
       * Locations: 1
+      * Values: "1:10"
 
 # to_chr_scalar() respects allow_null (#22, #189)
 

--- a/tests/testthat/_snaps/to_date.md
+++ b/tests/testthat/_snaps/to_date.md
@@ -23,6 +23,7 @@
       ! `"11/13/2018"` <character> must be coercible to <date>
       x Can't convert some values due to invalid or ambiguous date format.
       * Locations: 1
+      * Values: "11/13/2018"
 
 ---
 
@@ -33,6 +34,7 @@
       ! `val` <character> must be coercible to <date>
       x Can't convert some values due to invalid or ambiguous date format.
       * Locations: 1
+      * Values: "11/13/2018"
 
 # to_date() rejects unparseable date strings (#104)
 
@@ -43,6 +45,7 @@
       ! `given` <character> must be coercible to <date>
       x Can't convert some values due to invalid or ambiguous date format.
       * Locations: 2
+      * Values: "not-a-date"
 
 # to_date() rejects impossible dates (#104)
 
@@ -53,6 +56,7 @@
       ! `"2024-02-30"` <character> must be coercible to <date>
       x Can't convert some values due to invalid or ambiguous date format.
       * Locations: 1
+      * Values: "2024-02-30"
 
 # to_date() errors informatively for bad factors (#104)
 
@@ -63,6 +67,7 @@
       ! `given` <factor> must be coercible to <date>
       x Can't convert some values due to invalid or ambiguous date format.
       * Locations: 2
+      * Values: "nope"
 
 # to_date_scalar() provides informative error messages (#104)
 

--- a/tests/testthat/_snaps/to_dbl.md
+++ b/tests/testthat/_snaps/to_dbl.md
@@ -39,6 +39,7 @@
       ! `given` <character> must be coercible to <double>
       x Can't convert some values due to incompatible values.
       * Locations: 2
+      * Values: "a"
 
 ---
 
@@ -49,6 +50,7 @@
       ! `val` <character> must be coercible to <double>
       x Can't convert some values due to incompatible values.
       * Locations: 2
+      * Values: "a"
 
 # to_dbl() errors informatively for bad complexes (#23, #310)
 
@@ -59,6 +61,7 @@
       ! `given` <complex> must be coercible to <double>
       x Can't convert some values due to non-zero complex components.
       * Locations: 1
+      * Values: "1.1+1i"
 
 ---
 
@@ -69,6 +72,7 @@
       ! `val` <complex> must be coercible to <double>
       x Can't convert some values due to non-zero complex components.
       * Locations: 1
+      * Values: "1.1+1i"
 
 # to_dbl() respects coerce_factor (#23)
 
@@ -95,6 +99,7 @@
       ! `given` <factor> must be coercible to <double>
       x Can't convert some values due to incompatible values.
       * Locations: 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, ..., 25, and 26
+      * Values: "a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m", "n", "o", "p", "q", "r", ..., "y", and "z"
 
 ---
 
@@ -105,6 +110,7 @@
       ! `val` <factor> must be coercible to <double>
       x Can't convert some values due to incompatible values.
       * Locations: 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, ..., 25, and 26
+      * Values: "a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m", "n", "o", "p", "q", "r", ..., "y", and "z"
 
 # to_dbl() works for lists (#128, #273, #310)
 
@@ -115,6 +121,7 @@
       ! `list(1.1, 1:5)` <list> must be coercible to <double>
       x Can't convert some values due to incompatible element types.
       * Locations: 2
+      * Values: "1:5"
 
 # to_dbl_scalar() provides informative error messages (#23)
 

--- a/tests/testthat/_snaps/to_dttm.md
+++ b/tests/testthat/_snaps/to_dttm.md
@@ -23,6 +23,7 @@
       ! `"2024-01-01 12:00:00"` <character> must be coercible to <datetime>
       x Can't convert some values due to invalid or ambiguous date-time format.
       * Locations: 1
+      * Values: "2024-01-01 12:00:00"
 
 ---
 
@@ -33,6 +34,7 @@
       ! `val` <character> must be coercible to <datetime>
       x Can't convert some values due to invalid or ambiguous date-time format.
       * Locations: 1
+      * Values: "2024-01-01 12:00:00"
 
 # to_dttm() rejects unparseable date-time strings (#105)
 
@@ -43,6 +45,7 @@
       ! `given` <character> must be coercible to <datetime>
       x Can't convert some values due to invalid or ambiguous date-time format.
       * Locations: 2
+      * Values: "not-a-datetime"
 
 # to_dttm() rejects impossible date-times (#105)
 
@@ -53,6 +56,7 @@
       ! `"2024-02-30T12:00:00Z"` <character> must be coercible to <datetime>
       x Can't convert some values due to invalid or ambiguous date-time format.
       * Locations: 1
+      * Values: "2024-02-30T12:00:00Z"
 
 ---
 
@@ -63,6 +67,7 @@
       ! `"2024-01-01T25:00:00Z"` <character> must be coercible to <datetime>
       x Can't convert some values due to invalid or ambiguous date-time format.
       * Locations: 1
+      * Values: "2024-01-01T25:00:00Z"
 
 # to_dttm() rejects an unrecognized tz (#105)
 
@@ -82,6 +87,7 @@
       ! `given` <factor> must be coercible to <datetime>
       x Can't convert some values due to invalid or ambiguous date-time format.
       * Locations: 2
+      * Values: "nope"
 
 # to_dttm_scalar() provides informative error messages (#105)
 

--- a/tests/testthat/_snaps/to_dur.md
+++ b/tests/testthat/_snaps/to_dur.md
@@ -23,6 +23,7 @@
       ! `"P"` <character> must be coercible to <duration>
       x Can't convert some values due to invalid or ambiguous duration format.
       * Locations: 1
+      * Values: "P"
 
 ---
 
@@ -33,6 +34,7 @@
       ! `"PT"` <character> must be coercible to <duration>
       x Can't convert some values due to invalid or ambiguous duration format.
       * Locations: 1
+      * Values: "PT"
 
 # to_dur() rejects mixing the week form with other units (#295)
 
@@ -43,6 +45,7 @@
       ! `"P1W2D"` <character> must be coercible to <duration>
       x Can't convert some values due to invalid or ambiguous duration format.
       * Locations: 1
+      * Values: "P1W2D"
 
 # to_dur() rejects fractional components (#295)
 
@@ -53,6 +56,7 @@
       ! `"P1.5D"` <character> must be coercible to <duration>
       x Can't convert some values due to invalid or ambiguous duration format.
       * Locations: 1
+      * Values: "P1.5D"
 
 # to_dur() rejects a negative sign (#295)
 
@@ -63,6 +67,7 @@
       ! `"-P1D"` <character> must be coercible to <duration>
       x Can't convert some values due to invalid or ambiguous duration format.
       * Locations: 1
+      * Values: "-P1D"
 
 # to_dur() rejects out-of-order components (#295)
 
@@ -73,6 +78,7 @@
       ! `"P1D1Y"` <character> must be coercible to <duration>
       x Can't convert some values due to invalid or ambiguous duration format.
       * Locations: 1
+      * Values: "P1D1Y"
 
 # to_dur() rejects lowercase durations (#295)
 
@@ -83,6 +89,7 @@
       ! `"p1y2m"` <character> must be coercible to <duration>
       x Can't convert some values due to invalid or ambiguous duration format.
       * Locations: 1
+      * Values: "p1y2m"
 
 # to_dur() rejects unparseable duration strings (#295)
 
@@ -93,6 +100,7 @@
       ! `given` <character> must be coercible to <duration>
       x Can't convert some values due to invalid or ambiguous duration format.
       * Locations: 2
+      * Values: "not-a-duration"
 
 ---
 
@@ -103,6 +111,7 @@
       ! `val` <character> must be coercible to <duration>
       x Can't convert some values due to invalid or ambiguous duration format.
       * Locations: 2
+      * Values: "not-a-duration"
 
 # to_dur() errors informatively for bad factors (#295)
 
@@ -113,6 +122,7 @@
       ! `given` <factor> must be coercible to <duration>
       x Can't convert some values due to invalid or ambiguous duration format.
       * Locations: 2
+      * Values: "nope"
 
 # to_dur_scalar() provides informative error messages (#295)
 

--- a/tests/testthat/_snaps/to_fct.md
+++ b/tests/testthat/_snaps/to_fct.md
@@ -45,6 +45,7 @@
       ! `list("a", 1:5)` <list> must be coercible to <factor>
       x Can't convert some values due to incompatible element types.
       * Locations: 2
+      * Values: "1:5"
 
 # to_fct() errors for things that can't be coerced (#62, #273, #310)
 
@@ -87,6 +88,7 @@
       ! `given` <list> must be coercible to <factor>
       x Can't convert some values due to incompatible element types.
       * Locations: 1 and 2
+      * Values: "1" and "1:5"
 
 ---
 
@@ -97,6 +99,7 @@
       ! `val` <list> must be coercible to <factor>
       x Can't convert some values due to incompatible element types.
       * Locations: 1 and 2
+      * Values: "1" and "1:5"
 
 # to_fct_scalar() provides informative error messages (#62)
 

--- a/tests/testthat/_snaps/to_int.md
+++ b/tests/testthat/_snaps/to_int.md
@@ -23,6 +23,7 @@
       ! `given` <double> must be coercible to <integer>
       x Can't convert some values due to loss of precision.
       * Locations: 4
+      * Values: "1.1"
 
 ---
 
@@ -33,6 +34,7 @@
       ! `val` <double> must be coercible to <integer>
       x Can't convert some values due to loss of precision.
       * Locations: 4
+      * Values: "1.1"
 
 ---
 
@@ -43,6 +45,7 @@
       ! `given` <double> must be coercible to <integer>
       x Can't convert some values due to loss of precision.
       * Locations: 4
+      * Values: "Inf"
 
 ---
 
@@ -53,6 +56,7 @@
       ! `val` <double> must be coercible to <integer>
       x Can't convert some values due to loss of precision.
       * Locations: 4
+      * Values: "Inf"
 
 # to_int() respects coerce_character (#14)
 
@@ -79,6 +83,7 @@
       ! `given` <character> must be coercible to <integer>
       x Can't convert some values due to loss of precision.
       * Locations: 4
+      * Values: "1.1"
 
 ---
 
@@ -89,6 +94,7 @@
       ! `val` <character> must be coercible to <integer>
       x Can't convert some values due to loss of precision.
       * Locations: 4
+      * Values: "1.1"
 
 ---
 
@@ -99,6 +105,7 @@
       ! `given` <character> must be coercible to <integer>
       x Can't convert some values due to incompatible values.
       * Locations: 4
+      * Values: "a"
 
 ---
 
@@ -109,6 +116,7 @@
       ! `val` <character> must be coercible to <integer>
       x Can't convert some values due to incompatible values.
       * Locations: 4
+      * Values: "a"
 
 # to_int() errors informatively for bad complexes (#2, #310)
 
@@ -119,6 +127,7 @@
       ! `given` <complex> must be coercible to <integer>
       x Can't convert some values due to non-zero complex components.
       * Locations: 4
+      * Values: "1+1i"
 
 ---
 
@@ -129,6 +138,7 @@
       ! `val` <complex> must be coercible to <integer>
       x Can't convert some values due to non-zero complex components.
       * Locations: 4
+      * Values: "1+1i"
 
 # to_int() errors for complexes that would lose precision (#noissue, #310)
 
@@ -139,6 +149,7 @@
       ! `given` <complex> must be coercible to <integer>
       x Can't convert some values due to loss of precision.
       * Locations: 4
+      * Values: "1.5+0i"
 
 ---
 
@@ -149,6 +160,7 @@
       ! `val` <complex> must be coercible to <integer>
       x Can't convert some values due to loss of precision.
       * Locations: 4
+      * Values: "1.5+0i"
 
 ---
 
@@ -159,6 +171,7 @@
       ! `given` <complex> must be coercible to <integer>
       x Can't convert some values due to loss of precision.
       * Locations: 4
+      * Values: "Inf+0i"
 
 ---
 
@@ -169,6 +182,7 @@
       ! `val` <complex> must be coercible to <integer>
       x Can't convert some values due to loss of precision.
       * Locations: 4
+      * Values: "Inf+0i"
 
 # to_int() respects coerce_factor (#14)
 
@@ -195,6 +209,7 @@
       ! `given` <factor> must be coercible to <integer>
       x Can't convert some values due to incompatible values.
       * Locations: 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, ..., 25, and 26
+      * Values: "a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m", "n", "o", "p", "q", "r", ..., "y", and "z"
 
 ---
 
@@ -205,6 +220,7 @@
       ! `val` <factor> must be coercible to <integer>
       x Can't convert some values due to incompatible values.
       * Locations: 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, ..., 25, and 26
+      * Values: "a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m", "n", "o", "p", "q", "r", ..., "y", and "z"
 
 # to_int() works for lists (#2, #273, #310)
 
@@ -215,6 +231,7 @@
       ! `list(1L, 1:5)` <list> must be coercible to <integer>
       x Can't convert some values due to incompatible element types.
       * Locations: 2
+      * Values: "1:5"
 
 # to_int_scalar() provides informative error messages (#12)
 

--- a/tests/testthat/_snaps/to_lgl.md
+++ b/tests/testthat/_snaps/to_lgl.md
@@ -23,6 +23,7 @@
       ! `letters` <character> must be coercible to <logical>
       x Can't convert some values due to incompatible values.
       * Locations: 1, 2, 3, 4, 5, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, ..., 25, and 26
+      * Values: "a", "b", "c", "d", "e", "g", "h", "i", "j", "k", "l", "m", "n", "o", "p", "q", "r", "s", ..., "y", and "z"
 
 ---
 
@@ -33,6 +34,7 @@
       ! `val` <character> must be coercible to <logical>
       x Can't convert some values due to incompatible values.
       * Locations: 1, 2, 3, 4, 5, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, ..., 25, and 26
+      * Values: "a", "b", "c", "d", "e", "g", "h", "i", "j", "k", "l", "m", "n", "o", "p", "q", "r", "s", ..., "y", and "z"
 
 # to_lgl errors for bad factors (#21, #310)
 
@@ -43,6 +45,7 @@
       ! `given` <factor> must be coercible to <logical>
       x Can't convert some values due to incompatible values.
       * Locations: 1, 2, 3, 4, 5, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, ..., 25, and 26
+      * Values: "a", "b", "c", "d", "e", "g", "h", "i", "j", "k", "l", "m", "n", "o", "p", "q", "r", "s", ..., "y", and "z"
 
 ---
 
@@ -53,6 +56,7 @@
       ! `val` <factor> must be coercible to <logical>
       x Can't convert some values due to incompatible values.
       * Locations: 1, 2, 3, 4, 5, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, ..., 25, and 26
+      * Values: "a", "b", "c", "d", "e", "g", "h", "i", "j", "k", "l", "m", "n", "o", "p", "q", "r", "s", ..., "y", and "z"
 
 # to_lgl() works for lists (#21, #273, #310)
 
@@ -63,6 +67,7 @@
       ! `list(TRUE, 1:5)` <list> must be coercible to <logical>
       x Can't convert some values due to incompatible element types.
       * Locations: 2
+      * Values: "1:5"
 
 # to_lgl() errors for other types (#21, #273, #310)
 
@@ -73,6 +78,7 @@
       ! `given` <list> must be coercible to <logical>
       x Can't convert some values due to incompatible element types.
       * Locations: 2
+      * Values: "1:10"
 
 ---
 
@@ -83,6 +89,7 @@
       ! `val` <list> must be coercible to <logical>
       x Can't convert some values due to incompatible element types.
       * Locations: 2
+      * Values: "1:10"
 
 ---
 
@@ -127,6 +134,7 @@
       ! `given` <character> must be coercible to <logical>
       x Can't convert some values due to incompatible values.
       * Locations: 1
+      * Values: "a"
 
 ---
 
@@ -137,6 +145,7 @@
       ! `val` <character> must be coercible to <logical>
       x Can't convert some values due to incompatible values.
       * Locations: 1
+      * Values: "a"
 
 # to_lgl_scalar() respects allow_null (#32, #189)
 

--- a/tests/testthat/_snaps/to_null.md
+++ b/tests/testthat/_snaps/to_null.md
@@ -31,6 +31,7 @@
       ! `allow_null` <character> must be coercible to <logical>
       x Can't convert some values due to incompatible values.
       * Locations: 1
+      * Values: "fish"
 
 ---
 
@@ -41,6 +42,7 @@
       ! `allow_null` <character> must be coercible to <logical>
       x Can't convert some values due to incompatible values.
       * Locations: 1
+      * Values: "fish"
 
 # .to_null() errors informatively for missing value (#129)
 

--- a/tests/testthat/_snaps/to_time.md
+++ b/tests/testthat/_snaps/to_time.md
@@ -23,6 +23,7 @@
       ! `"13:20:00"` <character> must be coercible to <time>
       x Can't convert some values due to invalid or ambiguous time format.
       * Locations: 1
+      * Values: "13:20:00"
 
 ---
 
@@ -33,6 +34,7 @@
       ! `val` <character> must be coercible to <time>
       x Can't convert some values due to invalid or ambiguous time format.
       * Locations: 1
+      * Values: "13:20:00"
 
 # to_time() rejects unparseable time strings (#294)
 
@@ -43,6 +45,7 @@
       ! `given` <character> must be coercible to <time>
       x Can't convert some values due to invalid or ambiguous time format.
       * Locations: 2
+      * Values: "not-a-time"
 
 # to_time() rejects impossible times (#294)
 
@@ -53,6 +56,7 @@
       ! `"25:00:00Z"` <character> must be coercible to <time>
       x Can't convert some values due to invalid or ambiguous time format.
       * Locations: 1
+      * Values: "25:00:00Z"
 
 ---
 
@@ -63,6 +67,7 @@
       ! `"13:60:00Z"` <character> must be coercible to <time>
       x Can't convert some values due to invalid or ambiguous time format.
       * Locations: 1
+      * Values: "13:60:00Z"
 
 # to_time() errors informatively for bad factors (#294)
 
@@ -73,6 +78,7 @@
       ! `given` <factor> must be coercible to <time>
       x Can't convert some values due to invalid or ambiguous time format.
       * Locations: 2
+      * Values: "nope"
 
 # to_time() rejects out-of-range numerics (#294)
 
@@ -83,6 +89,7 @@
       ! `-1` <double> must be coercible to <time>
       x Can't convert some values due to not a valid number of seconds since midnight (must be at least 0 and less than 86400).
       * Locations: 1
+      * Values: "-1"
 
 ---
 
@@ -93,6 +100,7 @@
       ! `86400` <double> must be coercible to <time>
       x Can't convert some values due to not a valid number of seconds since midnight (must be at least 0 and less than 86400).
       * Locations: 1
+      * Values: "86400"
 
 # to_time() rejects out-of-range difftime values (#294)
 
@@ -103,6 +111,7 @@
       ! `given` <difftime> must be coercible to <time>
       x Can't convert some values due to not a valid number of seconds since midnight (must be at least 0 and less than 86400).
       * Locations: 1
+      * Values: "90000"
 
 # to_time() rejects out-of-range hms values (#294)
 
@@ -113,6 +122,7 @@
       ! `given` <hms> must be coercible to <time>
       x Can't convert some values due to not a valid number of seconds since midnight (must be at least 0 and less than 86400).
       * Locations: 1
+      * Values: "90000"
 
 # to_time_scalar() provides informative error messages (#294)
 

--- a/tests/testthat/test-aaa-conditions.R
+++ b/tests/testthat/test-aaa-conditions.R
@@ -108,9 +108,10 @@ test_that(".stop_null() passes dots (#95)", {
   # about the messaging.
 })
 
-test_that(".stop_incompatible() throws the expected error (#95, #310)", {
+test_that(".stop_incompatible() throws the expected error (#95, #310, #332)", {
   expect_pkg_error_snapshot(
     .stop_incompatible(
+      c("a", "b", "c", "d"),
       "character",
       integer(),
       c(FALSE, TRUE, FALSE, TRUE),
@@ -124,9 +125,10 @@ test_that(".stop_incompatible() throws the expected error (#95, #310)", {
   )
 })
 
-test_that(".stop_incompatible() passes dots (#95, #310)", {
+test_that(".stop_incompatible() passes dots (#95, #310, #332)", {
   expect_pkg_error_snapshot(
     .stop_incompatible(
+      c("a", "b", "c", "d"),
       "character",
       integer(),
       c(FALSE, TRUE, FALSE, TRUE),
@@ -139,4 +141,20 @@ test_that(".stop_incompatible() passes dots (#95, #310)", {
     "incompatible_values",
     "integer"
   )
+})
+
+test_that(".stop_incompatible() attaches failure values (#332)", {
+  cnd <- rlang::catch_cnd(
+    .stop_incompatible(
+      c("a", "b", "c", "d"),
+      "character",
+      integer(),
+      c(FALSE, TRUE, FALSE, TRUE),
+      "some reason",
+      "my_arg",
+      rlang::current_env()
+    )
+  )
+  expect_identical(cnd$locations, c(2L, 4L))
+  expect_identical(cnd$values, c("b", "d"))
 })

--- a/tests/testthat/test-check.R
+++ b/tests/testthat/test-check.R
@@ -99,10 +99,11 @@ test_that(".check_x_no_more_than_y() works (#95)", {
   )
 })
 
-test_that(".check_cast_failures() works (#310)", {
+test_that(".check_cast_failures() works (#310, #332)", {
   # Happy path
   expect_null(
     .check_cast_failures(
+      x = c("a", "b"),
       failures = c(FALSE, FALSE),
       x_class = "character",
       to = logical(),
@@ -116,6 +117,7 @@ test_that(".check_cast_failures() works (#310)", {
   failures <- c(FALSE, TRUE, FALSE, TRUE)
   expect_pkg_error_snapshot(
     .check_cast_failures(
+      x = c("a", "b", "c", "d"),
       failures = failures,
       x_class = "character",
       to = logical(),
@@ -129,9 +131,10 @@ test_that(".check_cast_failures() works (#310)", {
   )
 })
 
-test_that(".check_cast_failures() attaches failing locations (#274)", {
+test_that(".check_cast_failures() attaches failing locations and values (#274, #332)", {
   cnd <- rlang::catch_cnd(
     .check_cast_failures(
+      x = c("a", "b", "c", "d"),
       failures = c(FALSE, TRUE, FALSE, TRUE),
       x_class = "character",
       to = logical(),
@@ -141,6 +144,7 @@ test_that(".check_cast_failures() attaches failing locations (#274)", {
     )
   )
   expect_identical(cnd$locations, c(2L, 4L))
+  expect_identical(cnd$values, c("b", "d"))
 })
 
 test_that(".check_all_named() works (#203)", {

--- a/tests/testthat/test-cls_unexported.R
+++ b/tests/testthat/test-cls_unexported.R
@@ -251,6 +251,7 @@ test_that(".to_cls_from_fct() works (#23)", {
 
 test_that(".check_lst_failures() returns NULL when all elements are valid (#273)", {
   result <- .check_lst_failures(
+    list(1, 2, 3),
     c(TRUE, TRUE, TRUE),
     to = character(),
     x_class = "list",
@@ -260,19 +261,19 @@ test_that(".check_lst_failures() returns NULL when all elements are valid (#273)
   expect_null(result)
 })
 
-test_that(".check_lst_failures() errors when any element is invalid (#273, #310)", {
-  expect_pkg_error_classes(
+test_that(".check_lst_failures() errors when any element is invalid (#273, #310, #332)", {
+  cnd <- rlang::catch_cnd(
     .check_lst_failures(
+      list(1, "bad"),
       c(TRUE, FALSE),
       to = character(),
       x_class = "list",
       x_arg = "x",
       call = rlang::current_env()
-    ),
-    "stbl",
-    "incompatible_values",
-    "character"
+    )
   )
+  expect_pkg_error_classes(cnd, "stbl", "incompatible_values", "character")
+  expect_identical(cnd$values, list("bad"))
 })
 
 test_that(".to_num_from_complex() works (#23, #310)", {


### PR DESCRIPTION
Closes #332.

Whenever an error message reports failing element `Locations:`, it now also reports the corresponding `Values:`. Each affected internal helper (`.stop_incompatible()`, `.check_cast_failures()`, `.check_lst_failures()`, `.check_chr_to_int_failures()`, `.check_dbl_to_int_failures()`, `.check_cpx_to_int_failures()`) now takes `x` so it can subset the original values by the failing `locations`, and attaches that subset to the error condition as `values` (alongside the existing `locations`).

## Testing
- `devtools::test(reporter = "check")`: 0 failures
- 100% coverage confirmed for every edited `R/` file
- `devtools::check(error_on = "warning")`: 0 errors, 0 warnings, 0 notes