### PR TITLE
Fix stabilize_lst() missing-element check for unnamed/empty lists

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -20,9 +20,11 @@
 * New `to_date()`, `stabilize_date()`, `to_dttm()`, `stabilize_dttm()`, `to_time()`, `stabilize_time()`, `to_dur()`, and `stabilize_dur()` families (plus matching `specify_*()` factories) validate and coerce [RFC 3339](https://www.rfc-editor.org/info/rfc3339/) / [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) temporal values (#104, #105, #294, #295).
 * `stabilize_df()`'s `.extra_cols` argument and `stabilize_lst()`/`specify_lst()`'s `.named` and `.unnamed` arguments now also accept `TRUE` to allow extra or unnamed elements unchecked, in addition to the existing `NULL`/`FALSE` (forbid) and stabilizer-function (validate) forms (#281).
 * `stabilize_df()`, `stabilize_lst()`, `specify_df()`, and `specify_lst()` gain a new `.required` argument, letting you mark named specs passed via `...` as optional. `.required` defaults to all names in `...`, preserving the previous "every named spec is required" behavior; specs left out of `.required` are only validated when present (#279).
+* `stabilize_df()`, `stabilize_lst()`, `specify_df()`, and `specify_lst()` gain a new `.allow_zero_length` argument (default `TRUE`) that lets a zero-length `.x` (such as `list()` or a data frame with no columns) skip the required-element check even if it's missing elements listed in `.required` (#344).
 
 ## Bug fixes
 
+* `stabilize_lst()` (and `stabilize_df()`, which delegates to it) now correctly detects missing required named elements even when `.x` has no named elements at all, such as `list()` or `list(1L, 2L)`. Previously, the required-element check was silently skipped whenever `.x` had no named elements (#344).
 * `to_chr()`, `to_dbl()`, `to_fct()`, `to_int()`, and `to_lgl()` now throw an "incompatible type" error (with failing element locations) instead of a generic "can't coerce" error when a list contains elements that can't be converted (#273).
 
 # stbl 0.4.0

--- a/NEWS.md
+++ b/NEWS.md
@@ -20,7 +20,7 @@
 * New `to_date()`, `stabilize_date()`, `to_dttm()`, `stabilize_dttm()`, `to_time()`, `stabilize_time()`, `to_dur()`, and `stabilize_dur()` families (plus matching `specify_*()` factories) validate and coerce [RFC 3339](https://www.rfc-editor.org/info/rfc3339/) / [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) temporal values (#104, #105, #294, #295).
 * `stabilize_df()`'s `.extra_cols` argument and `stabilize_lst()`/`specify_lst()`'s `.named` and `.unnamed` arguments now also accept `TRUE` to allow extra or unnamed elements unchecked, in addition to the existing `NULL`/`FALSE` (forbid) and stabilizer-function (validate) forms (#281).
 * `stabilize_df()`, `stabilize_lst()`, `specify_df()`, and `specify_lst()` gain a new `.required` argument, letting you mark named specs passed via `...` as optional. `.required` defaults to all names in `...`, preserving the previous "every named spec is required" behavior; specs left out of `.required` are only validated when present (#279).
-* `stabilize_df()`, `stabilize_lst()`, `specify_df()`, and `specify_lst()` gain a new `.allow_zero_length` argument (default `TRUE`) that lets a zero-length `.x` (such as `list()` or a data frame with no columns) skip the required-element check even if it's missing elements listed in `.required` (#344).
+* `stabilize_df()`, `stabilize_lst()`, `specify_df()`, and `specify_lst()` gain a new `.allow_zero_length` argument (default `TRUE`) that lets a zero-length `.x` (such as `list()` or a data frame with no columns) skip the required-element check even if it's missing elements listed in `.required`; `.min_size`/`.max_size` (and, for data frames, `.min_rows`/`.max_rows`) are still enforced regardless of `.allow_zero_length` (#344).
 
 ## Bug fixes
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -20,7 +20,7 @@
 * New `to_date()`, `stabilize_date()`, `to_dttm()`, `stabilize_dttm()`, `to_time()`, `stabilize_time()`, `to_dur()`, and `stabilize_dur()` families (plus matching `specify_*()` factories) validate and coerce [RFC 3339](https://www.rfc-editor.org/info/rfc3339/) / [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) temporal values (#104, #105, #294, #295).
 * `stabilize_df()`'s `.extra_cols` argument and `stabilize_lst()`/`specify_lst()`'s `.named` and `.unnamed` arguments now also accept `TRUE` to allow extra or unnamed elements unchecked, in addition to the existing `NULL`/`FALSE` (forbid) and stabilizer-function (validate) forms (#281).
 * `stabilize_df()`, `stabilize_lst()`, `specify_df()`, and `specify_lst()` gain a new `.required` argument, letting you mark named specs passed via `...` as optional. `.required` defaults to all names in `...`, preserving the previous "every named spec is required" behavior; specs left out of `.required` are only validated when present (#279).
-* `stabilize_df()`, `stabilize_lst()`, `specify_df()`, and `specify_lst()` gain a new `.allow_zero_length` argument (default `TRUE`) that lets a zero-length `.x` (such as `list()` or a data frame with no columns) skip the required-element check even if it's missing elements listed in `.required`; `.min_size`/`.max_size` (and, for data frames, `.min_rows`/`.max_rows`) are still enforced regardless of `.allow_zero_length` (#344).
+* `stabilize_df()`, `stabilize_lst()`, `specify_df()`, and `specify_lst()` gain a new `.allow_zero_length` argument (default `TRUE`) that lets a zero-length `.x` (such as `list()` or a data frame with no columns) skip the required-element check even if it's missing elements listed in `.required` (#344).
 
 ## Bug fixes
 

--- a/R/specify_df.R
+++ b/R/specify_df.R
@@ -37,6 +37,7 @@ specify_df <- function(
   .min_rows = NULL,
   .max_rows = NULL,
   .allow_null = TRUE,
+  .allow_zero_length = TRUE,
   .required = ...names()
 ) {
   element_specs <- list(...)
@@ -58,6 +59,7 @@ specify_df <- function(
           .min_rows = .min_rows,
           .max_rows = .max_rows,
           .allow_null = .allow_null,
+          .allow_zero_length = .allow_zero_length,
           .required = .required,
           .x_arg = .x_arg,
           .call = .call,

--- a/R/specify_lst.R
+++ b/R/specify_lst.R
@@ -43,6 +43,7 @@ specify_lst <- function(
   .unnamed = NULL,
   .unique = FALSE,
   .allow_null = TRUE,
+  .allow_zero_length = TRUE,
   .min_size = NULL,
   .max_size = NULL,
   .required = ...names()
@@ -65,6 +66,7 @@ specify_lst <- function(
           .unnamed = .unnamed,
           .unique = .unique,
           .allow_null = .allow_null,
+          .allow_zero_length = .allow_zero_length,
           .min_size = .min_size,
           .max_size = .max_size,
           .required = .required,

--- a/R/stabilize_df.R
+++ b/R/stabilize_df.R
@@ -31,6 +31,8 @@
 #'   required unless you opt it out. Named specs *not* listed here are
 #'   optional: if absent, no error is raised; if present, they're validated
 #'   normally. Pass `NULL` or `character()` to make every named spec optional.
+#'   A `.x` with zero columns skips this check when
+#'   `.allow_zero_length = TRUE` (the default); see `allow_zero_length`.
 #' @inheritParams .shared-params
 #'
 #' @returns The validated data frame, or an error condition with classes
@@ -120,6 +122,7 @@ stabilize_df <- function(
   .min_rows = NULL,
   .max_rows = NULL,
   .allow_null = TRUE,
+  .allow_zero_length = TRUE,
   .required = ...names(),
   .x_arg = caller_arg(.x),
   .call = caller_env(),
@@ -149,6 +152,7 @@ stabilize_df <- function(
     .x,
     ...,
     .named = .extra_cols,
+    .allow_zero_length = .allow_zero_length,
     .required = .required,
     .x_arg = .x_arg,
     .call = .call,

--- a/R/stabilize_df.R
+++ b/R/stabilize_df.R
@@ -32,7 +32,7 @@
 #'   optional: if absent, no error is raised; if present, they're validated
 #'   normally. Pass `NULL` or `character()` to make every named spec optional.
 #'   A `.x` with zero columns skips this check when
-#'   `.allow_zero_length = TRUE` (the default); see `allow_zero_length`.
+#'   `.allow_zero_length = TRUE` (the default).
 #' @inheritParams .shared-params
 #'
 #' @returns The validated data frame, or an error condition with classes

--- a/R/stabilize_lst.R
+++ b/R/stabilize_lst.R
@@ -140,9 +140,6 @@ stabilize_lst <- function(
     ))
   }
   .x <- to_lst(.x, x_arg = .x_arg, call = .call)
-  if (!length(.x) && to_lgl_scalar(.allow_zero_length, call = .call)) {
-    return(.x)
-  }
   .check_size(
     .x,
     min_size = .min_size,
@@ -150,8 +147,13 @@ stabilize_lst <- function(
     x_arg = .x_arg,
     call = .call
   )
-
   .check_specs_named(..., .call = .call)
+  # .min_size/.max_size are checked above regardless of .allow_zero_length;
+  # this only lets an empty .x skip the *required-element* check.
+  if (!length(.x) && to_lgl_scalar(.allow_zero_length, call = .call)) {
+    return(.x)
+  }
+
   .required <- to_chr(.required, call = .call)
   .x <- .validate_named_elements(
     .x,

--- a/R/stabilize_lst.R
+++ b/R/stabilize_lst.R
@@ -37,7 +37,7 @@
 #'   optional: if absent, no error is raised; if present, they're validated
 #'   normally. Pass `NULL` or `character()` to make every named spec optional.
 #'   A zero-length `.x` (such as `list()`) skips this check when
-#'   `.allow_zero_length = TRUE` (the default); see `allow_zero_length`.
+#'   `.allow_zero_length = TRUE`.
 #' @inheritParams .shared-params
 #'
 #' @returns The validated list, or an error condition with classes
@@ -148,9 +148,8 @@ stabilize_lst <- function(
     call = .call
   )
   .check_specs_named(..., .call = .call)
-  # .min_size/.max_size are checked above regardless of .allow_zero_length;
-  # this only lets an empty .x skip the *required-element* check.
-  if (!length(.x) && to_lgl_scalar(.allow_zero_length, call = .call)) {
+  .allow_zero_length <- to_lgl_scalar(.allow_zero_length, call = .call)
+  if (!length(.x) && .allow_zero_length) {
     return(.x)
   }
 

--- a/R/stabilize_lst.R
+++ b/R/stabilize_lst.R
@@ -36,6 +36,8 @@
 #'   required unless you opt it out. Named specs *not* listed here are
 #'   optional: if absent, no error is raised; if present, they're validated
 #'   normally. Pass `NULL` or `character()` to make every named spec optional.
+#'   A zero-length `.x` (such as `list()`) skips this check when
+#'   `.allow_zero_length = TRUE` (the default); see `allow_zero_length`.
 #' @inheritParams .shared-params
 #'
 #' @returns The validated list, or an error condition with classes
@@ -119,6 +121,7 @@ stabilize_lst <- function(
   .allow_duplicate_names = FALSE,
   .unique = FALSE,
   .allow_null = TRUE,
+  .allow_zero_length = TRUE,
   .min_size = NULL,
   .max_size = NULL,
   .required = ...names(),
@@ -137,6 +140,9 @@ stabilize_lst <- function(
     ))
   }
   .x <- to_lst(.x, x_arg = .x_arg, call = .call)
+  if (!length(.x) && to_lgl_scalar(.allow_zero_length, call = .call)) {
+    return(.x)
+  }
   .check_size(
     .x,
     min_size = .min_size,
@@ -276,9 +282,6 @@ NULL
   .x_arg,
   .call
 ) {
-  if (!any(rlang::have_name(.x))) {
-    return(.x)
-  }
   .check_duplicate_names(
     .x,
     .allow_duplicate_names,

--- a/man/dot-validate_named_elements.Rd
+++ b/man/dot-validate_named_elements.Rd
@@ -41,7 +41,7 @@ required unless you opt it out. Named specs \emph{not} listed here are
 optional: if absent, no error is raised; if present, they're validated
 normally. Pass \code{NULL} or \code{character()} to make every named spec optional.
 A zero-length \code{.x} (such as \code{list()}) skips this check when
-\code{.allow_zero_length = TRUE} (the default); see \code{allow_zero_length}.}
+\code{.allow_zero_length = TRUE}.}
 
 \item{.allow_duplicate_names}{(\code{logical(1)}) Should \code{.x} be allowed to
 have duplicate names? If \code{FALSE} (default), an error is thrown when any

--- a/man/dot-validate_named_elements.Rd
+++ b/man/dot-validate_named_elements.Rd
@@ -39,7 +39,9 @@ element.
 present in \code{.x}. Defaults to all names in \code{...}, so every named spec is
 required unless you opt it out. Named specs \emph{not} listed here are
 optional: if absent, no error is raised; if present, they're validated
-normally. Pass \code{NULL} or \code{character()} to make every named spec optional.}
+normally. Pass \code{NULL} or \code{character()} to make every named spec optional.
+A zero-length \code{.x} (such as \code{list()}) skips this check when
+\code{.allow_zero_length = TRUE} (the default); see \code{allow_zero_length}.}
 
 \item{.allow_duplicate_names}{(\code{logical(1)}) Should \code{.x} be allowed to
 have duplicate names? If \code{FALSE} (default), an error is thrown when any

--- a/man/dot-validate_required_elements.Rd
+++ b/man/dot-validate_required_elements.Rd
@@ -24,7 +24,7 @@ required unless you opt it out. Named specs \emph{not} listed here are
 optional: if absent, no error is raised; if present, they're validated
 normally. Pass \code{NULL} or \code{character()} to make every named spec optional.
 A zero-length \code{.x} (such as \code{list()}) skips this check when
-\code{.allow_zero_length = TRUE} (the default); see \code{allow_zero_length}.}
+\code{.allow_zero_length = TRUE}.}
 
 \item{.x_arg}{(\code{character(1)}) The name of the object being stabilized to use
 in error messages. The automatic value will work in most cases, or pass it

--- a/man/dot-validate_required_elements.Rd
+++ b/man/dot-validate_required_elements.Rd
@@ -22,7 +22,9 @@ when present. Whether the element is required is controlled by
 present in \code{.x}. Defaults to all names in \code{...}, so every named spec is
 required unless you opt it out. Named specs \emph{not} listed here are
 optional: if absent, no error is raised; if present, they're validated
-normally. Pass \code{NULL} or \code{character()} to make every named spec optional.}
+normally. Pass \code{NULL} or \code{character()} to make every named spec optional.
+A zero-length \code{.x} (such as \code{list()}) skips this check when
+\code{.allow_zero_length = TRUE} (the default); see \code{allow_zero_length}.}
 
 \item{.x_arg}{(\code{character(1)}) The name of the object being stabilized to use
 in error messages. The automatic value will work in most cases, or pass it

--- a/man/specify_df.Rd
+++ b/man/specify_df.Rd
@@ -64,7 +64,7 @@ required unless you opt it out. Named specs \emph{not} listed here are
 optional: if absent, no error is raised; if present, they're validated
 normally. Pass \code{NULL} or \code{character()} to make every named spec optional.
 A \code{.x} with zero columns skips this check when
-\code{.allow_zero_length = TRUE} (the default); see \code{allow_zero_length}.}
+\code{.allow_zero_length = TRUE} (the default).}
 }
 \value{
 A function of class \code{"stbl_specified_fn"} that calls

--- a/man/specify_df.Rd
+++ b/man/specify_df.Rd
@@ -12,6 +12,7 @@ specify_df(
   .min_rows = NULL,
   .max_rows = NULL,
   .allow_null = TRUE,
+  .allow_zero_length = TRUE,
   .required = ...names()
 )
 
@@ -22,6 +23,7 @@ specify_data_frame(
   .min_rows = NULL,
   .max_rows = NULL,
   .allow_null = TRUE,
+  .allow_zero_length = TRUE,
   .required = ...names()
 )
 }
@@ -54,11 +56,15 @@ cause an error. Unlike \code{...}, this does not validate the column contents.}
 
 \item{.allow_null}{(\code{logical(1)}) Is NULL an acceptable value?}
 
+\item{.allow_zero_length}{(\code{logical(1)}) Are zero-length vectors acceptable?}
+
 \item{.required}{\code{(character)} Names (from \code{...}) of columns that must be
 present in \code{.x}. Defaults to all names in \code{...}, so every named spec is
 required unless you opt it out. Named specs \emph{not} listed here are
 optional: if absent, no error is raised; if present, they're validated
-normally. Pass \code{NULL} or \code{character()} to make every named spec optional.}
+normally. Pass \code{NULL} or \code{character()} to make every named spec optional.
+A \code{.x} with zero columns skips this check when
+\code{.allow_zero_length = TRUE} (the default); see \code{allow_zero_length}.}
 }
 \value{
 A function of class \code{"stbl_specified_fn"} that calls

--- a/man/specify_lst.Rd
+++ b/man/specify_lst.Rd
@@ -11,6 +11,7 @@ specify_lst(
   .unnamed = NULL,
   .unique = FALSE,
   .allow_null = TRUE,
+  .allow_zero_length = TRUE,
   .min_size = NULL,
   .max_size = NULL,
   .required = ...names()
@@ -22,6 +23,7 @@ specify_list(
   .unnamed = NULL,
   .unique = FALSE,
   .allow_null = TRUE,
+  .allow_zero_length = TRUE,
   .min_size = NULL,
   .max_size = NULL,
   .required = ...names()
@@ -60,6 +62,8 @@ If \code{TRUE}, duplicated elements are rejected.}
 
 \item{.allow_null}{(\code{logical(1)}) Is NULL an acceptable value?}
 
+\item{.allow_zero_length}{(\code{logical(1)}) Are zero-length vectors acceptable?}
+
 \item{.min_size}{(\code{integer(1)}) The minimum size of the object. Object size
 will be tested using \code{\link[vctrs:vec_size]{vctrs::vec_size()}}.}
 
@@ -70,7 +74,9 @@ will be tested using \code{\link[vctrs:vec_size]{vctrs::vec_size()}}.}
 present in \code{.x}. Defaults to all names in \code{...}, so every named spec is
 required unless you opt it out. Named specs \emph{not} listed here are
 optional: if absent, no error is raised; if present, they're validated
-normally. Pass \code{NULL} or \code{character()} to make every named spec optional.}
+normally. Pass \code{NULL} or \code{character()} to make every named spec optional.
+A zero-length \code{.x} (such as \code{list()}) skips this check when
+\code{.allow_zero_length = TRUE} (the default); see \code{allow_zero_length}.}
 }
 \value{
 A function of class \code{"stbl_specified_fn"} that calls

--- a/man/specify_lst.Rd
+++ b/man/specify_lst.Rd
@@ -76,7 +76,7 @@ required unless you opt it out. Named specs \emph{not} listed here are
 optional: if absent, no error is raised; if present, they're validated
 normally. Pass \code{NULL} or \code{character()} to make every named spec optional.
 A zero-length \code{.x} (such as \code{list()}) skips this check when
-\code{.allow_zero_length = TRUE} (the default); see \code{allow_zero_length}.}
+\code{.allow_zero_length = TRUE}.}
 }
 \value{
 A function of class \code{"stbl_specified_fn"} that calls

--- a/man/stabilize_df.Rd
+++ b/man/stabilize_df.Rd
@@ -106,7 +106,7 @@ required unless you opt it out. Named specs \emph{not} listed here are
 optional: if absent, no error is raised; if present, they're validated
 normally. Pass \code{NULL} or \code{character()} to make every named spec optional.
 A \code{.x} with zero columns skips this check when
-\code{.allow_zero_length = TRUE} (the default); see \code{allow_zero_length}.}
+\code{.allow_zero_length = TRUE} (the default).}
 
 \item{.x_arg}{(\code{character(1)}) The name of the object being stabilized to use
 in error messages. The automatic value will work in most cases, or pass it

--- a/man/stabilize_df.Rd
+++ b/man/stabilize_df.Rd
@@ -15,6 +15,7 @@ stabilize_df(
   .min_rows = NULL,
   .max_rows = NULL,
   .allow_null = TRUE,
+  .allow_zero_length = TRUE,
   .required = ...names(),
   .x_arg = caller_arg(.x),
   .call = caller_env(),
@@ -29,6 +30,7 @@ stabilise_df(
   .min_rows = NULL,
   .max_rows = NULL,
   .allow_null = TRUE,
+  .allow_zero_length = TRUE,
   .required = ...names(),
   .x_arg = caller_arg(.x),
   .call = caller_env(),
@@ -43,6 +45,7 @@ stabilize_data_frame(
   .min_rows = NULL,
   .max_rows = NULL,
   .allow_null = TRUE,
+  .allow_zero_length = TRUE,
   .required = ...names(),
   .x_arg = caller_arg(.x),
   .call = caller_env(),
@@ -57,6 +60,7 @@ stabilise_data_frame(
   .min_rows = NULL,
   .max_rows = NULL,
   .allow_null = TRUE,
+  .allow_zero_length = TRUE,
   .required = ...names(),
   .x_arg = caller_arg(.x),
   .call = caller_env(),
@@ -94,11 +98,15 @@ cause an error. Unlike \code{...}, this does not validate the column contents.}
 
 \item{.allow_null}{(\code{logical(1)}) Is NULL an acceptable value?}
 
+\item{.allow_zero_length}{(\code{logical(1)}) Are zero-length vectors acceptable?}
+
 \item{.required}{\code{(character)} Names (from \code{...}) of columns that must be
 present in \code{.x}. Defaults to all names in \code{...}, so every named spec is
 required unless you opt it out. Named specs \emph{not} listed here are
 optional: if absent, no error is raised; if present, they're validated
-normally. Pass \code{NULL} or \code{character()} to make every named spec optional.}
+normally. Pass \code{NULL} or \code{character()} to make every named spec optional.
+A \code{.x} with zero columns skips this check when
+\code{.allow_zero_length = TRUE} (the default); see \code{allow_zero_length}.}
 
 \item{.x_arg}{(\code{character(1)}) The name of the object being stabilized to use
 in error messages. The automatic value will work in most cases, or pass it

--- a/man/stabilize_lst.Rd
+++ b/man/stabilize_lst.Rd
@@ -15,6 +15,7 @@ stabilize_lst(
   .allow_duplicate_names = FALSE,
   .unique = FALSE,
   .allow_null = TRUE,
+  .allow_zero_length = TRUE,
   .min_size = NULL,
   .max_size = NULL,
   .required = ...names(),
@@ -31,6 +32,7 @@ stabilize_list(
   .allow_duplicate_names = FALSE,
   .unique = FALSE,
   .allow_null = TRUE,
+  .allow_zero_length = TRUE,
   .min_size = NULL,
   .max_size = NULL,
   .required = ...names(),
@@ -47,6 +49,7 @@ stabilise_lst(
   .allow_duplicate_names = FALSE,
   .unique = FALSE,
   .allow_null = TRUE,
+  .allow_zero_length = TRUE,
   .min_size = NULL,
   .max_size = NULL,
   .required = ...names(),
@@ -63,6 +66,7 @@ stabilise_list(
   .allow_duplicate_names = FALSE,
   .unique = FALSE,
   .allow_null = TRUE,
+  .allow_zero_length = TRUE,
   .min_size = NULL,
   .max_size = NULL,
   .required = ...names(),
@@ -110,6 +114,8 @@ If \code{TRUE}, duplicated elements are rejected.}
 
 \item{.allow_null}{(\code{logical(1)}) Is NULL an acceptable value?}
 
+\item{.allow_zero_length}{(\code{logical(1)}) Are zero-length vectors acceptable?}
+
 \item{.min_size}{(\code{integer(1)}) The minimum size of the object. Object size
 will be tested using \code{\link[vctrs:vec_size]{vctrs::vec_size()}}.}
 
@@ -120,7 +126,9 @@ will be tested using \code{\link[vctrs:vec_size]{vctrs::vec_size()}}.}
 present in \code{.x}. Defaults to all names in \code{...}, so every named spec is
 required unless you opt it out. Named specs \emph{not} listed here are
 optional: if absent, no error is raised; if present, they're validated
-normally. Pass \code{NULL} or \code{character()} to make every named spec optional.}
+normally. Pass \code{NULL} or \code{character()} to make every named spec optional.
+A zero-length \code{.x} (such as \code{list()}) skips this check when
+\code{.allow_zero_length = TRUE} (the default); see \code{allow_zero_length}.}
 
 \item{.x_arg}{(\code{character(1)}) The name of the object being stabilized to use
 in error messages. The automatic value will work in most cases, or pass it

--- a/man/stabilize_lst.Rd
+++ b/man/stabilize_lst.Rd
@@ -128,7 +128,7 @@ required unless you opt it out. Named specs \emph{not} listed here are
 optional: if absent, no error is raised; if present, they're validated
 normally. Pass \code{NULL} or \code{character()} to make every named spec optional.
 A zero-length \code{.x} (such as \code{list()}) skips this check when
-\code{.allow_zero_length = TRUE} (the default); see \code{allow_zero_length}.}
+\code{.allow_zero_length = TRUE}.}
 
 \item{.x_arg}{(\code{character(1)}) The name of the object being stabilized to use
 in error messages. The automatic value will work in most cases, or pass it

--- a/tests/testthat/_snaps/stabilize_df.md
+++ b/tests/testthat/_snaps/stabilize_df.md
@@ -38,6 +38,14 @@
       Error:
       ! `data.frame(foo = "a")` must contain element "name".
 
+# stabilize_df() checks required columns for zero-column .x when .allow_zero_length = FALSE (#344)
+
+    Code
+      stabilize_df(data.frame(), name = specify_chr_scalar(), .allow_zero_length = FALSE)
+    Condition <stbl-error-missing_element>
+      Error:
+      ! `data.frame()` must contain element "name".
+
 # stabilize_df() errors informatively when column fails validation (#142, #310, #335)
 
     Code

--- a/tests/testthat/_snaps/stabilize_lst.md
+++ b/tests/testthat/_snaps/stabilize_lst.md
@@ -159,6 +159,15 @@
       Error:
       ! `list(1L, 2L)` must contain element "a".
 
+# stabilize_lst() still enforces .min_size on empty .x when .allow_zero_length = TRUE (#344)
+
+    Code
+      stabilize_lst(list(), .min_size = 2)
+    Condition <stbl-error-size_too_small>
+      Error:
+      ! `list()` must have size >= 2.
+      x 0 is too small.
+
 # stabilize_lst() checks required elements for empty .x when .allow_zero_length = FALSE (#344)
 
     Code

--- a/tests/testthat/_snaps/stabilize_lst.md
+++ b/tests/testthat/_snaps/stabilize_lst.md
@@ -151,6 +151,22 @@
       Error:
       ! `list(z = 1L)` must contain element "a".
 
+# stabilize_lst() errors on missing required element in unnamed non-empty list (#344)
+
+    Code
+      stabilize_lst(list(1L, 2L), a = specify_int_scalar())
+    Condition <stbl-error-missing_element>
+      Error:
+      ! `list(1L, 2L)` must contain element "a".
+
+# stabilize_lst() checks required elements for empty .x when .allow_zero_length = FALSE (#344)
+
+    Code
+      stabilize_lst(list(), a = specify_int_scalar(), .allow_zero_length = FALSE)
+    Condition <stbl-error-missing_element>
+      Error:
+      ! `list()` must contain element "a".
+
 # .check_duplicate_names(): errors on duplicate names by default (#110)
 
     Code

--- a/tests/testthat/test-specify_df.R
+++ b/tests/testthat/test-specify_df.R
@@ -50,6 +50,21 @@ test_that("specify_df() passes through .col_names (#142)", {
   )
 })
 
+test_that("specify_df() passes through .allow_zero_length (#344)", {
+  validator <- specify_df(name = specify_chr_scalar())
+  expect_identical(validator(data.frame()), data.frame())
+
+  validator_strict <- specify_df(
+    name = specify_chr_scalar(),
+    .allow_zero_length = FALSE
+  )
+  expect_pkg_error_classes(
+    validator_strict(data.frame()),
+    "stbl",
+    "missing_element"
+  )
+})
+
 test_that("specify_df() allows additional specs via ... (#142)", {
   base_validator <- specify_df(.extra_cols = assert_present)
   given <- data.frame(a = 1L, b = "hello")

--- a/tests/testthat/test-specify_lst.R
+++ b/tests/testthat/test-specify_lst.R
@@ -58,6 +58,17 @@ test_that("specify_lst() passes through .required (#279)", {
   expect_identical(spec(given), given)
 })
 
+test_that("specify_lst() passes through .allow_zero_length (#344)", {
+  spec <- specify_lst(a = specify_int_scalar())
+  expect_identical(spec(list()), list())
+
+  spec_strict <- specify_lst(
+    a = specify_int_scalar(),
+    .allow_zero_length = FALSE
+  )
+  expect_pkg_error_classes(spec_strict(list()), "stbl", "missing_element")
+})
+
 test_that("specify_lst() requires all element specs by default (#279)", {
   spec <- specify_lst(a = specify_int_scalar(), b = specify_int_scalar())
   expect_pkg_error_classes(spec(list(a = 1L)), "stbl", "missing_element")

--- a/tests/testthat/test-stabilize_df.R
+++ b/tests/testthat/test-stabilize_df.R
@@ -79,6 +79,23 @@ test_that("stabilize_df() allows an absent optional column via .required (#279)"
   expect_identical(result, given)
 })
 
+test_that("stabilize_df() skips required-column check for zero-column .x by default (#344)", {
+  result <- stabilize_df(data.frame(), name = specify_chr_scalar())
+  expect_identical(result, data.frame())
+})
+
+test_that("stabilize_df() checks required columns for zero-column .x when .allow_zero_length = FALSE (#344)", {
+  expect_pkg_error_snapshot(
+    stabilize_df(
+      data.frame(),
+      name = specify_chr_scalar(),
+      .allow_zero_length = FALSE
+    ),
+    "stbl",
+    "missing_element"
+  )
+})
+
 test_that("stabilize_df() still validates an optional column when present (#279)", {
   expect_pkg_error_classes(
     stabilize_df(

--- a/tests/testthat/test-stabilize_lst.R
+++ b/tests/testthat/test-stabilize_lst.R
@@ -331,6 +331,14 @@ test_that("stabilize_lst() skips required-element check for empty .x by default 
   )
 })
 
+test_that("stabilize_lst() still enforces .min_size on empty .x when .allow_zero_length = TRUE (#344)", {
+  expect_pkg_error_snapshot(
+    stabilize_lst(list(), .min_size = 2),
+    "stbl",
+    "size_too_small"
+  )
+})
+
 test_that("stabilize_lst() checks required elements for empty .x when .allow_zero_length = FALSE (#344)", {
   expect_pkg_error_snapshot(
     stabilize_lst(list(), a = specify_int_scalar(), .allow_zero_length = FALSE),

--- a/tests/testthat/test-stabilize_lst.R
+++ b/tests/testthat/test-stabilize_lst.R
@@ -316,6 +316,29 @@ test_that("stabilize_lst() still errors on required elements not in .required (#
   )
 })
 
+test_that("stabilize_lst() errors on missing required element in unnamed non-empty list (#344)", {
+  expect_pkg_error_snapshot(
+    stabilize_lst(list(1L, 2L), a = specify_int_scalar()),
+    "stbl",
+    "missing_element"
+  )
+})
+
+test_that("stabilize_lst() skips required-element check for empty .x by default (#344)", {
+  expect_identical(
+    stabilize_lst(list(), a = specify_int_scalar()),
+    list()
+  )
+})
+
+test_that("stabilize_lst() checks required elements for empty .x when .allow_zero_length = FALSE (#344)", {
+  expect_pkg_error_snapshot(
+    stabilize_lst(list(), a = specify_int_scalar(), .allow_zero_length = FALSE),
+    "stbl",
+    "missing_element"
+  )
+})
+
 test_that("stabilize_lst() with unnamed specs errors informatively (#110)", {
   expect_pkg_error_classes(
     stabilize_lst(list(1L), specify_int_scalar()),


### PR DESCRIPTION
## Summary

`.validate_named_elements()` in `stabilize_lst()` returned early whenever `.x` had no named elements at all (e.g. `list()` or `list(1L, 2L)`), which silently skipped the required-element check (`.validate_required_elements()`). This meant `stabilize_lst(list(), a = specify_int_scalar())` and `stabilize_lst(list(1L, 2L), a = specify_int_scalar())` did not error even though `a` is required.

## Changes

- Removed the early-return gate in `.validate_named_elements()`. The downstream checks (`.check_duplicate_names()`, `.validate_extra_named_elements()`) already guard against zero named elements internally, so required-element checking now always runs.
- Added a new `.allow_zero_length` argument (default `TRUE`) to `stabilize_lst()`, `specify_lst()`, `stabilize_df()`, and `specify_df()`. When `.x` is zero-length (e.g. `list()` or a data frame with no columns) and `.allow_zero_length = TRUE`, the required-element check is skipped, preserving prior behavior for genuinely empty input. Setting `.allow_zero_length = FALSE` enforces `.required` even for empty `.x`.
- Non-empty, fully-unnamed lists (e.g. `list(1L, 2L)`) are no longer able to bypass the required-element check — this is the actual bug fix and isn't gated by `.allow_zero_length`.
- Added regression tests for `stabilize_lst()`, `specify_lst()`, `stabilize_df()`, and `specify_df()` covering empty and fully-unnamed `.x` with required specs.
- Documentation for the new argument is inherited from `.shared-params`'s `allow_zero_length` entry.

## Testing

- `devtools::test(reporter = "check")`: all tests pass.
- `devtools::check(error_on = "warning")`: 0 errors, 0 warnings, 0 notes.
- Verified no zero-coverage lines introduced in the four edited files via `covr`.

Closes #344