### PR TITLE
Return NULL early from `stabilize_*()` when allowed

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -32,6 +32,7 @@
 
 * `stabilize_lst()` (and `stabilize_df()`, which delegates to it) now correctly detects missing required named elements even when `.x` has no named elements at all, such as `list()` or `list(1L, 2L)`. Previously, the required-element check was silently skipped whenever `.x` had no named elements (#344).
 * `to_chr()`, `to_dbl()`, `to_fct()`, `to_int()`, and `to_lgl()` now throw an "incompatible type" error (with failing element locations) instead of a generic "can't coerce" error when a list contains elements that can't be converted (#273).
+* `stabilize_*(NULL, allow_null = TRUE)` always returns `NULL`, without checking other `stabilize_*()` rules. For example, `stabilize_int(NULL, min_value = 1)` now returns `NULL`, rather than erroring (#353).
 
 # stbl 0.4.0
 

--- a/R/cls_unexported.R
+++ b/R/cls_unexported.R
@@ -74,6 +74,9 @@
       x_class = x_class
     )
   )
+  if (is.null(x)) {
+    return(x)
+  }
   if (!is.null(check_cls_value_fn)) {
     inject(
       check_cls_value_fn(

--- a/tests/testthat/test-cls_unexported.R
+++ b/tests/testthat/test-cls_unexported.R
@@ -52,6 +52,30 @@ test_that(".stabilize_cls() calls to_cls_fn with to_cls_args", {
   )
 })
 
+test_that(".stabilize_cls() returns NULL if allowed (#353)", {
+  to_fn <- function(x, ..., allow_null = TRUE) {
+    if (is.null(x) && allow_null) {
+      return(NULL)
+    }
+    as.integer(x)
+  }
+  expect_null(
+    .stabilize_cls(
+      NULL,
+      to_cls_fn = to_fn,
+      allow_null = TRUE
+    )
+  )
+  expect_equal(
+    .stabilize_cls(
+      1:5,
+      to_cls_fn = to_fn,
+      allow_null = TRUE
+    ),
+    1:5
+  )
+})
+
 test_that(".stabilize_cls() calls check_cls_value_fn", {
   check_fn <- function(x, ..., my_arg = "default") {
     if (my_arg != "success") {


### PR DESCRIPTION
Fixes #353.