### PR TITLE
feat: add .required argument for optional named elements in stabilize_lst()

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -19,7 +19,7 @@
 * `stabilize_chr()`, `stabilize_dbl()`, `stabilize_int()`, `stabilize_lst()`, `specify_chr()`, `specify_dbl()`, `specify_int()`, and `specify_lst()` gain new `unique`/`.unique` arguments to enforce distinct elements and raise duplicate-element errors when repeated values are found (#280).
 * New `to_date()`, `stabilize_date()`, `to_dttm()`, `stabilize_dttm()`, `to_time()`, `stabilize_time()`, `to_dur()`, and `stabilize_dur()` families (plus matching `specify_*()` factories) validate and coerce [RFC 3339](https://www.rfc-editor.org/info/rfc3339/) / [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) temporal values (#104, #105, #294, #295).
 * `stabilize_df()`'s `.extra_cols` argument and `stabilize_lst()`/`specify_lst()`'s `.named` and `.unnamed` arguments now also accept `TRUE` to allow extra or unnamed elements unchecked, in addition to the existing `NULL`/`FALSE` (forbid) and stabilizer-function (validate) forms (#281).
-* `stabilize_df()`, `stabilize_lst()`, `specify_df()`, and `specify_lst()` gain a new `.required` argument, letting you mark named specs passed via `...` as optional. `.required` defaults to all names in `...`, preserving the previous "every named spec is required" behavior; specs left out of `.required` are only validated when present, modeling JSON Schema's `required` array (#279).
+* `stabilize_df()`, `stabilize_lst()`, `specify_df()`, and `specify_lst()` gain a new `.required` argument, letting you mark named specs passed via `...` as optional. `.required` defaults to all names in `...`, preserving the previous "every named spec is required" behavior; specs left out of `.required` are only validated when present (#279).
 
 ## Bug fixes
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -19,6 +19,7 @@
 * `stabilize_chr()`, `stabilize_dbl()`, `stabilize_int()`, `stabilize_lst()`, `specify_chr()`, `specify_dbl()`, `specify_int()`, and `specify_lst()` gain new `unique`/`.unique` arguments to enforce distinct elements and raise duplicate-element errors when repeated values are found (#280).
 * New `to_date()`, `stabilize_date()`, `to_dttm()`, `stabilize_dttm()`, `to_time()`, `stabilize_time()`, `to_dur()`, and `stabilize_dur()` families (plus matching `specify_*()` factories) validate and coerce [RFC 3339](https://www.rfc-editor.org/info/rfc3339/) / [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) temporal values (#104, #105, #294, #295).
 * `stabilize_df()`'s `.extra_cols` argument and `stabilize_lst()`/`specify_lst()`'s `.named` and `.unnamed` arguments now also accept `TRUE` to allow extra or unnamed elements unchecked, in addition to the existing `NULL`/`FALSE` (forbid) and stabilizer-function (validate) forms (#281).
+* `stabilize_df()`, `stabilize_lst()`, `specify_df()`, and `specify_lst()` gain a new `.required` argument, letting you mark named specs passed via `...` as optional. `.required` defaults to all names in `...`, preserving the previous "every named spec is required" behavior; specs left out of `.required` are only validated when present, modeling JSON Schema's `required` array (#279).
 
 ## Bug fixes
 

--- a/R/specify_df.R
+++ b/R/specify_df.R
@@ -22,13 +22,22 @@
 #' )
 #' stabilize_person_df(data.frame(name = "Alice", age = 30L, score = 99.5))
 #' try(stabilize_person_df(data.frame(name = "Alice")))
+#'
+#' # Mark a column as optional via .required
+#' stabilize_person_df2 <- specify_df(
+#'   name = specify_chr_scalar(allow_na = FALSE),
+#'   age = specify_int_scalar(allow_na = FALSE),
+#'   .required = "name"
+#' )
+#' stabilize_person_df2(data.frame(name = "Alice"))
 specify_df <- function(
   ...,
   .extra_cols = NULL,
   .col_names = NULL,
   .min_rows = NULL,
   .max_rows = NULL,
-  .allow_null = TRUE
+  .allow_null = TRUE,
+  .required = ...names()
 ) {
   element_specs <- list(...)
   structure(
@@ -49,6 +58,7 @@ specify_df <- function(
           .min_rows = .min_rows,
           .max_rows = .max_rows,
           .allow_null = .allow_null,
+          .required = .required,
           .x_arg = .x_arg,
           .call = .call,
           .x_class = .x_class

--- a/R/specify_lst.R
+++ b/R/specify_lst.R
@@ -29,6 +29,14 @@
 #'     list(name = "myapp", version = 1L, debug = FALSE, c("a", "b"))
 #'   )
 #' )
+#'
+#' # Mark some elements as optional via .required
+#' stabilize_settings <- specify_lst(
+#'   name = specify_chr_scalar(),
+#'   nickname = specify_chr_scalar(),
+#'   .required = "name"
+#' )
+#' stabilize_settings(list(name = "Alice"))
 specify_lst <- function(
   ...,
   .named = NULL,
@@ -36,7 +44,8 @@ specify_lst <- function(
   .unique = FALSE,
   .allow_null = TRUE,
   .min_size = NULL,
-  .max_size = NULL
+  .max_size = NULL,
+  .required = ...names()
 ) {
   element_specs <- list(...)
   structure(
@@ -58,6 +67,7 @@ specify_lst <- function(
           .allow_null = .allow_null,
           .min_size = .min_size,
           .max_size = .max_size,
+          .required = .required,
           .x_arg = .x_arg,
           .call = .call,
           .x_class = .x_class

--- a/R/stabilize_df.R
+++ b/R/stabilize_df.R
@@ -9,8 +9,9 @@
 #'
 #' @param ... Named stabilizer functions, such as `stabilize_*` functions
 #'   ([stabilize_chr()], etc) or functions produced by `specify_*()` functions
-#'   ([specify_chr()], etc). Each name corresponds to a required column in `.x`,
-#'   and the function is used to validate that column.
+#'   ([specify_chr()], etc). Each name corresponds to a column in `.x`, and the
+#'   function is used to validate that column when present. Whether the column
+#'   is required is controlled by `.required`.
 #' @param .extra_cols Controls how columns of `.x` that are *not* explicitly
 #'   listed in `...` are handled. One of:
 #'   - `NULL` or `FALSE` (default): any extra columns cause an error.
@@ -25,6 +26,11 @@
 #'   `.x`. If `NULL` (default), the row count is not checked.
 #' @param .max_rows (`integer(1)`) The maximum number of rows allowed in
 #'   `.x`. If `NULL` (default), the row count is not checked.
+#' @param .required `(character)` Names (from `...`) of columns that must be
+#'   present in `.x`. Defaults to all names in `...`, so every named spec is
+#'   required unless you opt it out. Named specs *not* listed here are
+#'   optional: if absent, no error is raised; if present, they're validated
+#'   normally. Pass `NULL` or `character()` to make every named spec optional.
 #' @inheritParams .shared-params
 #'
 #' @returns The validated data frame, or an error condition with classes
@@ -98,6 +104,14 @@
 #'
 #' # Non-coercible inputs are rejected
 #' try(stabilize_df("not a data frame"))
+#'
+#' # Mark a column as optional via .required
+#' stabilize_df(
+#'   data.frame(name = "Alice"),
+#'   name = specify_chr_scalar(),
+#'   age = specify_int_scalar(),
+#'   .required = "name"
+#' )
 stabilize_df <- function(
   .x,
   ...,
@@ -106,6 +120,7 @@ stabilize_df <- function(
   .min_rows = NULL,
   .max_rows = NULL,
   .allow_null = TRUE,
+  .required = ...names(),
   .x_arg = caller_arg(.x),
   .call = caller_env(),
   .x_class = object_type(.x)
@@ -134,6 +149,7 @@ stabilize_df <- function(
     .x,
     ...,
     .named = .extra_cols,
+    .required = .required,
     .x_arg = .x_arg,
     .call = .call,
     .x_class = .x_class

--- a/R/stabilize_lst.R
+++ b/R/stabilize_lst.R
@@ -8,8 +8,10 @@
 #'
 #' @param ... Named stabilizer functions, such as `stabilize_*` functions
 #'   ([stabilize_chr()], etc) or functions produced by `specify_*()` functions
-#'   ([specify_chr()], etc). Each name corresponds to a required element in
-#'   `.x`, and the function is used to validate that element.
+#'   ([specify_chr()], etc). Each name corresponds to an element in `.x`, and
+#'   the function is used to validate that element when present. Whether the
+#'   element is required (its absence is an error) is controlled by
+#'   `.required`.
 #' @param .named Controls how named elements of `.x` that are *not* explicitly
 #'   listed in `...` are handled. One of:
 #'   - `NULL` or `FALSE` (default): any extra named elements cause an error.
@@ -29,6 +31,11 @@
 #'   named element of `.x` shares a name with another.
 #' @param .unique (`logical(1)`) Should all elements in `.x` be distinct?
 #'   If `TRUE`, duplicated elements are rejected.
+#' @param .required `(character)` Names (from `...`) of elements that must be
+#'   present in `.x`. Defaults to all names in `...`, so every named spec is
+#'   required unless you opt it out. Named specs *not* listed here are
+#'   optional: if absent, no error is raised; if present, they're validated
+#'   normally. Pass `NULL` or `character()` to make every named spec optional.
 #' @inheritParams .shared-params
 #'
 #' @returns The validated list, or an error condition with classes
@@ -93,6 +100,17 @@
 #'   .named = specify_int_scalar(),
 #'   .allow_duplicate_names = TRUE
 #' )
+#'
+#' # Mark named specs as optional via .required
+#' stabilize_lst(
+#'   list(a = 1L),
+#'   a = specify_int_scalar(),
+#'   b = specify_int_scalar(),
+#'   .required = "a"
+#' )
+#' try(
+#'   stabilize_lst(list(a = 1L), a = specify_int_scalar(), b = specify_int_scalar())
+#' )
 stabilize_lst <- function(
   .x,
   ...,
@@ -103,6 +121,7 @@ stabilize_lst <- function(
   .allow_null = TRUE,
   .min_size = NULL,
   .max_size = NULL,
+  .required = ...names(),
   .x_arg = caller_arg(.x),
   .call = caller_env(),
   .x_class = object_type(.x)
@@ -127,10 +146,12 @@ stabilize_lst <- function(
   )
 
   .check_specs_named(..., .call = .call)
+  .required <- to_chr(.required, x_arg = ".required", call = .call)
   .x <- .validate_named_elements(
     .x,
     ...,
     .named = .named,
+    .required = .required,
     .allow_duplicate_names = .allow_duplicate_names,
     .x_arg = .x_arg,
     .call = .call
@@ -173,9 +194,10 @@ stabilise_list <- stabilize_lst
 #'
 #' @param element_specs `(list)` Named list of stabilizer functions, such as
 #'   `stabilize_*` functions ([stabilize_chr()], etc) or functions produced by
-#'   `specify_*()` functions ([specify_chr()], etc). Each name corresponds to a
-#'   required element in `.x`, and the function is used to validate that
-#'   element.
+#'   `specify_*()` functions ([specify_chr()], etc). Each name corresponds to
+#'   an element in `.x`, and the function is used to validate that element
+#'   when present. Whether the element is required is controlled by
+#'   `.required`.
 #' @param is_extra_named `(logical)` Element-wise indicator of extra named
 #'   positions.
 #' @param named_spec A single stabilizer function, such as a `stabilize_*`
@@ -249,6 +271,7 @@ NULL
   .x,
   ...,
   .named,
+  .required,
   .allow_duplicate_names,
   .x_arg,
   .call
@@ -269,6 +292,7 @@ NULL
     .x,
     element_specs,
     nms,
+    .required = .required,
     .x_arg = .x_arg,
     .call = .call
   )
@@ -285,21 +309,35 @@ NULL
 
 #' Validate required named elements against their spec functions
 #'
+#' Named specs not listed in `.required` are optional: when absent, they're
+#' skipped rather than erroring, but they're still validated normally when
+#' present.
+#'
 #' @inheritParams stabilize_lst
 #' @inheritParams .shared-params-lst
 #' @returns The updated list.
 #' @keywords internal
-.validate_required_elements <- function(.x, element_specs, nms, .x_arg, .call) {
+.validate_required_elements <- function(
+  .x,
+  element_specs,
+  nms,
+  .required,
+  .x_arg,
+  .call
+) {
   for (nm in names(element_specs)) {
     positions <- which(nms == nm)
     if (!length(positions)) {
-      .stop_must(
-        "must contain element {.val {nm}}.",
-        x_arg = .x_arg,
-        call = .call,
-        subclass = "missing_element",
-        message_env = rlang::current_env()
-      )
+      if (nm %in% .required) {
+        .stop_must(
+          "must contain element {.val {nm}}.",
+          x_arg = .x_arg,
+          call = .call,
+          subclass = "missing_element",
+          message_env = rlang::current_env()
+        )
+      }
+      next
     }
     for (i in positions) {
       # Use name-based path when unambiguous; fall back to position for

--- a/R/stabilize_lst.R
+++ b/R/stabilize_lst.R
@@ -146,7 +146,7 @@ stabilize_lst <- function(
   )
 
   .check_specs_named(..., .call = .call)
-  .required <- to_chr(.required, x_arg = ".required", call = .call)
+  .required <- to_chr(.required, call = .call)
   .x <- .validate_named_elements(
     .x,
     ...,
@@ -308,10 +308,6 @@ NULL
 }
 
 #' Validate required named elements against their spec functions
-#'
-#' Named specs not listed in `.required` are optional: when absent, they're
-#' skipped rather than erroring, but they're still validated normally when
-#' present.
 #'
 #' @inheritParams stabilize_lst
 #' @inheritParams .shared-params-lst

--- a/man/dot-check_specs_named.Rd
+++ b/man/dot-check_specs_named.Rd
@@ -9,8 +9,10 @@
 \arguments{
 \item{...}{Named stabilizer functions, such as \verb{stabilize_*} functions
 (\code{\link[=stabilize_chr]{stabilize_chr()}}, etc) or functions produced by \verb{specify_*()} functions
-(\code{\link[=specify_chr]{specify_chr()}}, etc). Each name corresponds to a required element in
-\code{.x}, and the function is used to validate that element.}
+(\code{\link[=specify_chr]{specify_chr()}}, etc). Each name corresponds to an element in \code{.x}, and
+the function is used to validate that element when present. Whether the
+element is required (its absence is an error) is controlled by
+\code{.required}.}
 
 \item{.call}{\code{(environment)} The execution environment to mention as the
 source of error messages.}

--- a/man/dot-shared-params-lst.Rd
+++ b/man/dot-shared-params-lst.Rd
@@ -6,9 +6,10 @@
 \arguments{
 \item{element_specs}{\code{(list)} Named list of stabilizer functions, such as
 \verb{stabilize_*} functions (\code{\link[=stabilize_chr]{stabilize_chr()}}, etc) or functions produced by
-\verb{specify_*()} functions (\code{\link[=specify_chr]{specify_chr()}}, etc). Each name corresponds to a
-required element in \code{.x}, and the function is used to validate that
-element.}
+\verb{specify_*()} functions (\code{\link[=specify_chr]{specify_chr()}}, etc). Each name corresponds to
+an element in \code{.x}, and the function is used to validate that element
+when present. Whether the element is required is controlled by
+\code{.required}.}
 
 \item{is_extra_named}{\code{(logical)} Element-wise indicator of extra named
 positions.}

--- a/man/dot-validate_named_elements.Rd
+++ b/man/dot-validate_named_elements.Rd
@@ -8,6 +8,7 @@
   .x,
   ...,
   .named,
+  .required,
   .allow_duplicate_names,
   .x_arg,
   .call
@@ -18,8 +19,10 @@
 
 \item{...}{Named stabilizer functions, such as \verb{stabilize_*} functions
 (\code{\link[=stabilize_chr]{stabilize_chr()}}, etc) or functions produced by \verb{specify_*()} functions
-(\code{\link[=specify_chr]{specify_chr()}}, etc). Each name corresponds to a required element in
-\code{.x}, and the function is used to validate that element.}
+(\code{\link[=specify_chr]{specify_chr()}}, etc). Each name corresponds to an element in \code{.x}, and
+the function is used to validate that element when present. Whether the
+element is required (its absence is an error) is controlled by
+\code{.required}.}
 
 \item{.named}{Controls how named elements of \code{.x} that are \emph{not} explicitly
 listed in \code{...} are handled. One of:
@@ -31,6 +34,12 @@ listed in \code{...} are handled. One of:
 function (\code{\link[=specify_chr]{specify_chr()}}, etc), used to validate every extra named
 element.
 }}
+
+\item{.required}{\code{(character)} Names (from \code{...}) of elements that must be
+present in \code{.x}. Defaults to all names in \code{...}, so every named spec is
+required unless you opt it out. Named specs \emph{not} listed here are
+optional: if absent, no error is raised; if present, they're validated
+normally. Pass \code{NULL} or \code{character()} to make every named spec optional.}
 
 \item{.allow_duplicate_names}{(\code{logical(1)}) Should \code{.x} be allowed to
 have duplicate names? If \code{FALSE} (default), an error is thrown when any

--- a/man/dot-validate_required_elements.Rd
+++ b/man/dot-validate_required_elements.Rd
@@ -36,8 +36,6 @@ source of error messages.}
 The updated list.
 }
 \description{
-Named specs not listed in \code{.required} are optional: when absent, they're
-skipped rather than erroring, but they're still validated normally when
-present.
+Validate required named elements against their spec functions
 }
 \keyword{internal}

--- a/man/dot-validate_required_elements.Rd
+++ b/man/dot-validate_required_elements.Rd
@@ -4,18 +4,25 @@
 \alias{.validate_required_elements}
 \title{Validate required named elements against their spec functions}
 \usage{
-.validate_required_elements(.x, element_specs, nms, .x_arg, .call)
+.validate_required_elements(.x, element_specs, nms, .required, .x_arg, .call)
 }
 \arguments{
 \item{.x}{The object to stabilize.}
 
 \item{element_specs}{\code{(list)} Named list of stabilizer functions, such as
 \verb{stabilize_*} functions (\code{\link[=stabilize_chr]{stabilize_chr()}}, etc) or functions produced by
-\verb{specify_*()} functions (\code{\link[=specify_chr]{specify_chr()}}, etc). Each name corresponds to a
-required element in \code{.x}, and the function is used to validate that
-element.}
+\verb{specify_*()} functions (\code{\link[=specify_chr]{specify_chr()}}, etc). Each name corresponds to
+an element in \code{.x}, and the function is used to validate that element
+when present. Whether the element is required is controlled by
+\code{.required}.}
 
 \item{nms}{\code{(character)} Result of \code{rlang::names2(.x)}.}
+
+\item{.required}{\code{(character)} Names (from \code{...}) of elements that must be
+present in \code{.x}. Defaults to all names in \code{...}, so every named spec is
+required unless you opt it out. Named specs \emph{not} listed here are
+optional: if absent, no error is raised; if present, they're validated
+normally. Pass \code{NULL} or \code{character()} to make every named spec optional.}
 
 \item{.x_arg}{(\code{character(1)}) The name of the object being stabilized to use
 in error messages. The automatic value will work in most cases, or pass it
@@ -29,6 +36,8 @@ source of error messages.}
 The updated list.
 }
 \description{
-Validate required named elements against their spec functions
+Named specs not listed in \code{.required} are optional: when absent, they're
+skipped rather than erroring, but they're still validated normally when
+present.
 }
 \keyword{internal}

--- a/man/specify_df.Rd
+++ b/man/specify_df.Rd
@@ -11,7 +11,8 @@ specify_df(
   .col_names = NULL,
   .min_rows = NULL,
   .max_rows = NULL,
-  .allow_null = TRUE
+  .allow_null = TRUE,
+  .required = ...names()
 )
 
 specify_data_frame(
@@ -20,14 +21,16 @@ specify_data_frame(
   .col_names = NULL,
   .min_rows = NULL,
   .max_rows = NULL,
-  .allow_null = TRUE
+  .allow_null = TRUE,
+  .required = ...names()
 )
 }
 \arguments{
 \item{...}{Named stabilizer functions, such as \verb{stabilize_*} functions
 (\code{\link[=stabilize_chr]{stabilize_chr()}}, etc) or functions produced by \verb{specify_*()} functions
-(\code{\link[=specify_chr]{specify_chr()}}, etc). Each name corresponds to a required column in \code{.x},
-and the function is used to validate that column.}
+(\code{\link[=specify_chr]{specify_chr()}}, etc). Each name corresponds to a column in \code{.x}, and the
+function is used to validate that column when present. Whether the column
+is required is controlled by \code{.required}.}
 
 \item{.extra_cols}{Controls how columns of \code{.x} that are \emph{not} explicitly
 listed in \code{...} are handled. One of:
@@ -50,6 +53,12 @@ cause an error. Unlike \code{...}, this does not validate the column contents.}
 \code{.x}. If \code{NULL} (default), the row count is not checked.}
 
 \item{.allow_null}{(\code{logical(1)}) Is NULL an acceptable value?}
+
+\item{.required}{\code{(character)} Names (from \code{...}) of columns that must be
+present in \code{.x}. Defaults to all names in \code{...}, so every named spec is
+required unless you opt it out. Named specs \emph{not} listed here are
+optional: if absent, no error is raised; if present, they're validated
+normally. Pass \code{NULL} or \code{character()} to make every named spec optional.}
 }
 \value{
 A function of class \code{"stbl_specified_fn"} that calls
@@ -70,6 +79,14 @@ stabilize_person_df <- specify_df(
 )
 stabilize_person_df(data.frame(name = "Alice", age = 30L, score = 99.5))
 try(stabilize_person_df(data.frame(name = "Alice")))
+
+# Mark a column as optional via .required
+stabilize_person_df2 <- specify_df(
+  name = specify_chr_scalar(allow_na = FALSE),
+  age = specify_int_scalar(allow_na = FALSE),
+  .required = "name"
+)
+stabilize_person_df2(data.frame(name = "Alice"))
 }
 \seealso{
 Other data frame functions:

--- a/man/specify_lst.Rd
+++ b/man/specify_lst.Rd
@@ -12,7 +12,8 @@ specify_lst(
   .unique = FALSE,
   .allow_null = TRUE,
   .min_size = NULL,
-  .max_size = NULL
+  .max_size = NULL,
+  .required = ...names()
 )
 
 specify_list(
@@ -22,14 +23,17 @@ specify_list(
   .unique = FALSE,
   .allow_null = TRUE,
   .min_size = NULL,
-  .max_size = NULL
+  .max_size = NULL,
+  .required = ...names()
 )
 }
 \arguments{
 \item{...}{Named stabilizer functions, such as \verb{stabilize_*} functions
 (\code{\link[=stabilize_chr]{stabilize_chr()}}, etc) or functions produced by \verb{specify_*()} functions
-(\code{\link[=specify_chr]{specify_chr()}}, etc). Each name corresponds to a required element in
-\code{.x}, and the function is used to validate that element.}
+(\code{\link[=specify_chr]{specify_chr()}}, etc). Each name corresponds to an element in \code{.x}, and
+the function is used to validate that element when present. Whether the
+element is required (its absence is an error) is controlled by
+\code{.required}.}
 
 \item{.named}{Controls how named elements of \code{.x} that are \emph{not} explicitly
 listed in \code{...} are handled. One of:
@@ -61,6 +65,12 @@ will be tested using \code{\link[vctrs:vec_size]{vctrs::vec_size()}}.}
 
 \item{.max_size}{(\code{integer(1)}) The maximum size of the object. Object size
 will be tested using \code{\link[vctrs:vec_size]{vctrs::vec_size()}}.}
+
+\item{.required}{\code{(character)} Names (from \code{...}) of elements that must be
+present in \code{.x}. Defaults to all names in \code{...}, so every named spec is
+required unless you opt it out. Named specs \emph{not} listed here are
+optional: if absent, no error is raised; if present, they're validated
+normally. Pass \code{NULL} or \code{character()} to make every named spec optional.}
 }
 \value{
 A function of class \code{"stbl_specified_fn"} that calls
@@ -86,6 +96,14 @@ try(
     list(name = "myapp", version = 1L, debug = FALSE, c("a", "b"))
   )
 )
+
+# Mark some elements as optional via .required
+stabilize_settings <- specify_lst(
+  name = specify_chr_scalar(),
+  nickname = specify_chr_scalar(),
+  .required = "name"
+)
+stabilize_settings(list(name = "Alice"))
 }
 \seealso{
 Other list functions:

--- a/man/stabilize_df.Rd
+++ b/man/stabilize_df.Rd
@@ -15,6 +15,7 @@ stabilize_df(
   .min_rows = NULL,
   .max_rows = NULL,
   .allow_null = TRUE,
+  .required = ...names(),
   .x_arg = caller_arg(.x),
   .call = caller_env(),
   .x_class = object_type(.x)
@@ -28,6 +29,7 @@ stabilise_df(
   .min_rows = NULL,
   .max_rows = NULL,
   .allow_null = TRUE,
+  .required = ...names(),
   .x_arg = caller_arg(.x),
   .call = caller_env(),
   .x_class = object_type(.x)
@@ -41,6 +43,7 @@ stabilize_data_frame(
   .min_rows = NULL,
   .max_rows = NULL,
   .allow_null = TRUE,
+  .required = ...names(),
   .x_arg = caller_arg(.x),
   .call = caller_env(),
   .x_class = object_type(.x)
@@ -54,6 +57,7 @@ stabilise_data_frame(
   .min_rows = NULL,
   .max_rows = NULL,
   .allow_null = TRUE,
+  .required = ...names(),
   .x_arg = caller_arg(.x),
   .call = caller_env(),
   .x_class = object_type(.x)
@@ -64,8 +68,9 @@ stabilise_data_frame(
 
 \item{...}{Named stabilizer functions, such as \verb{stabilize_*} functions
 (\code{\link[=stabilize_chr]{stabilize_chr()}}, etc) or functions produced by \verb{specify_*()} functions
-(\code{\link[=specify_chr]{specify_chr()}}, etc). Each name corresponds to a required column in \code{.x},
-and the function is used to validate that column.}
+(\code{\link[=specify_chr]{specify_chr()}}, etc). Each name corresponds to a column in \code{.x}, and the
+function is used to validate that column when present. Whether the column
+is required is controlled by \code{.required}.}
 
 \item{.extra_cols}{Controls how columns of \code{.x} that are \emph{not} explicitly
 listed in \code{...} are handled. One of:
@@ -88,6 +93,12 @@ cause an error. Unlike \code{...}, this does not validate the column contents.}
 \code{.x}. If \code{NULL} (default), the row count is not checked.}
 
 \item{.allow_null}{(\code{logical(1)}) Is NULL an acceptable value?}
+
+\item{.required}{\code{(character)} Names (from \code{...}) of columns that must be
+present in \code{.x}. Defaults to all names in \code{...}, so every named spec is
+required unless you opt it out. Named specs \emph{not} listed here are
+optional: if absent, no error is raised; if present, they're validated
+normally. Pass \code{NULL} or \code{character()} to make every named spec optional.}
 
 \item{.x_arg}{(\code{character(1)}) The name of the object being stabilized to use
 in error messages. The automatic value will work in most cases, or pass it
@@ -181,6 +192,14 @@ stabilize_df(
 
 # Non-coercible inputs are rejected
 try(stabilize_df("not a data frame"))
+
+# Mark a column as optional via .required
+stabilize_df(
+  data.frame(name = "Alice"),
+  name = specify_chr_scalar(),
+  age = specify_int_scalar(),
+  .required = "name"
+)
 }
 \seealso{
 Other data frame functions:

--- a/man/stabilize_lst.Rd
+++ b/man/stabilize_lst.Rd
@@ -17,6 +17,7 @@ stabilize_lst(
   .allow_null = TRUE,
   .min_size = NULL,
   .max_size = NULL,
+  .required = ...names(),
   .x_arg = caller_arg(.x),
   .call = caller_env(),
   .x_class = object_type(.x)
@@ -32,6 +33,7 @@ stabilize_list(
   .allow_null = TRUE,
   .min_size = NULL,
   .max_size = NULL,
+  .required = ...names(),
   .x_arg = caller_arg(.x),
   .call = caller_env(),
   .x_class = object_type(.x)
@@ -47,6 +49,7 @@ stabilise_lst(
   .allow_null = TRUE,
   .min_size = NULL,
   .max_size = NULL,
+  .required = ...names(),
   .x_arg = caller_arg(.x),
   .call = caller_env(),
   .x_class = object_type(.x)
@@ -62,6 +65,7 @@ stabilise_list(
   .allow_null = TRUE,
   .min_size = NULL,
   .max_size = NULL,
+  .required = ...names(),
   .x_arg = caller_arg(.x),
   .call = caller_env(),
   .x_class = object_type(.x)
@@ -72,8 +76,10 @@ stabilise_list(
 
 \item{...}{Named stabilizer functions, such as \verb{stabilize_*} functions
 (\code{\link[=stabilize_chr]{stabilize_chr()}}, etc) or functions produced by \verb{specify_*()} functions
-(\code{\link[=specify_chr]{specify_chr()}}, etc). Each name corresponds to a required element in
-\code{.x}, and the function is used to validate that element.}
+(\code{\link[=specify_chr]{specify_chr()}}, etc). Each name corresponds to an element in \code{.x}, and
+the function is used to validate that element when present. Whether the
+element is required (its absence is an error) is controlled by
+\code{.required}.}
 
 \item{.named}{Controls how named elements of \code{.x} that are \emph{not} explicitly
 listed in \code{...} are handled. One of:
@@ -109,6 +115,12 @@ will be tested using \code{\link[vctrs:vec_size]{vctrs::vec_size()}}.}
 
 \item{.max_size}{(\code{integer(1)}) The maximum size of the object. Object size
 will be tested using \code{\link[vctrs:vec_size]{vctrs::vec_size()}}.}
+
+\item{.required}{\code{(character)} Names (from \code{...}) of elements that must be
+present in \code{.x}. Defaults to all names in \code{...}, so every named spec is
+required unless you opt it out. Named specs \emph{not} listed here are
+optional: if absent, no error is raised; if present, they're validated
+normally. Pass \code{NULL} or \code{character()} to make every named spec optional.}
 
 \item{.x_arg}{(\code{character(1)}) The name of the object being stabilized to use
 in error messages. The automatic value will work in most cases, or pass it
@@ -191,6 +203,17 @@ stabilize_lst(
   list(a = 1L, a = 2L),
   .named = specify_int_scalar(),
   .allow_duplicate_names = TRUE
+)
+
+# Mark named specs as optional via .required
+stabilize_lst(
+  list(a = 1L),
+  a = specify_int_scalar(),
+  b = specify_int_scalar(),
+  .required = "a"
+)
+try(
+  stabilize_lst(list(a = 1L), a = specify_int_scalar(), b = specify_int_scalar())
 )
 }
 \seealso{

--- a/tests/testthat/_snaps/stabilize_lst.md
+++ b/tests/testthat/_snaps/stabilize_lst.md
@@ -134,6 +134,23 @@
       Error:
       ! Can't coerce `list(aes = list(x = mtcars, y = "hp"))[["aes"]][["x"]]` <data.frame> to <character>.
 
+# stabilize_lst() requires all named specs by default (#279)
+
+    Code
+      stabilize_lst(list(a = 1L), a = specify_int_scalar(), b = specify_int_scalar())
+    Condition <stbl-error-missing_element>
+      Error:
+      ! `list(a = 1L)` must contain element "b".
+
+# stabilize_lst() still errors on required elements not in .required (#279)
+
+    Code
+      stabilize_lst(list(z = 1L), a = specify_int_scalar(), b = specify_int_scalar(),
+      .named = TRUE, .required = "a")
+    Condition <stbl-error-missing_element>
+      Error:
+      ! `list(z = 1L)` must contain element "a".
+
 # .check_duplicate_names(): errors on duplicate names by default (#110)
 
     Code

--- a/tests/testthat/test-specify_df.R
+++ b/tests/testthat/test-specify_df.R
@@ -19,6 +19,16 @@ test_that("specify_df() errors when required column is missing (#142)", {
   )
 })
 
+test_that("specify_df() passes through .required (#279)", {
+  validator <- specify_df(
+    name = specify_chr_scalar(),
+    age = specify_int_scalar(),
+    .required = "name"
+  )
+  given <- data.frame(name = "Alice")
+  expect_identical(validator(given), given)
+})
+
 test_that("specify_df() passes through .min_rows, .max_rows (#142)", {
   validator <- specify_df(.min_rows = 2, .extra_cols = assert_present)
   expect_pkg_error_snapshot(

--- a/tests/testthat/test-specify_lst.R
+++ b/tests/testthat/test-specify_lst.R
@@ -48,6 +48,21 @@ test_that("specify_lst() enforces .unique when configured (#280)", {
   expect_pkg_error_classes(spec(list(1L, 2L, 1L)), "stbl", "duplicate_elements")
 })
 
+test_that("specify_lst() passes through .required (#279)", {
+  spec <- specify_lst(
+    a = specify_int_scalar(),
+    b = specify_int_scalar(),
+    .required = "a"
+  )
+  given <- list(a = 1L)
+  expect_identical(spec(given), given)
+})
+
+test_that("specify_lst() requires all element specs by default (#279)", {
+  spec <- specify_lst(a = specify_int_scalar(), b = specify_int_scalar())
+  expect_pkg_error_classes(spec(list(a = 1L)), "stbl", "missing_element")
+})
+
 test_that("specify_lst() allows extra named elements unchecked with .named = TRUE (#281)", {
   spec <- specify_lst(.named = TRUE)
   given <- list(a = 1L, b = "anything")

--- a/tests/testthat/test-stabilize_df.R
+++ b/tests/testthat/test-stabilize_df.R
@@ -68,6 +68,31 @@ test_that("stabilize_df() errors when required column is missing (#142)", {
   )
 })
 
+test_that("stabilize_df() allows an absent optional column via .required (#279)", {
+  given <- data.frame(name = "Alice")
+  result <- stabilize_df(
+    given,
+    name = specify_chr_scalar(),
+    age = specify_int_scalar(),
+    .required = "name"
+  )
+  expect_identical(result, given)
+})
+
+test_that("stabilize_df() still validates an optional column when present (#279)", {
+  expect_pkg_error_classes(
+    stabilize_df(
+      data.frame(name = "Alice", age = "not-int"),
+      name = specify_chr_scalar(),
+      age = specify_int_scalar(),
+      .required = "name"
+    ),
+    "stbl",
+    "incompatible_values",
+    "integer"
+  )
+})
+
 test_that("stabilize_df() errors informatively when column fails validation (#142, #310, #335)", {
   expect_pkg_error_snapshot(
     stabilize_df(

--- a/tests/testthat/test-stabilize_lst.R
+++ b/tests/testthat/test-stabilize_lst.R
@@ -249,6 +249,73 @@ test_that("stabilize_lst() validates nested lists (#110)", {
   )
 })
 
+test_that("stabilize_lst() requires all named specs by default (#279)", {
+  expect_pkg_error_snapshot(
+    stabilize_lst(
+      list(a = 1L),
+      a = specify_int_scalar(),
+      b = specify_int_scalar()
+    ),
+    "stbl",
+    "missing_element"
+  )
+})
+
+test_that("stabilize_lst() allows an absent optional element via .required (#279)", {
+  given <- list(a = 1L)
+  expect_identical(
+    stabilize_lst(
+      given,
+      a = specify_int_scalar(),
+      b = specify_int_scalar(),
+      .required = "a"
+    ),
+    given
+  )
+})
+
+test_that("stabilize_lst() still validates an optional element when present (#279)", {
+  expect_pkg_error_classes(
+    stabilize_lst(
+      list(a = 1L, b = "not-int"),
+      a = specify_int_scalar(),
+      b = specify_int_scalar(),
+      .required = "a"
+    ),
+    "stbl",
+    "incompatible_values",
+    "integer"
+  )
+})
+
+test_that("stabilize_lst() treats .required = NULL as making everything optional (#279)", {
+  given <- list(z = 1L)
+  expect_identical(
+    stabilize_lst(
+      given,
+      a = specify_int_scalar(),
+      b = specify_int_scalar(),
+      .named = TRUE,
+      .required = NULL
+    ),
+    given
+  )
+})
+
+test_that("stabilize_lst() still errors on required elements not in .required (#279)", {
+  expect_pkg_error_snapshot(
+    stabilize_lst(
+      list(z = 1L),
+      a = specify_int_scalar(),
+      b = specify_int_scalar(),
+      .named = TRUE,
+      .required = "a"
+    ),
+    "stbl",
+    "missing_element"
+  )
+})
+
 test_that("stabilize_lst() with unnamed specs errors informatively (#110)", {
   expect_pkg_error_classes(
     stabilize_lst(list(1L), specify_int_scalar()),


### PR DESCRIPTION
Closes #279.

## Summary

Adds a `.required` argument to `stabilize_lst()`, `specify_lst()`, `stabilize_df()`, and `specify_df()` so named element/column specs passed via `...` can be marked optional, matching JSON Schema's `required`/`properties` split.

## Behavior

- `.required` defaults to `...names()`, so every named spec is required unless explicitly opted out — existing behavior is unchanged.
- Named specs *not* listed in `.required`: absence is no longer an error; if present, they're still validated normally.
- `stabilize_df()`/`specify_df()` mirror the same design since `stabilize_df()` delegates column validation to `stabilize_lst()`.

## Testing

- Added tests for the default (all-required) behavior, absent/present optional elements, `.required = NULL` (everything optional), and specs left out of `.required` still erroring — across `stabilize_lst()`, `specify_lst()`, `stabilize_df()`, and `specify_df()`.
- `devtools::test(reporter = "check")`: 0 failures.
- `devtools::check(error_on = "warning")`: 0 errors, 0 warnings, 0 notes.

## Notes

While implementing this, I found a pre-existing, unrelated bug where `stabilize_lst()` skips required-element checks entirely when `.x` has no named elements at all (e.g. `stabilize_lst(list(), a = specify_int_scalar())` doesn't error). Filed as #344; not addressed in this PR.
